### PR TITLE
[BOUNTY $100] Pre-tool-use hook — blocks destructive bash commands

### DIFF
--- a/pre-tool-hook/README.md
+++ b/pre-tool-hook/README.md
@@ -1,0 +1,44 @@
+# Claude Code Pre-Tool-Use Hook: Destructive Command Blocker
+
+A `pre-tool-use` hook for Claude Code that intercepts and blocks dangerous bash commands before they execute.
+
+## What It Blocks
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf` | Recursive force delete |
+| `DROP TABLE` | SQL drop — irreversible |
+| `git push --force` | Rewrites remote history |
+| `TRUNCATE` | Deletes all table rows |
+| `DELETE FROM` without `WHERE` | Wipes entire table |
+| `mkfs.*` | Destroys filesystem |
+| `dd of=/dev/*` | Direct block device write |
+
+## Installation
+
+```bash
+# 2 commands
+curl -fsSL https://raw.githubusercontent.com/sungdark/claude-builders-bounty/pre-tool-hook/pre-tool-hook/pre-tool-use-hook.sh -o ~/.claude/hooks/pre-tool-use
+chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+## How It Works
+
+1. Hook script lives at `~/.claude/hooks/pre-tool-use`
+2. Receives tool payload via stdin as JSON
+3. Checks bash command against dangerous regex patterns
+4. If blocked: logs to `~/.claude/hooks/blocked.log` + tells Claude why
+5. Exit code `1` = block, `0` = allow
+
+## Log Format
+
+Each blocked attempt is logged with timestamp, tool name, command, reason, and working directory.
+
+## Requirements
+
+- Python 3.6+
+- Claude Code (latest version with hooks support)
+
+## Claude Code Hooks Docs
+
+https://docs.anthropic.com/claude-code/hooks

--- a/pre-tool-hook/pre-tool-use-hook.sh
+++ b/pre-tool-hook/pre-tool-use-hook.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: blocks destructive bash commands.
+Install: cp pre-tool-use-hook.sh ~/.claude/hooks/pre-tool-use
+"""
+import sys
+import json
+import os
+import re
+from datetime import datetime
+
+HOOKS_DIR = os.path.expanduser("~/.claude/hooks")
+BLOCKED_LOG = os.path.join(HOOKS_DIR, "blocked.log")
+
+# Dangerous patterns to block
+DANGEROUS_PATTERNS = [
+    (r'rm\s+-rf\s+', "Recursive force delete — catastrophic if wrong path"),
+    (r'DROP\s+TABLE', "SQL DROP TABLE — irreversibly deletes data"),
+    (r'git\s+push\s+.*--force', "Force push — rewrites remote history"),
+    (r'TRUNCATE', "SQL TRUNCATE — deletes all rows without backup"),
+    (r'DELETE\s+FROM\s+(?!.*WHERE)', "SQL DELETE without WHERE clause"),
+    (r'DELETE\s+FROM\s+\w+\s*$', "SQL DELETE without WHERE clause"),
+    (r'\|\s*rm\s+', "Pipe to rm — dangerous pattern"),
+    (r'>\s*/dev/sd', "Direct block device write"),
+    (r'>\s*/dev/hd', "Direct block device write"),
+    (r'mkfs\.', "Filesystem format — destroys data"),
+    (r'dd\s+.*of=/dev/', "Direct block device write"),
+]
+
+def is_dangerous(command: str) -> tuple:
+    for pattern, reason in DANGEROUS_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return True, reason
+    return False, ""
+
+def log_blocked(timestamp, tool, command, reason, cwd):
+    os.makedirs(HOOKS_DIR, exist_ok=True)
+    entry = (
+        f"[{timestamp}] BLOCKED\n"
+        f"  Tool: {tool}\n"
+        f"  Command: {command}\n"
+        f"  Reason: {reason}\n"
+        f"  CWD: {cwd}\n"
+        f"---\n"
+    )
+    try:
+        with open(BLOCKED_LOG, "a") as f:
+            f.write(entry)
+    except Exception:
+        pass
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool", "")
+    tool_input = payload.get("input", {})
+    
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+    else:
+        command = ""
+
+    blocked, reason = is_dangerous(command)
+
+    if blocked:
+        timestamp = datetime.now().isoformat()
+        cwd = os.getcwd()
+        log_blocked(timestamp, tool_name, command, reason, cwd)
+        
+        msg = (
+            f"\n🛑 HOOK: Command blocked by pre-tool-use hook\n"
+            f"   Reason: {reason}\n"
+            f"   Command: {command}\n"
+            f"   This command was blocked. Use a safer alternative or ask the user.\n"
+            f"   Logged to: {BLOCKED_LOG}\n"
+        )
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Implementation: Pre-Tool-Use Hook (Issue #3)

### What this PR does
Implements a Claude Code `pre-tool-use` hook in Python that intercepts and blocks dangerous bash commands before execution.

### Files added
- `pre-tool-hook/pre-tool-use-hook.sh` — the hook script (Python 3)
- `pre-tool-hook/README.md` — installation + usage docs

### Patterns blocked
| Pattern | Reason |
|---------|--------|
| `rm -rf` | Recursive force delete |
| `DROP TABLE` | SQL drop — irreversible |
| `git push --force` | Rewrites remote history |
| `TRUNCATE` | Deletes all table rows |
| `DELETE FROM` without `WHERE` | Wipes entire table |
| `mkfs.*` | Filesystem format |
| `dd of=/dev/*` | Direct block device write |

### Features
- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp + CWD
- Shows clear message to Claude explaining why the command was blocked
- Non-intrusive: allows all safe commands through
- Install in 2 commands as specified

### Testing
The hook correctly identifies and blocks all listed patterns.

收款地址：eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9