### PR TITLE
Add auto-generate CHANGELOG tool + SKILL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [2026-03-27] HEAD
+
+### Added
+
+- [BOUNTY] Add pre-tool-use hook: dangerous command guard (c113478)
+- Add production-ready CLAUDE.md for Next.js 15 + SQLite SaaS (cf62260)
+- feat: initial README with bounty board (1aeae2a)
+
+### Changed
+
+- Initial commit (a80a580)
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,432 @@
+# Claude Code Context - Next.js 15 + SQLite SaaS
+
+## Stack & Versions
+
+- **Next.js**: 15+ (App Router only - no Pages Router)
+- **React**: 19+
+- **TypeScript**: 5.8+
+- **Database**: SQLite via `better-sqlite3`
+- **Node.js**: 20+ LTS
+
+## Folder Structure
+
+```
+src/
+├── app/                    # App Router routes
+│   ├── (auth)/            # Route groups for layout organization
+│   ├── (dashboard)/       # Authenticated routes
+│   ├── api/               # Route handlers
+│   ├── layout.tsx         # Root layout
+│   └── page.tsx           # Home page
+├── components/            # React components
+│   ├── ui/               # Reusable UI primitives
+│   ├── forms/            # Form components
+│   └── features/         # Feature-specific components
+├── lib/                  # Shared utilities
+│   ├── db.ts             # Database singleton & connection
+│   ├── queries/          # SQL query functions (organized by table)
+│   └── utils.ts          # General utilities
+├── migrations/           # Database migrations
+├── types/                # TypeScript types/schemas
+└── middleware.ts         # Next.js middleware (auth, etc.)
+```
+
+**Why**: Route groups `(name)` let you share layouts without affecting URLs. Separating `lib/queries/` keeps SQL logic organized and testable.
+
+---
+
+## Naming Conventions
+
+| Context | Convention | Example |
+|---------|------------|---------|
+| Files/Folders | `kebab-case` | `user-profile.tsx`, `api/routes/` |
+| React Components | `PascalCase` | `UserProfile`, `DataTable` |
+| Functions/Variables | `camelCase` | `getUserById`, `formatDate` |
+| Database Tables | `snake_case` | `user_profiles`, `api_keys` |
+| Database Columns | `snake_case` | `created_at`, `is_active` |
+| TypeScript Types | `PascalCase` | `UserProfile`, `DbUser` |
+| Environment Variables | `SCREAMING_SNAKE_CASE` | `DATABASE_URL`, `JWT_SECRET` |
+
+**Why**: `kebab-case` files avoid case-insensitive filesystem issues. `snake_case` in databases is standard SQL practice. `PascalCase` components signals React/TypeScript convention.
+
+---
+
+## Component Patterns
+
+### Default: Server Components
+
+```typescript
+// ✅ GOOD - Server Component (default)
+export default async function UserProfile({ userId }: { userId: string }) {
+  const user = await getUserById(userId);
+  return <div>{user.name}</div>;
+}
+```
+
+**Why**: Server Components reduce client JS bundle, enable direct database access, and improve performance.
+
+### Use Client Components Only When Needed
+
+Add `'use client'` ONLY for:
+- Browser APIs (`window`, `localStorage`, etc.)
+- React hooks (`useState`, `useEffect`, event handlers)
+- Interactive UI (modals, dropdowns, forms with real-time validation)
+
+```typescript
+// ✅ GOOD - Client Component with clear purpose
+'use client';
+
+export function LoginForm() {
+  const [email, setEmail] = useState('');
+  // ...
+}
+```
+
+### Composition Pattern: Server → Client Boundary
+
+```typescript
+// ✅ GOOD - Server Component fetches data, passes to Client Component
+export default async function DashboardPage() {
+  const data = await fetchDashboardData();
+
+  return <DashboardClient initialData={data} />;
+}
+```
+
+**Why**: Keeps data fetching on server, interactivity on client. Minimizes client JS while maintaining interactivity.
+
+---
+
+## SQL & Database Rules
+
+### 1. Use Prepared Statements Only
+
+```typescript
+// ✅ GOOD
+const stmt = db.prepare('SELECT * FROM users WHERE id = ?');
+const user = stmt.get(userId);
+
+// ❌ FORBIDDEN - SQL injection risk
+const user = db.exec(`SELECT * FROM users WHERE id = ${userId}`);
+```
+
+**Why**: Prevents SQL injection. `better-sqlite3` throws on unsafe operations.
+
+### 2. All Schema Changes Via Migrations
+
+```bash
+# ✅ GOOD - Named migration
+migrations/20250327_120000_create_users.sql
+```
+
+```sql
+-- migrations/20250327_120000_create_users.sql
+-- UP
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- DOWN
+DROP TABLE users;
+```
+
+**Why**: Migrations provide version control, rollback capability, and reproducible deployments.
+
+### 3. Migration Naming Format
+
+Use `YYYYMMDD_HHMMSS_descriptive_name.sql` format.
+
+**Why**: Timestamps sort chronologically. Descriptive names make migrations self-documenting.
+
+### 4. Query Organization
+
+```
+lib/queries/
+├── users.ts          # All user-related queries
+├── sessions.ts       # Auth/session queries
+└── analytics.ts      # Analytics queries
+```
+
+```typescript
+// lib/queries/users.ts
+import { db } from '@/lib/db';
+
+export const usersQueries = {
+  findById: db.prepare('SELECT * FROM users WHERE id = ?'),
+  findByEmail: db.prepare('SELECT * FROM users WHERE email = ?'),
+  create: db.prepare('INSERT INTO users (id, email) VALUES (?, ?)'),
+};
+
+// Usage
+export function getUserById(id: string) {
+  return usersQueries.findById.get(id);
+}
+```
+
+**Why**: Centralized queries are easier to test, optimize, and maintain. Prepared statements cached at startup.
+
+### 5. Database Connection Singleton
+
+```typescript
+// lib/db.ts
+import Database from 'better-sqlite3';
+import path from 'path';
+
+let db: Database.Database | null = null;
+
+export function getDb(): Database.Database {
+  if (!db) {
+    const dbPath = process.env.DATABASE_PATH ?? path.join(process.cwd(), 'data.db');
+    db = new Database(dbPath);
+    db.pragma('journal_mode = WAL'); // Enable WAL for better concurrency
+  }
+  return db;
+}
+```
+
+**Why**: Singleton prevents multiple connections. WAL mode enables concurrent reads.
+
+---
+
+## Migrations
+
+### Running Migrations
+
+```bash
+# Apply all pending migrations
+npm run migrate
+
+# Rollback last migration
+npm run migrate:rollback
+
+# Create new migration
+npm run migrate:create --name create_users_table
+```
+
+### Migration Template
+
+```sql
+-- migrations/20250327_120000_description.sql
+
+-- === UP ===
+-- Add your schema changes here
+
+-- === DOWN ===
+-- Revert your schema changes here
+```
+
+**Why**: UP/DOWN structure enables rollbacks. Comments make migrations self-explanatory.
+
+---
+
+## TypeScript & Types
+
+### Database Types
+
+```typescript
+// types/database.ts
+export interface DbUser {
+  id: string;
+  email: string;
+  created_at: string;
+}
+
+// Row types from queries
+export type UserInsert = Omit<DbUser, 'id' | 'created_at'>;
+```
+
+**Why**: Type safety catches errors at compile time. Separating `Db` prefix from API types prevents confusion.
+
+---
+
+## Anti-Patterns (Forbidden)
+
+### ❌ useState in Server Components
+
+```typescript
+// FORBIDDEN
+export default function UserProfile() {
+  const [count, setCount] = useState(0); // ❌ Server Components can't use hooks
+  return <div>{count}</div>;
+}
+```
+
+**Why**: Server Components run on server, React hooks only work in client components.
+
+### ❌ Direct DOM Manipulation
+
+```typescript
+// FORBIDDEN
+document.getElementById('app').innerHTML = '...'; // ❌ Never do this
+```
+
+**Why**: React manages the DOM. Direct manipulation breaks React's virtual DOM and causes bugs.
+
+### ❌ SQL String Concatenation
+
+```typescript
+// FORBIDDEN
+const query = `SELECT * FROM users WHERE name = '${userName}'`; // ❌ SQL injection
+```
+
+**Why**: SQL injection vulnerability. Always use prepared statements with `?` placeholders.
+
+### ❌ Client-Side Secrets
+
+```typescript
+// FORBIDDEN - Exposes secret to browser
+const apiKey = process.env.SECRET_KEY;
+```
+
+**Why**: Client code can be inspected. Secrets must stay on server (API routes, Server Components).
+
+### ❌ Mixed Client/Server in One File
+
+```typescript
+// FORBIDDEN - Don't export both Server and Client Components from same file
+export default async function ServerComponent() { /* ... */ }
+export function ClientComponent() { 'use client'; /* ... */ }
+```
+
+**Why**: Confusing boundary. Separate files make Server/Client distinction explicit.
+
+---
+
+## Development Commands
+
+```bash
+# Development
+npm run dev              # Start dev server (localhost:3000)
+
+# Building
+npm run build            # Production build
+npm start                # Start production server
+
+# Code Quality
+npm run lint             # ESLint
+npm run lint:fix         # Auto-fix lint issues
+npm run type-check       # TypeScript check (no emit)
+
+# Database
+npm run migrate          # Apply pending migrations
+npm run migrate:rollback # Rollback last migration
+npm run migrate:create   # Generate new migration file
+
+# Testing
+npm run test             # Run Vitest tests
+npm run test:watch       // Watch mode
+npm run test:coverage    # Coverage report
+```
+
+---
+
+## Testing
+
+### Test File Location
+
+```
+src/
+├── lib/
+│   └── queries/
+│       ├── users.ts
+│       └── users.test.ts    # Co-located test file
+```
+
+**Why**: Co-located tests are easier to find and maintain.
+
+### Test Naming
+
+- Test files: `*.test.ts`
+- Describe real-world behavior, not implementation details
+
+```typescript
+// users.test.ts
+import { describe, it, expect } from 'vitest';
+import { getUserById } from './users';
+
+describe('getUserById', () => {
+  it('returns user when exists', async () => {
+    const user = await getUserById('123');
+    expect(user?.email).toBe('test@example.com');
+  });
+
+  it('returns null when not found', async () => {
+    const user = await getUserById('nonexistent');
+    expect(user).toBeNull();
+  });
+});
+```
+
+**Why**: Behavior-focused tests survive refactoring. Implementation details couple tests to code structure.
+
+### Database Testing
+
+Use in-memory SQLite for tests:
+
+```typescript
+// vitest.setup.ts
+import Database from 'better-sqlite3';
+
+export function setupTestDb() {
+  const db = new Database(':memory:');
+  // Run migrations...
+  return db;
+}
+```
+
+**Why**: In-memory DB is fast and isolated. Each test gets a clean slate.
+
+---
+
+## API Routes
+
+```typescript
+// src/app/api/users/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { getUsers } from '@/lib/queries/users';
+
+export async function GET(request: NextRequest) {
+  const users = await getUsers();
+  return NextResponse.json(users);
+}
+```
+
+**Why**: Route handlers are Server Functions by default. Direct database access, no API layer needed.
+
+---
+
+## Environment Variables
+
+Create `.env.local` (gitignored):
+
+```bash
+DATABASE_PATH=./data/dev.db
+SESSION_SECRET=your-secret-here
+```
+
+**Why**: `.env.local` overrides `.env` for local development. Never commit secrets.
+
+---
+
+## Performance Guidelines
+
+1. **Cache Database Connections**: Use singleton pattern in `lib/db.ts`
+2. **Use Static Rendering**: Mark pages with `export const dynamic = 'auto'` (default) or `'force-static'` where possible
+3. **Avoid `fetch` in Server Components** when DB access is possible
+4. **Lazy Load Client Components**: Use `dynamic` import for heavy client-side libraries
+
+**Why**: Reduces database load, improves TTFB, minimizes client bundle size.
+
+---
+
+## When to Ask for Clarification
+
+Before implementing, ask if:
+- Requirements conflict with these rules
+- Database schema design is unclear
+- Authentication/authorization approach not specified
+- Performance requirements not defined
+
+**Why**: These rules cover 95% of cases. Edge cases need explicit decisions.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: generate-changelog
 description: Auto-generate structured CHANGELOG.md from git history since last tag.
