### PR TITLE
[bounty #1] SKILL: Generate structured CHANGELOG from git history

### DIFF
--- a/bounties/issue-1-changelog/README.md
+++ b/bounties/issue-1-changelog/README.md
@@ -1,0 +1,53 @@
+# changelog.sh — Generate a structured CHANGELOG from git
+
+Automatically generate a `CHANGELOG.md` from your git history, categorized by commit type.
+
+## Setup
+
+```bash
+# 1. Copy the script to your project root
+cp changelog.sh /your/project/
+
+# 2. Make it executable
+chmod +x changelog.sh
+```
+
+## Run
+
+```bash
+bash changelog.sh
+```
+
+That's it. The script auto-detects your last git tag and generates `CHANGELOG.md`.
+
+---
+
+## How it works
+
+| Commit prefix | Category |
+|---|---|
+| `feat:`, `add:`, `new:`, `implement:` | **Added** |
+| `fix:`, `bug:`, `patch:`, `hotfix:` | **Fixed** |
+| `refactor:`, `perf:`, `update:`, `chore:` | **Changed** |
+| `remove:`, `delete:`, `drop:`, `revert:` | **Removed** |
+| Everything else | **Other** |
+
+Follows [Conventional Commits](https://www.conventionalcommits.org/) convention.
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--since <tag\|commit>` | last git tag | Override baseline |
+| `--version <x.y.z>` | from `package.json` / `Cargo.toml` / date | Override version |
+| `--output <file>` | `CHANGELOG.md` | Output file |
+
+## Sample output
+
+See [`SAMPLE_OUTPUT.md`](./SAMPLE_OUTPUT.md) for a real example.
+
+## Requirements
+
+- `git` (any version)
+- `bash` 4+ (macOS: `brew install bash` if needed)
+- Optional: `node` (for `package.json` version detection)

--- a/bounties/issue-1-changelog/SAMPLE_OUTPUT.md
+++ b/bounties/issue-1-changelog/SAMPLE_OUTPUT.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## [1.0.0] — 2026-03-27
+
+### Added
+- feat(bounty-hunter): auto-solve CF Turnstile challenges in guardedFetch (Pi Agent)
+- feat(tools): twitter-post.py/js — poster sur @SR_Cryptos via Brave Profile 4 (Fino) sans API Twitter (Pi Agent)
+- feat(web-bot-auth): publish JWKS to fino-oss public Gist, update submission doc (Pi Agent)
+- feat(bounty-hunter): integrate signedFetch into guardedFetch + patch scan.js direct fetch() calls (Pi Agent)
+- feat(identity): Cloudflare Web Bot Auth — Ed25519 signing module + submission doc (Pi Agent)
+- feat(bounty-hunter): replace HTTP fetch with Playwright for Superteam CSR pages (Pi Agent)
+- feat(bounty-hunter): add watch.js periodic scanner + launchd daemon (Pi Agent)
+- feat(bounty-hunter): add Superteam Earn source + real money filter + human blocker detection (Pi Agent)
+- feat(routing): add Step 0 problem-type filter (metric-shaped vs software-shaped) + auto-optimize in Domain Skills table (Pi Agent)
+- feat(pi-remote): implement voice message handler (Telegram → Groq Whisper → Claude) (Pi Agent)
+- feat(evals): add prototype-mvp A/B evals + update run-ab.js — 15/15 passing (Pi Agent)
+
+### Fixed
+- fix(watch): 'deadline passed' sur toutes les bounties GitHub/OnlyDust (Pi Agent)
+- fix(guard): use cf_clearance cookie flow instead of header for CF Turnstile (Pi Agent)
+- fix(bounty-hunter): filter fake token repos (RustChain/RTC) from GitHub scanner (Pi Agent)
+- fix(pi-remote): formatForTelegram — remplacer sentinelles par split-escape-join (Pi Agent)
+- fix(pi-remote): remap .oga→.ogg for Groq Whisper — Telegram voice format rejected (Pi Agent)
+- fix(pi-remote): atomic poll lock with O_EXCL to prevent 7-8 simultaneous pollers (Pi Agent)
+- fix(pi-remote): sentinel \x00→\x02/\x03 dans formatForTelegram — null bytes strippés causaient CODE0 visible (Pi Agent)
+- fix(pi-remote): accepter /remote-stop, /remote-restart, /remote-reload depuis Telegram (aliases des commandes courtes) (Pi Agent)
+- fix(pi-remote): race condition — generation counter prevents stale poll loops stacking on reload (Pi Agent)
+
+### Changed
+- chore: init — snapshot initial de l'infrastructure agent (Pi Agent)
+
+### Other
+- checkpoint: 20260327-1305 — feat(p8): multicall retry count in scan summary (Pi Agent)
+- checkpoint: 20260327-0102 — feat(tools): add sms-reader.js — iPhone SMS gateway via SMSMobileAPI + OTP extraction (Pi Agent)
+- checkpoint: 20260326-1810 — feat(captcha): GateSolve x402 integration — captcha-solver.py + captcha-solver.js, API key (100 free solves), wallet verified 3.78 USDC on Base (Pi Agent)
+- checkpoint: 20260326-1605 — feat(tools): browser-use bridge — Node.js→Python Playwright automation (Pi Agent)
+- checkpoint: 20260324-1800 — feat(tools): add git-checkpoint.sh + AGENTS.md reference (Pi Agent)
+

--- a/bounties/issue-1-changelog/SKILL.md
+++ b/bounties/issue-1-changelog/SKILL.md
@@ -1,0 +1,45 @@
+# SKILL: Generate CHANGELOG from git history
+
+## What it does
+Generates a structured `CHANGELOG.md` from your project's git history.
+- Automatically fetches commits since the last git tag
+- Categorizes into **Added / Fixed / Changed / Removed**
+- Detects version from `package.json` or `Cargo.toml`
+- Prepends to existing CHANGELOG without destroying history
+
+## Usage
+
+```bash
+# Run directly — auto-detects last tag
+bash changelog.sh
+
+# Custom range
+bash changelog.sh --since v1.2.0
+
+# Specify version and output file
+bash changelog.sh --version 2.0.0 --output RELEASES.md
+```
+
+## Trigger phrase (Claude Code)
+```
+/generate-changelog
+```
+
+---
+
+## SKILL.md Instructions (for Claude Code)
+
+When the user types `/generate-changelog`:
+
+1. Check if `changelog.sh` exists in the project root. If not, offer to create it.
+2. Run:
+   ```bash
+   bash changelog.sh
+   ```
+3. Read the generated `CHANGELOG.md` and summarize what was categorized.
+4. Ask the user if they want to review or commit the file.
+
+### Advanced options
+- `--since <tag>` — override the baseline tag
+- `--version <x.y.z>` — override the detected version
+- `--output <file>` — write to a different file (default: `CHANGELOG.md`)

--- a/bounties/issue-1-changelog/changelog.sh
+++ b/bounties/issue-1-changelog/changelog.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# changelog.sh — Generate a structured CHANGELOG.md from git history
+# Usage: bash changelog.sh [--since <tag|commit>] [--output <file>]
+# Requirements: git (any version)
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+OUTPUT="CHANGELOG.md"
+SINCE=""
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --since)   SINCE="$2";  shift 2 ;;
+    --output)  OUTPUT="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# ── Detect range ──────────────────────────────────────────────────────────────
+if [[ -z "$SINCE" ]]; then
+  # Use the most recent tag as baseline
+  SINCE=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+fi
+
+if [[ -z "$SINCE" ]]; then
+  echo "ℹ️  No tags found — using full history"
+  RANGE=""
+else
+  echo "📌 Generating CHANGELOG since: $SINCE"
+  RANGE="${SINCE}..HEAD"
+fi
+
+# ── Auto-detect version ───────────────────────────────────────────────────────
+if [[ -z "$VERSION" ]]; then
+  # Try package.json, then Cargo.toml, then next tag, then date
+  if [[ -f "package.json" ]]; then
+    VERSION=$(node -e "try{console.log(require('./package.json').version)}catch(e){}" 2>/dev/null || echo "")
+  fi
+  if [[ -z "$VERSION" ]] && [[ -f "Cargo.toml" ]]; then
+    VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"//' | sed 's/"//' || echo "")
+  fi
+  if [[ -z "$VERSION" ]]; then
+    VERSION=$(date +"%Y-%m-%d")
+  fi
+fi
+
+DATE=$(date +"%Y-%m-%d")
+
+# ── Fetch commits ─────────────────────────────────────────────────────────────
+# Format: <hash>|<subject>|<author>
+COMMITS=$(git log ${RANGE} --pretty=format:"%H|%s|%an" --no-merges 2>/dev/null || echo "")
+
+if [[ -z "$COMMITS" ]]; then
+  echo "⚠️  No commits found in range. Nothing to generate."
+  exit 0
+fi
+
+# ── Categorize ────────────────────────────────────────────────────────────────
+declare -a ADDED FIXED CHANGED REMOVED UNCATEGORIZED
+
+while IFS='|' read -r hash subject author; do
+  [[ -z "$subject" ]] && continue
+
+  lower=$(echo "$subject" | tr '[:upper:]' '[:lower:]')
+  entry="- ${subject} (${author})"
+
+  if echo "$lower" | grep -qE '^(feat|add|new|implement|create|introduce)(\(.+\))?[!:]?'; then
+    ADDED+=("$entry")
+  elif echo "$lower" | grep -qE '^(fix|bug|patch|hotfix|correct|resolve)(\(.+\))?[!:]?'; then
+    FIXED+=("$entry")
+  elif echo "$lower" | grep -qE '^(refactor|perf|improve|update|upgrade|change|style|chore|docs|ci|build|test)(\(.+\))?[!:]?'; then
+    CHANGED+=("$entry")
+  elif echo "$lower" | grep -qE '^(remove|delete|drop|deprecate|revert)(\(.+\))?[!:]?'; then
+    REMOVED+=("$entry")
+  else
+    UNCATEGORIZED+=("$entry")
+  fi
+done <<< "$COMMITS"
+
+# ── Write CHANGELOG ───────────────────────────────────────────────────────────
+TMP=$(mktemp)
+
+echo "# Changelog" > "$TMP"
+echo "" >> "$TMP"
+
+# Prepend to existing CHANGELOG if it exists
+EXISTING=""
+if [[ -f "$OUTPUT" ]]; then
+  # Skip the first "# Changelog" line to avoid duplication
+  EXISTING=$(tail -n +2 "$OUTPUT")
+fi
+
+cat >> "$TMP" << HEADER
+## [${VERSION}] — ${DATE}
+
+HEADER
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+  if [[ ${#items[@]} -gt 0 ]]; then
+    echo "### $title" >> "$TMP"
+    for item in "${items[@]}"; do
+      echo "$item" >> "$TMP"
+    done
+    echo "" >> "$TMP"
+  fi
+}
+
+write_section "Added"   "${ADDED[@]+"${ADDED[@]}"}"
+write_section "Fixed"   "${FIXED[@]+"${FIXED[@]}"}"
+write_section "Changed" "${CHANGED[@]+"${CHANGED[@]}"}"
+write_section "Removed" "${REMOVED[@]+"${REMOVED[@]}"}"
+
+if [[ ${#UNCATEGORIZED[@]} -gt 0 ]]; then
+  write_section "Other" "${UNCATEGORIZED[@]}"
+fi
+
+# Append previous content
+if [[ -n "$EXISTING" ]]; then
+  echo "" >> "$TMP"
+  echo "---" >> "$TMP"
+  echo "$EXISTING" >> "$TMP"
+fi
+
+mv "$TMP" "$OUTPUT"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+TOTAL=$(echo "$COMMITS" | wc -l | tr -d ' ')
+echo "✅ CHANGELOG.md generated (${TOTAL} commits)"
+echo "   📂 Output: ${OUTPUT}"
+echo "   📦 Version: ${VERSION}"
+echo "   ➕ Added: ${#ADDED[@]}  🐛 Fixed: ${#FIXED[@]}  🔄 Changed: ${#CHANGED[@]}  ❌ Removed: ${#REMOVED[@]}"


### PR DESCRIPTION
## Solution

Implements `changelog.sh` — a bash script that generates a structured `CHANGELOG.md` from git history.

## What's included

- `changelog.sh` — main script (bash, no external dependencies)
- `SKILL.md` — Claude Code `/generate-changelog` trigger instructions
- `README.md` — setup in 2 commands, options, how-it-works table
- `SAMPLE_OUTPUT.md` — real output from a 26-commit repo

## Acceptance criteria

- [x] Works via `bash changelog.sh` or `/generate-changelog` Claude Code command
- [x] Fetches commits since the last git tag (falls back to full history if no tags)
- [x] Auto-categorizes: **Added / Fixed / Changed / Removed** (conventional commits)
- [x] Outputs properly formatted `CHANGELOG.md`
- [x] Tested on real repos (see `SAMPLE_OUTPUT.md`)
- [x] README with setup in 2 steps

## Tests

**Repo with tags:**
```
📌 Generating CHANGELOG since: v0.1.0
✅ CHANGELOG.md generated (4 commits)
   ➕ Added: 1  🐛 Fixed: 1  🔄 Changed: 1  ❌ Removed: 1
```

**Repo without tags (26 commits):**
```
ℹ️  No tags found — using full history
✅ CHANGELOG.md generated (26 commits)
   ➕ Added: 11  🐛 Fixed: 9  🔄 Changed: 1  ❌ Removed: 0
```

Closes #1