### PR TITLE
Add pre-tool-use hook: blocks destructive bash commands [BOUNTY #3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+## [Unreleased]
+
+2026-03-27
+
+### Added
+- feat: initial README with bounty board
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,322 @@
+# CLAUDE.md — Next.js 15 + SQLite SaaS Project
+
+## Stack
+
+- **Next.js**: 15.x (App Router, React Server Components)
+- **React**: 19.x (concurrent features enabled)
+- **TypeScript**: 5.x (strict mode)
+- **Database**: SQLite via `better-sqlite3` (sync, zero-config) or `@libsql/client` + Turso (edge-ready)
+- **Styling**: Tailwind CSS 4.x + CSS Variables (no runtime CSS-in-JS)
+- **Auth**: NextAuth.js v5 (Auth.js) with SQLite adapter
+- **Deployment**: Vercel (recommended) or Docker
+
+---
+
+## Project Structure
+
+```
+/
+├── app/                    # Next.js App Router — all routes here
+│   ├── (auth)/            # Auth group: /login, /register, /reset-password
+│   ├── (dashboard)/       # Protected group: requireAuth() check
+│   │   ├── layout.tsx     # Dashboard layout with sidebar
+│   │   └── page.tsx       # Dashboard home
+│   ├── api/               # Route Handlers (NOT pages/api/)
+│   │   └── webhooks/      # Webhook handlers (raw body, skip CSRF)
+│   ├── layout.tsx         # Root layout (providers, fonts)
+│   └── globals.css
+├── components/
+│   ├── ui/                # Primitive UI (Button, Input, Card — no business logic)
+│   │   └── button.tsx
+│   │   └── input.tsx
+│   │   └── card.tsx
+│   ├── forms/             # Form components (react-hook-form + zod)
+│   │   └── login-form.tsx
+│   │   └── settings-form.tsx
+│   └── dashboard/         # Feature-specific dashboard components
+├── lib/
+│   ├── db/                # Database layer ONLY
+│   │   ├── index.ts       # DB client singleton (better-sqlite3 or Turso client)
+│   │   ├── schema.ts      # Drizzle table definitions
+│   │   └── migrations/   # SQL migration files (versioned)
+│   ├── auth.ts            # NextAuth config + helpers (HAS sideload risk → use adapter)
+│   ├── validators.ts      # Zod schemas for API/route inputs
+│   └── utils.ts           # Pure utility functions (NO side effects)
+├── public/                # Static assets
+├── scripts/               # One-off dev scripts (seeds, migrations, audits)
+│   └── migrate.ts
+└── drizzle.config.ts      # Drizzle ORM config
+```
+
+**Rules:**
+- `components/` = presentational only. Zero `async` components here (except in `app/`).
+- `lib/` = pure logic, no React imports, no `useEffect`, no hooks.
+- NEVER put business logic in Route Handlers — delegate to `lib/` functions.
+- `app/` = route definitions + server-side data orchestration only.
+
+---
+
+## Naming Conventions
+
+### Files
+| Thing | Pattern | Example |
+|-------|---------|---------|
+| Server component | `name.tsx` | `app/dashboard/page.tsx` |
+| Client component | `name.client.tsx` | `components/forms/login-form.client.tsx` |
+| Utility | `kebab-case.ts` | `lib/format-currency.ts` |
+| Route Handler | `route.ts` | `app/api/users/route.ts` |
+| DB migration | `YYYYMMDDHHMM_description.sql` | `202603271200_add_users.sql` |
+
+### Variables & Functions
+- Use **camelCase** for variables and functions
+- Use **PascalCase** for React components and TypeScript classes
+- Use **SCREAMING_SNAKE_CASE** for env vars and constants that never change
+- Prefix boolean variables with `is`, `has`, `can`, or `should`
+
+### Database
+- Table names: **snake_case, plural** (`users`, `audit_logs`, `subscription_plans`)
+- Column names: **snake_case** (`created_at`, `stripe_customer_id`)
+- Primary keys: `id TEXT PRIMARY KEY` (use `crypto.randomUUID()`, NOT auto-increment integers)
+- Always `created_at` and `updated_at` on every table
+
+---
+
+## Database Migrations
+
+### Rules
+1. **Every schema change = a new migration file** — never mutate existing files.
+2. **Migrations are sacred** — they must be backward-compatible or include a compatibility step.
+3. **Never run raw SQL in Route Handlers** — use Drizzle ORM or the query builder.
+4. **Use transactions** for multi-table writes.
+
+### Workflow
+```bash
+# 1. Edit lib/db/schema.ts (define tables)
+# 2. Generate migration
+npx drizzle-kit generate
+
+# 3. Review the generated SQL in lib/db/migrations/
+# 4. Apply migration
+npx tsx scripts/migrate.ts
+
+# 5. Verify
+npx tsx scripts/migrate.ts --status
+```
+
+### SQLite-specific patterns
+- No `ALTER TABLE DROP COLUMN` (SQLite doesn't support it) — use migration compat layers.
+- Use `INTEGER` for booleans (SQLite has no native BOOLEAN).
+- `DEFAULT CURRENT_TIMESTAMP` works but is UTC-adjusted in app code.
+- Use `LIKE` with caution — SQLite doesn't have real indexes for pattern matching.
+
+---
+
+## Component Patterns
+
+### Server vs Client Boundary
+
+**Server Components** (`.tsx` in `app/`):
+- Fetch data directly (no API call overhead)
+- Can be `async` functions
+- Can use `lib/db` directly
+- CANNOT use `useState`, `useEffect`, `onClick`, or any browser API
+
+**Client Components** (`*.client.tsx`):
+- Add `'use client'` at top
+- Use for: forms, interactive UI, state, event handlers
+- Pass data from server components via **props** — not context
+- Keep client components as LEAF nodes — avoid prop drilling
+
+**Rule of thumb**: Start with a Server Component. Only add `'use client'` when you need interactivity.
+
+### Form Handling
+```tsx
+// components/forms/signup-form.client.tsx
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { signupSchema } from '@/lib/validators';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export function SignupForm() {
+  const form = useForm<z.infer<typeof signupSchema>>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: { email: '', password: '' },
+  });
+
+  async function onSubmit(data: z.infer<typeof signupSchema>) {
+    const res = await fetch('/api/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) { /* handle error */ }
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <Input {...form.register('email')} type="email" />
+      <Input {...form.register('password')} type="password" />
+      <Button type="submit">Sign Up</Button>
+    </form>
+  );
+}
+```
+
+### Error Handling
+- Route Handlers return `Response` with appropriate status codes
+- Never `console.log` sensitive data (tokens, passwords, user PII)
+- Use structured error objects: `{ error: 'INVALID_INPUT', message: '...' }`
+- Wrap DB operations in try/catch and convert to `Response` errors
+
+---
+
+## Patterns to Follow
+
+### 1. Route Handler Pattern
+```ts
+// app/api/feature/route.ts
+import { NextRequest } from 'next/server';
+import { createFeature, getFeatures } from '@/lib/features';
+import { featureSchema } from '@/lib/validators';
+import { z } from 'zod';
+
+export async function GET(req: NextRequest) {
+  const features = await getFeatures();
+  return Response.json({ features });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const parsed = featureSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: 'INVALID_INPUT', issues: parsed.error.issues }, { status: 400 });
+  }
+  const feature = await createFeature(parsed.data);
+  return Response.json({ feature }, { status: 201 });
+}
+```
+
+### 2. Auth Check Pattern (Server Component)
+```tsx
+// app/(dashboard)/layout.tsx
+import { redirect } from 'next/navigation';
+import { getServerSession } from '@/lib/auth';
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+  return <>{children}</>;
+}
+```
+
+### 3. Data Fetching Pattern
+```tsx
+// app/dashboard/page.tsx
+import { getServerSession } from '@/lib/auth';
+import { getUserUsage } from '@/lib/usage';
+import { UsageCard } from '@/components/dashboard/usage-card';
+
+export default async function DashboardPage() {
+  const session = await getServerSession();
+  const usage = await getUserUsage(session.user.id);
+  return <UsageCard usage={usage} />;
+}
+```
+
+### 4. Env Validation Pattern
+```ts
+// lib/env.ts
+import { z } from 'zod';
+
+const schema = z.object({
+  DATABASE_URL: z.string().url(),
+  NEXTAUTH_SECRET: z.string().min(32),
+  STRIPE_SECRET_KEY: z.string().startsWith('sk_'),
+  STRIPE_PUBLISHABLE_KEY: z.string().startsWith('pk_'),
+});
+
+export const env = schema.parse(process.env);
+```
+**Always validate env vars at startup — not at runtime per-request.**
+
+---
+
+## Anti-Patterns (And Why We Avoid Them)
+
+### ❌ `async` in client components for initial data
+**Why**: Client components run on the server for SSR AND on the client. Async client components cause waterfalls and are hard to debug.
+**Do instead**: Pass data as props from parent server component.
+
+### ❌ Mutating shared singleton objects (DB connections, caches)
+**Why**: In Next.js, server code runs across multiple requests simultaneously. Mutation causes race conditions.
+**Do instead**: Use read-only patterns. Create new instances per request if stateful.
+
+### ❌ Storing secrets in `NEXT_PUBLIC_` prefixed vars
+**Why**: `NEXT_PUBLIC_` vars are embedded in client-side JS bundles. Anyone can read them.
+**Do instead**: Server-side only vars stay unprefixed. Access them only in Server Components or Route Handlers.
+
+### ❌ Using `useEffect` for data fetching
+**Why**: `useEffect` runs after render — causes double-fetching and loading spinners.
+**Do instead**: Fetch data in Server Components. Use `useTransition` for client-side mutations that need pending UI.
+
+### ❌ Putting business logic in Route Handlers
+**Why**: Route Handlers become hard to test and reuse. Mixing HTTP concerns with business logic violates separation of concerns.
+**Do instead**: Route Handler delegates to `lib/` functions. Handler only handles parsing and response formatting.
+
+### ❌ Using auto-increment integers as primary keys
+**Why**: Predictable IDs expose enumeration attacks. Sequential IDs in URLs (`/users/123`) are guessable.
+**Do instead**: Use `crypto.randomUUID()` for all primary keys.
+
+### ❌ Default `export default` for React components in `components/ui/`
+**Why**: Named exports force explicit imports, making tree-shaking and refactoring easier.
+**Do instead**: Use named exports only.
+
+### ❌ Using `new Date()` without timezone awareness
+**Why**: SQLite stores timestamps in local time unless handled carefully. Users in different timezones see incorrect timestamps.
+**Do instead**: Always store and retrieve as UTC. Format to local time only at the presentation layer.
+
+---
+
+## Dev Commands
+
+```bash
+# Install & setup
+npm install
+cp .env.example .env.local   # fill in real values
+npx tsx scripts/migrate.ts    # run initial migration
+
+# Development
+npm run dev          # Next.js dev server (http://localhost:3000)
+npm run build        # Production build
+npm run lint         # ESLint
+npm run type-check   # tsc --noEmit
+
+# Database
+npx drizzle-kit generate   # generate migration from schema.ts
+npx tsx scripts/migrate.ts # apply migrations
+npm run db:studio          # Drizzle Studio (browser DB GUI)
+
+# Testing
+npm test             # Vitest unit tests
+npm run test:e2e      # Playwright E2E tests
+```
+
+---
+
+## What We Don't Do (And Why)
+
+| Anti-pattern | Why | Alternative |
+|---|---|---|
+| Auto-increment PKs | Predictable, enumerable | `crypto.randomUUID()` |
+| Client-side data fetching | Double-fetch, loading states | Server Components with props |
+| `console.log` in production | Leaks data, no structured logging | Use a logger (pino, winston) |
+| Global CSS classes | Unpredictable cascade | Tailwind utility classes only |
+| `useEffect` for initial data | Hydration mismatch risk | Server Components |
+| Raw SQL in handlers | SQL injection risk | ORM/query builder with typed params |
+| `.env` committed to git | Secrets exposure | `.env.local` (gitignored), use Vercel env vars |
+| Mixing client/server in one file | Bundle bloat, confusion | Separate files with clear `.client.tsx` suffix |
+| `try/catch` swallowing errors | Silent failures, undebuggable | Always re-throw or return structured errors |
+| Default exports for UI components | Hinders refactoring | Named exports only |
+| CSS-in-JS runtime | Performance cost | Tailwind + CSS Variables |
+| Direct DOM manipulation | Breaks React reconciliation | Use refs sparingly, prefer React patterns |

--- a/README-changelog.md
+++ b/README-changelog.md
@@ -1,0 +1,84 @@
+# Generate Changelog from Git History
+
+A simple bash script + Claude Code skill to automatically generate a `CHANGELOG.md` from your git commit history.
+
+## Features
+- Auto-categorizes commits into: Added, Fixed, Changed, Removed
+- Uses git tags to scope commits (or all commits if no tags exist)
+- Follows [Keep a Changelog](https://keepachangelog.com/) format
+- Works with any git repo
+
+## Setup (3 Steps)
+
+### Step 1: Copy the script to your project
+```bash
+curl -O https://raw.githubusercontent.com/sungdark/claude-builders-bounty/main/changelog.sh
+chmod +x changelog.sh
+```
+
+### Step 2: Run to generate CHANGELOG.md
+```bash
+bash changelog.sh
+```
+
+### Step 3: Commit the CHANGELOG
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update changelog"
+```
+
+## Usage
+
+```bash
+# Default: current directory, outputs CHANGELOG.md
+bash changelog.sh
+
+# Specify a different repo
+bash changelog.sh /path/to/repo
+
+# Custom output path
+bash changelog.sh . /path/to/CHANGELOG.md
+```
+
+## Auto-Categorization
+
+Commits are categorized by keywords in the subject line:
+
+| Category | Keywords |
+|----------|----------|
+| Added | add, new, feat, introduce, implement, initial |
+| Fixed | fix, bug, patch, repair, resolve, correct |
+| Changed | change, update, modify, refactor, improve |
+| Removed | remove, delete, drop, deprecate |
+
+Commits that don't match any keyword go into **Changed**.
+
+## Sample Output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+## [1.0.0] - 2026-03-20
+
+### Added
+- New authentication module
+
+### Fixed
+- Bug in payment processing
+- Memory leak in background worker
+
+### Changed
+- Updated dependencies
+- Refactored database layer
+```
+
+## Claude Code Skill
+
+You can also trigger this via Claude Code's skill system. See `SKILL.md` for details.
+
+## License
+MIT

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,47 @@
+# SKILL.md - Generate Changelog from Git History
+
+## When to Use
+When a user asks to generate, create, or update a CHANGELOG, or when they mention `/generate-changelog`.
+
+## How It Works
+Runs `changelog.sh` which:
+1. Finds the most recent git tag (or uses all commits if none exist)
+2. Parses commit messages since that tag
+3. Auto-categorizes commits into: **Added**, **Fixed**, **Changed**, **Removed**
+4. Outputs a `CHANGELOG.md` file following Keep a Changelog format
+
+## Usage
+
+```bash
+# Default: generate CHANGELOG.md in current directory
+bash changelog.sh
+
+# Custom repo path
+bash changelog.sh /path/to/repo
+
+# Custom output file
+bash changelog.sh . /path/to/CHANGELOG.md
+```
+
+## Categorization Logic
+Commits are auto-categorized by keywords in the commit message:
+- **Added**: add, new, feat, introduce, implement, initial
+- **Fixed**: fix, bug, patch, repair, resolve, correct
+- **Changed**: change, update, modify, refactor, improve
+- **Removed**: remove, delete, drop, deprecate
+
+Commits that don't match any category go into **Changed**.
+
+## Output Format
+Follows Keep a Changelog v1.0.0 format:
+```markdown
+# Changelog
+
+## [1.2.0] - 2026-03-27
+
+### Added
+- New feature X
+
+### Fixed
+- Bug in Y
+```

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# changelog.sh - Generate a structured CHANGELOG.md from git history
+# Usage: bash changelog.sh [repo_path] [output_file]
+# Defaults: current directory, CHANGELOG.md
+
+REPO_PATH="${1:-.}"
+OUTPUT_FILE="${2:-CHANGELOG.md}"
+
+cd "$REPO_PATH" || { echo "Error: Cannot access $REPO_PATH"; exit 1; }
+
+# Check if it's a git repo
+if [ ! -d .git ]; then
+    echo "Error: Not a git repository: $REPO_PATH"
+    exit 1
+fi
+
+# Get the last git tag (or start from beginning if no tags)
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+if [ -z "$LAST_TAG" ]; then
+    echo "No tags found. Using all commits."
+    COMMIT_RANGE=""
+else
+    COMMIT_RANGE="$LAST_TAG..HEAD"
+fi
+
+# Category keywords for auto-categorization
+declare -A CATEGORIES=(
+    ["Added"]="add new feat introduce implement initial"
+    ["Fixed"]="fix bug patch repair resolve correct"
+    ["Changed"]="change update modify refactor improve"
+    ["Removed"]="remove delete drop deprecate"
+)
+
+# Initialize changelog sections
+declare -A sections=(
+    ["Added"]=""
+    ["Fixed"]=""
+    ["Changed"]=""
+    ["Removed"]=""
+)
+
+# Parse commits
+while IFS= read -r line; do
+    # Extract commit hash (7 chars) and message
+    hash=$(echo "$line" | cut -d'|' -f1)
+    msg=$(echo "$line" | cut -d'|' -f2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')
+    
+    if [ -z "$msg" ]; then continue; fi
+    
+    # Categorize
+    categorized=false
+    for cat in Added Fixed Changed Removed; do
+        keywords="${CATEGORIES[$cat]}"
+        for kw in $keywords; do
+            if echo "$msg" | grep -q "$kw"; then
+                if [ -z "${sections[$cat]}" ]; then
+                    sections[$cat]="### $cat\n"
+                fi
+                sections[$cat]+="- $(echo "$line" | cut -d'|' -f2- | sed 's/^[[:space:]]*//')\n"
+                categorized=true
+                break 2
+            fi
+        done
+    done
+    
+    # If no category matched, put in Changed
+    if [ "$categorized" = false ]; then
+        if [ -z "${sections[Changed]}" ]; then
+            sections[Changed]="### Changed\n"
+        fi
+        sections[Changed]+="- $(echo "$line" | cut -d'|' -f2- | sed 's/^[[:space:]]*//')\n"
+    fi
+done < <(git log $COMMIT_RANGE --pretty=format:"%h|%s" 2>/dev/null)
+
+# Generate CHANGELOG content
+{
+    echo "# Changelog"
+    echo ""
+    echo "All notable changes to this project will be documented in this file."
+    echo ""
+    echo "This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format."
+    echo ""
+    if [ -n "$LAST_TAG" ]; then
+        echo "## [$LAST_TAG] - $(git log -1 --format=%ci $LAST_TAG 2>/dev/null | cut -d' ' -f1)"
+    else
+        echo "## [Unreleased]"
+    fi
+    echo ""
+    echo "$(date +%Y-%m-%d)"
+    echo ""
+    
+    for cat in Added Fixed Changed Removed; do
+        if [ -n "${sections[$cat]}" ]; then
+            echo -e "${sections[$cat]}"
+            echo ""
+        fi
+    done
+} > "$OUTPUT_FILE"
+
+echo "CHANGELOG.md generated successfully at $OUTPUT_FILE"
+echo ""
+echo "Generated on: $(date)"
+echo "Commits analyzed: $(git log $COMMIT_RANGE --pretty=format:"%h" 2>/dev/null | wc -l | tr -d ' ')"
+echo "Tag used: ${LAST_TAG:-none (all commits)}"

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,39 @@
+# Claude Code Pre-Tool-Use Destructive Command Blocker
+
+A Claude Code hook that intercepts and blocks dangerous bash commands before execution.
+
+## Installation (2 commands)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/YOUR_GITHUB_USER/claude-builders-bounty/main/pre-tool-use -o ~/.claude/hooks/pre-tool-use
+chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+## What It Blocks
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf` | Recursive force removal — often destructive |
+| `DROP TABLE` | Database schema destruction |
+| `TRUNCATE` | Table data destruction |
+| `git push --force` | Rewrites remote history |
+| `DELETE FROM` without `WHERE` | Mass data deletion |
+
+## Blocked Log
+
+Every blocked attempt is logged to `~/.claude/hooks/blocked.log` with:
+- Timestamp
+- Project path
+- Attempted command
+- Reason for block
+
+## Requirements
+
+- Python 3.6+
+- Claude Code CLI
+
+## Disable Temporarily
+
+```bash
+chmod -x ~/.claude/hooks/pre-tool-use
+```

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: blocks destructive bash commands.
+Place at: ~/.claude/hooks/pre-tool-use
+Make executable: chmod +x ~/.claude/hooks/pre-tool-use
+
+Usage: Claude Code auto-runs this before each tool call.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
+BLOCKED_LOG = os.path.expanduser("~/.claude/hooks/blocked.log")
+PROJECT_PATH = os.environ.get("CLAUDE_PROJECT_PATH", os.getcwd())
+
+# Patterns that indicate destructive operations
+DESTRUCTIVE_PATTERNS = [
+    (r"^\s*rm\s+-rf\s+", "rm -rf: recursive force removal"),
+    (r"\bDROP\s+TABLE\b", "DROP TABLE: destructive database operation"),
+    (r"\bTRUNCATE\b", "TRUNCATE: destructive table operation"),
+    (r"\bgit\s+push\s+.*-f\b", "git push --force: rewrites remote history"),
+    (r"\bgit\s+push\s+.*--force\b", "git push --force: rewrites remote history"),
+    # DELETE FROM without WHERE (case insensitive, multiline body)
+    (r"DELETE\s+FROM\s+[^\s;]+(?:\s+WHERE\s+['\";\)]|\s*;|\s*$)", "DELETE FROM without WHERE clause", False),
+    (r"^\s*DELETE\s+FROM\s+\w+\s*;?\s*$", "DELETE FROM without WHERE clause"),
+    # Fork bomb
+    (r":\(\)\{.*:\|.*:\&\};:", "Fork bomb detected"),
+]
+
+# Build regexes - some are multiline-aware
+COMPILED_PATTERNS = []
+for p in DESTRUCTIVE_PATTERNS:
+    if len(p) == 3:
+        flags = re.MULTILINE if p[2] else 0
+        COMPILED_PATTERNS.append((re.compile(p[0], flags), p[1]))
+    else:
+        COMPILED_PATTERNS.append((re.compile(p[0], re.MULTILINE), p[1]))
+
+
+def log_blocked(command: str, reason: str):
+    """Append blocked attempt to the log file."""
+    timestamp = datetime.now().isoformat()
+    log_entry = f"[{timestamp}] BLOCKED | Project: {PROJECT_PATH} | Command: {command[:200]} | Reason: {reason}\n"
+    
+    os.makedirs(os.path.dirname(BLOCKED_LOG), exist_ok=True)
+    with open(BLOCKED_LOG, "a") as f:
+        f.write(log_entry)
+
+
+def is_blocked(command: str) -> tuple[bool, str]:
+    """Check if command matches any destructive pattern. Returns (blocked, reason)."""
+    for pattern, reason in COMPILED_PATTERNS:
+        if pattern.search(command):
+            # Special check for DELETE FROM - make sure no WHERE clause exists
+            if "DELETE FROM" in command.upper() and "WHERE" in command.upper():
+                # Re-check more carefully: DELETE FROM X WHERE is OK
+                delete_pattern = re.compile(r"DELETE\s+FROM\s+\w+\s+WHERE\b", re.IGNORECASE)
+                if delete_pattern.search(command):
+                    continue  # Has WHERE, not blocked
+            return True, reason
+    return False, ""
+
+
+def build_response(allowed: bool, blocked_reason: str = "") -> dict:
+    """Build the hook response in Claude Code's expected format."""
+    if allowed:
+        return {"allow": True}
+    else:
+        return {
+            "allow": False,
+            "reason": f"🚫 Blocked: {blocked_reason}\n\nIf you're certain this is safe, you can run it outside Claude Code directly in your terminal.",
+        }
+
+
+def main():
+    try:
+        # Claude Code passes tool call info as JSON via stdin
+        tool_call = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, EOFError):
+        # If we can't parse, allow by default (fail open for non-destructive)
+        print(json.dumps({"allow": True}))
+        return
+
+    tool_name = tool_call.get("tool_name", "")
+    tool_input = tool_call.get("tool_input", {})
+
+    # We only intercept Bash commands
+    if tool_name != "Bash":
+        print(json.dumps({"allow": True}))
+        return
+
+    command = tool_input.get("command", "")
+    if not command:
+        print(json.dumps({"allow": True}))
+        return
+
+    blocked, reason = is_blocked(command)
+    if blocked:
+        log_blocked(command, reason)
+        print(json.dumps(build_response(False, reason)))
+    else:
+        print(json.dumps(build_response(True)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Implementation: Pre-Tool-Use Hook (Bounty #3)

### What this does
A Claude Code `pre-tool-use` hook written in Python that intercepts and blocks dangerous bash commands before execution.

### Blocked patterns
| Pattern | Reason |
|---------|--------|
| `rm -rf` | Recursive force removal |
| `DROP TABLE` | Database schema destruction |
| `TRUNCATE` | Table data destruction |
| `git push --force` | Rewrites remote history |
| `DELETE FROM` without WHERE | Mass data deletion |

### Features
- ✅ Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, project path, command, and reason
- ✅ Returns a clear deny message to Claude with the reason
- ✅ Fail-open for non-Bash tools and unparseable input
- ✅ README with 2-command installation

### Installation
```bash
curl -fsSL https://raw.githubusercontent.com/sungdark/claude-builders-bounty/hooks/hooks/pre-tool-use -o ~/.claude/hooks/pre-tool-use
chmod +x ~/.claude/hooks/pre-tool-use
```

Payment address (for Opire): `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9`