+triggers:
+  - /generate-changelog
 ---
 
 # generate-changelog
 
 Generate a structured `CHANGELOG.md` from git commit history.
 
-## Usage
+## Trigger
+
+```
+/generate-changelog
+```
+
+Or run manually:
 
 ```bash
 python3 changelog-tool/generate_changelog.py
@@ -23,3 +31,11 @@ python3 changelog-tool/generate_changelog.py
    - **Changed**: update, improve, refactor, rename
    - **Removed**: remove, delete, drop, deprecate
 4. Generates a formatted CHANGELOG.md (prepends to existing)
+
+## Setup
+
+```bash
+cp -r changelog-tool/ your-project/
+```
+
+Then use `/generate-changelog` in Claude Code or run `python3 changelog-tool/generate_changelog.py`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: generate-changelog
+description: Auto-generate structured CHANGELOG.md from git history since last tag.
+---
+
+# generate-changelog
+
+Generate a structured `CHANGELOG.md` from git commit history.
+
+## Usage
+
+```bash
+python3 changelog-tool/generate_changelog.py
+```
+
+## How It Works
+
+1. Finds the most recent git tag
+2. Fetches all commits since that tag
+3. Auto-categorizes each commit by keyword:
+   - **Added**: feat, add, new, implement, create
+   - **Fixed**: fix, bug, patch, resolve
+   - **Changed**: update, improve, refactor, rename
+   - **Removed**: remove, delete, drop, deprecate
+4. Generates a formatted CHANGELOG.md (prepends to existing)

--- a/changelog-tool/README.md
+++ b/changelog-tool/README.md
@@ -1,0 +1,10 @@
+# CHANGELOG Generator
+
+Auto-generate structured CHANGELOG.md from git history.
+
+## Setup (2 steps)
+
+1. `cp -r changelog-tool/ your-project/`
+2. `cd your-project && python3 changelog-tool/generate_changelog.py`
+
+That's it. CHANGELOG.md will be generated with commits categorized into Added/Fixed/Changed/Removed.

--- a/changelog-tool/generate_changelog.py
+++ b/changelog-tool/generate_changelog.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Auto-generate structured CHANGELOG.md from git history since last tag."""
+import subprocess, re, sys, os
+from datetime import datetime
+
+def run(cmd):
+    return subprocess.check_output(cmd, shell=True, stderr=subprocess.DEVNULL).decode().strip()
+
+def get_last_tag():
+    tags = run("git tag --sort=-creatordate").split("\n")
+    return tags[0] if tags and tags[0] else None
+
+def get_commits(since_ref):
+    if since_ref:
+        log = run(f'git log {since_ref}..HEAD --pretty=format:"%s||%h||%an||%ad" --date=short')
+    else:
+        log = run('git log --pretty=format:"%s||%h||%an||%ad" --date=short')
+    commits = []
+    for line in log.split("\n"):
+        if "||" in line:
+            parts = line.split("||")
+            commits.append({"msg": parts[0], "hash": parts[1], "author": parts[2], "date": parts[3]})
+    return commits
+
+def categorize(msg):
+    m = msg.lower()
+    prefixes = [
+        ("feat", "Added"), ("add", "Added"), ("new", "Added"), ("implement", "Added"), ("create", "Added"),
+        ("fix", "Fixed"), ("bug", "Fixed"), ("patch", "Fixed"), ("resolve", "Fixed"), ("repair", "Fixed"),
+        ("change", "Changed"), ("update", "Changed"), ("improve", "Changed"), ("refactor", "Changed"), ("rename", "Changed"),
+        ("remove", "Removed"), ("delete", "Removed"), ("drop", "Removed"), ("deprecate", "Removed"),
+    ]
+    for kw, cat in prefixes:
+        if kw in m:
+            return cat
+    return "Changed"
+
+def generate():
+    last_tag = get_last_tag()
+    commits = get_commits(last_tag)
+    if not commits:
+        print("No new commits since last tag.")
+        return
+
+    categories = {"Added": [], "Fixed": [], "Changed": [], "Removed": []}
+    for c in commits:
+        cat = categorize(c["msg"])
+        categories[cat].append(c)
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    tag_range = f"{last_tag}...HEAD" if last_tag else "HEAD"
+    md = f"# Changelog\n\n## [{today}] {tag_range}\n\n"
+
+    for cat in ["Added", "Fixed", "Changed", "Removed"]:
+        if categories[cat]:
+            md += f"### {cat}\n\n"
+            for c in categories[cat]:
+                md += f"- {c['msg']} ({c['hash']})\n"
+            md += "\n"
+
+    # Prepend to existing or create new
+    changelog = "CHANGELOG.md"
+    if os.path.exists(changelog):
+        with open(changelog) as f:
+            existing = f.read()
+        md += "\n" + existing
+    with open(changelog, "w") as f:
+        f.write(md)
+    print(f"✅ CHANGELOG.md generated ({len(commits)} commits)")
+
+if __name__ == "__main__":
+    generate()

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,64 @@
+# Claude Code Pre-Tool-Use Hooks
+
+## Installation
+
+### Quick Install (One Command)
+
+```bash
+mkdir -p ~/.claude/hooks && cp -r hooks/* ~/.claude/hooks/ && chmod +x ~/.claude/hooks/pre-tool-use/*.sh
+```
+
+### Manual Install
+
+```bash
+# 1. Create hooks directory
+mkdir -p ~/.claude/hooks
+
+# 2. Copy hooks
+cp -r hooks/* ~/.claude/hooks/
+
+# 3. Make scripts executable
+chmod +x ~/.claude/hooks/pre-tool-use/*.sh
+```
+
+## Available Hooks
+
+### `dangerous-command-guard.sh`
+
+Blocks destructive commands before execution:
+
+- `rm -rf /` - Deleting root filesystem
+- `DROP TABLE/DATABASE/SCHEMA` - SQL destruction
+- `TRUNCATE` - SQL table truncation
+- `git push --force` - Force pushing to git
+- `DELETE FROM` without WHERE clause - Deleting all rows
+
+Blocked commands are logged to `~/.claude/hooks/blocked.log`.
+
+## Hook Format Reference
+
+Claude Code pre-tool-use hooks receive JSON on stdin:
+
+```json
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm -rf /"
+  }
+}
+```
+
+And respond with JSON on stdout:
+
+```json
+{
+  "decision": "block",
+  "reason": "Dangerous command detected"
+}
+```
+
+## Uninstall
+
+```bash
+rm -rf ~/.claude/hooks/pre-tool-use/dangerous-command-guard.sh
+```

--- a/hooks/pre-tool-use/dangerous-command-guard.sh
+++ b/hooks/pre-tool-use/dangerous-command-guard.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Claude Code pre-tool-use hook: Dangerous Command Guard
+# Intercepts destructive commands before execution
+
+set -euo pipefail
+
+# Log file for blocked commands
+BLOCKED_LOG="${HOME}/.claude/hooks/blocked.log"
+mkdir -p "$(dirname "$BLOCKED_LOG")"
+
+# Read JSON from stdin
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Default: allow
+DECISION="allow"
+REASON=""
+
+# Only check Bash tool
+if [[ "$TOOL_NAME" == "Bash" ]]; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+  # Dangerous patterns
+  DANGEROUS_PATTERNS=(
+    "rm -rf /"                      # Delete root
+    "rm -rf /\*"                    # Delete root (wildcard)
+    "rm -rf //\*"                   # Delete root (double slash)
+    "DROP TABLE"                    # SQL: drop table
+    "DROP DATABASE"                 # SQL: drop database
+    "DROP SCHEMA"                   # SQL: drop schema
+    "TRUNCATE"                      # SQL: truncate table
+    "git push --force"              # Git force push
+    "git push -f"                   # Git force push (short)
+    "DELETE FROM.*;"                # SQL: delete all (no WHERE)
+    "DELETE FROM\s+\w+\s*$"         # SQL: delete all (end of line)
+  )
+
+  # Check each pattern
+  for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qE "$pattern"; then
+      DECISION="block"
+      REASON="Dangerous command detected: pattern '$pattern' matched"
+      break
+    fi
+  done
+
+  # Block if blocked
+  if [[ "$DECISION" == "block" ]]; then
+    TIMESTAMP=$(date -Iseconds)
+    PROJECT_PATH="$(pwd)"
+    echo "[${TIMESTAMP}] [${PROJECT_PATH}] ${COMMAND}" >> "$BLOCKED_LOG"
+  fi
+fi
+
+# Output decision
+if [[ "$DECISION" == "block" ]]; then
+  jq -n \
+    --arg decision "block" \
+    --arg reason "$REASON" \
+    '{decision: $decision, reason: $reason}'
+else
+  jq -n '{decision: "allow"}'
+fi
+
+exit 0


### PR DESCRIPTION
Resolves #1

Created a Python-based CHANGELOG generator + Claude Code SKILL.md:

- ✅ `python3 changelog-tool/generate_changelog.py` works standalone
- ✅ Fetches commits since last git tag
- ✅ Auto-categorizes: Added / Fixed / Changed / Removed
- ✅ Outputs formatted CHANGELOG.md (prepends to existing)
- ✅ Tested on this repo (see CHANGELOG.md in PR)
- ✅ SKILL.md for Claude Code integration
- ✅ README with 2-step setup

/opire submit