### PR TITLE
feat: pre-tool-use hook — block destructive bash commands (closes #3)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,135 @@
+# Destructive Command Guard 🛡️
+
+A `pre-tool-use` hook for Claude Code that intercepts and blocks destructive bash commands before they execute.
+
+## What it blocks
+
+| Pattern | Example | Why |
+|---------|---------|-----|
+| `rm -rf` | `rm -rf /` | Irreversible recursive file deletion |
+| `DROP TABLE/DATABASE` | `psql -c 'DROP TABLE users'` | SQL schema destruction |
+| `TRUNCATE TABLE` | `mysql -e 'TRUNCATE TABLE orders'` | SQL mass data deletion |
+| `DELETE FROM` (no WHERE) | `psql -c 'DELETE FROM users'` | SQL mass deletion without filter |
+| `git push --force` / `-f` | `git push -f origin main` | Remote history rewrite |
+| `mkfs` | `mkfs.ext4 /dev/sda1` | Filesystem formatting |
+| `dd of=/dev/*` | `dd if=/dev/zero of=/dev/sda` | Direct disk overwrite |
+| `chmod 777` | `chmod 777 /etc/passwd` | Overly permissive file permissions |
+| Fork bomb | `:(){ :|:& };:` | System resource exhaustion |
+| Device overwrite | `> /dev/sda` | Direct device redirection |
+
+## What it allows
+
+Safe commands pass through without interference:
+- `rm file.txt` (single file, no `-rf`)
+- `git push origin main` (normal push)
+- `git push --force-with-lease` (safe force push)
+- `DELETE FROM users WHERE id = 5` (has WHERE clause)
+- All non-destructive commands: `ls`, `cat`, `npm`, `pip`, etc.
+
+## Install (2 commands)
+
+```bash
+# 1. Copy the hook script
+cp hooks/guard.sh ~/.claude/hooks/guard.sh && chmod +x ~/.claude/hooks/guard.sh
+
+# 2. Add to your Claude Code settings (~/.claude/settings.json)
+# Merge this into your existing settings:
+```
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": { "tool_name": "Bash" },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+That's it! The hook will now intercept every `Bash` tool call and block destructive commands.
+
+## Logging
+
+Every blocked command is logged to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-03-28T02:15:00Z] BLOCKED | project=/home/user/myapp | command=rm -rf / | reason=Destructive file deletion: 'rm -rf' can irreversibly delete files and directories
+```
+
+## Testing
+
+```bash
+bash hooks/test/test.sh
+```
+
+Output:
+
+```
+🛡️ Destructive Command Guard — Test Suite
+
+🔴 Should BLOCK:
+  ✓ BLOCKED: rm -rf /
+  ✓ BLOCKED: rm -rf /home
+  ✓ BLOCKED: rm -fr .
+  ✓ BLOCKED: sudo rm -rf
+  ✓ BLOCKED: DROP TABLE
+  ✓ BLOCKED: DROP DATABASE
+  ✓ BLOCKED: TRUNCATE TABLE
+  ✓ BLOCKED: DELETE without WHERE
+  ✓ BLOCKED: git push --force
+  ✓ BLOCKED: git push -f
+  ✓ BLOCKED: mkfs
+  ✓ BLOCKED: dd of=/dev
+  ✓ BLOCKED: chmod 777
+  ✓ BLOCKED: fork bomb
+
+🟢 Should ALLOW:
+  ✓ ALLOWED: rm single file
+  ✓ ALLOWED: rm -r (no -f)
+  ✓ ALLOWED: git push
+  ✓ ALLOWED: git push --force-with-lease
+  ✓ ALLOWED: npm install
+  ✓ ALLOWED: pip install
+  ✓ ALLOWED: ls -la
+  ✓ ALLOWED: cat file
+  ✓ ALLOWED: DELETE with WHERE
+  ✓ ALLOWED: SELECT
+  ✓ ALLOWED: echo
+  ✓ ALLOWED: mkdir
+  ✓ ALLOWED: chmod 644
+  ✓ ALLOWED: git commit
+
+📝 Log output:
+  ✓ blocked.log has 14 entries
+
+────────────────────────────────────────
+Results: 29 passed, 0 failed
+```
+
+## How it works
+
+1. Claude Code calls the `Bash` tool → hook receives JSON on stdin
+2. Hook extracts the `command` field from `tool_input`
+3. Command is checked against 12 destructive patterns via regex
+4. If matched: logs the attempt and outputs `{ "permissionDecision": "deny" }` JSON
+5. If safe: exits silently (command proceeds normally)
+
+## Requirements
+
+- Bash 4+
+- Python 3 (for JSON parsing from stdin)
+- Claude Code with hooks support
+
+## License
+
+MIT

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Claude Code Pre-Tool-Use Hook: Destructive Command Guard   ║
+# ║                                                              ║
+# ║  Intercepts dangerous bash commands before Claude executes   ║
+# ║  them. Blocks: rm -rf, DROP TABLE, git push --force,        ║
+# ║  TRUNCATE, DELETE FROM (without WHERE).                      ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+set -euo pipefail
+
+LOG_FILE="${HOME}/.claude/hooks/blocked.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract tool name and command from JSON
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# Only check Bash tool commands
+if [ -z "$TOOL_NAME" ]; then
+  exit 0  # Not a bash command — allow
+fi
+
+COMMAND="$TOOL_NAME"
+BLOCKED=""
+REASON=""
+
+# ─── Pattern Matching ─────────────────────────────────────────
+
+# 1. rm -rf (recursive force delete)
+if echo "$COMMAND" | grep -qiP 'rm\s+(-[^\s]*r[^\s]*f|-[^\s]*f[^\s]*r)\b'; then
+  BLOCKED="true"
+  REASON="Destructive file deletion: 'rm -rf' can irreversibly delete files and directories"
+fi
+
+# 2. rm -r / (root deletion)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP 'rm\s+.*-[^\s]*r[^\s]*\s+/(\s|$)'; then
+  BLOCKED="true"
+  REASON="Root filesystem deletion detected"
+fi
+
+# 3. mkfs (format filesystem)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '\bmkfs\b'; then
+  BLOCKED="true"
+  REASON="Filesystem formatting command 'mkfs' detected"
+fi
+
+# 4. dd with of=/dev (disk overwrite)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '\bdd\b.*\bof=/dev/'; then
+  BLOCKED="true"
+  REASON="Direct disk write via 'dd of=/dev/' detected"
+fi
+
+# 5. DROP TABLE / DROP DATABASE (SQL)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '\bDROP\s+(TABLE|DATABASE)\b'; then
+  BLOCKED="true"
+  REASON="SQL destructive operation: DROP TABLE/DATABASE"
+fi
+
+# 6. TRUNCATE TABLE (SQL)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '\bTRUNCATE\s+TABLE\b'; then
+  BLOCKED="true"
+  REASON="SQL destructive operation: TRUNCATE TABLE"
+fi
+
+# 7. DELETE FROM without WHERE (SQL mass deletion)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '\bDELETE\s+FROM\b' && ! echo "$COMMAND" | grep -qiP '\bWHERE\b'; then
+  BLOCKED="true"
+  REASON="SQL mass deletion: DELETE FROM without WHERE clause"
+fi
+
+# 8. git push --force (history rewrite) — but NOT --force-with-lease (which is safe)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP 'git\s+push\s+.*--force(?!-with-lease)\b'; then
+  BLOCKED="true"
+  REASON="Forced git push can rewrite remote history: 'git push --force'"
+fi
+
+# 9. git push -f (shorthand force)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP 'git\s+push\s+(-f\b|.*\s-f\b)'; then
+  BLOCKED="true"
+  REASON="Forced git push can rewrite remote history: 'git push -f'"
+fi
+
+# 10. chmod 777 (overly permissive)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '\bchmod\s+777\b'; then
+  BLOCKED="true"
+  REASON="Overly permissive file permissions: 'chmod 777' is a security risk"
+fi
+
+# 11. > /dev/sda or similar device overwrite
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qiP '>\s*/dev/(sd|nvme|hd)'; then
+  BLOCKED="true"
+  REASON="Direct device overwrite via redirection detected"
+fi
+
+# 12. :(){ :|:& };: (fork bomb)
+if [ -z "$BLOCKED" ] && echo "$COMMAND" | grep -qP ':\(\)\s*\{'; then
+  BLOCKED="true"
+  REASON="Fork bomb pattern detected"
+fi
+
+# ─── Decision ─────────────────────────────────────────────────
+
+if [ -n "$BLOCKED" ]; then
+  # Log the blocked attempt
+  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  PROJECT_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd','unknown'))" 2>/dev/null || echo "unknown")
+  echo "[$TIMESTAMP] BLOCKED | project=$PROJECT_PATH | command=$COMMAND | reason=$REASON" >> "$LOG_FILE"
+
+  # Output deny decision as JSON
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "🛡️ BLOCKED by Destructive Command Guard: $REASON. Command: '$COMMAND'"
+  }
+}
+EOF
+  exit 0
+fi
+
+# Allow safe commands — exit with no output
+exit 0

--- a/hooks/test/test.sh
+++ b/hooks/test/test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════╗
+# ║  Test suite for Destructive Command Guard hook           ║
+# ║  Tests: blocked patterns, allowed patterns, log output   ║
+# ╚══════════════════════════════════════════════════════════╝
+
+set -uo pipefail
+
+HOOK="$(dirname "$0")/../guard.sh"
+PASS="\033[32m✓\033[0m"
+FAIL="\033[31m✗\033[0m"
+PASSED=0
+FAILED=0
+
+# Use temp log to avoid polluting real log
+export HOME=$(mktemp -d)
+mkdir -p "$HOME/.claude/hooks"
+
+test_blocked() {
+  local name="$1"
+  local command="$2"
+  local input="{\"tool_input\":{\"command\":\"$command\"},\"cwd\":\"/tmp/test\"}"
+  local output
+  output=$(echo "$input" | bash "$HOOK" 2>/dev/null)
+  if echo "$output" | grep -q '"deny"'; then
+    echo -e "  $PASS BLOCKED: $name"
+    ((PASSED++))
+  else
+    echo -e "  $FAIL SHOULD BLOCK: $name (got: $output)"
+    ((FAILED++))
+  fi
+}
+
+test_allowed() {
+  local name="$1"
+  local command="$2"
+  local input="{\"tool_input\":{\"command\":\"$command\"},\"cwd\":\"/tmp/test\"}"
+  local output
+  output=$(echo "$input" | bash "$HOOK" 2>/dev/null)
+  if [ -z "$output" ] || ! echo "$output" | grep -q '"deny"'; then
+    echo -e "  $PASS ALLOWED: $name"
+    ((PASSED++))
+  else
+    echo -e "  $FAIL SHOULD ALLOW: $name (got: $output)"
+    ((FAILED++))
+  fi
+}
+
+echo ""
+echo "🛡️ Destructive Command Guard — Test Suite"
+echo ""
+
+# ─── Blocked Commands ────────────────────────────────────────
+echo "🔴 Should BLOCK:"
+test_blocked "rm -rf /"           "rm -rf /"
+test_blocked "rm -rf /home"       "rm -rf /home/user/important"
+test_blocked "rm -fr ."           "rm -fr ."
+test_blocked "sudo rm -rf"        "sudo rm -rf /var/log"
+test_blocked "DROP TABLE"         "psql -c 'DROP TABLE users'"
+test_blocked "DROP DATABASE"      "mysql -e 'DROP DATABASE prod'"
+test_blocked "TRUNCATE TABLE"     "psql -c 'TRUNCATE TABLE orders'"
+test_blocked "DELETE without WHERE" "psql -c 'DELETE FROM users'"
+test_blocked "git push --force"   "git push --force origin main"
+test_blocked "git push -f"        "git push -f origin main"
+test_blocked "mkfs"               "mkfs.ext4 /dev/sda1"
+test_blocked "dd of=/dev"         "dd if=/dev/zero of=/dev/sda bs=1M"
+test_blocked "chmod 777"          "chmod 777 /etc/passwd"
+test_blocked "fork bomb"          ':(){ :|:& };:'
+
+echo ""
+
+# ─── Allowed Commands ────────────────────────────────────────
+echo "🟢 Should ALLOW:"
+test_allowed "rm single file"     "rm file.txt"
+test_allowed "rm -r (no -f)"     "rm -r temp_dir"
+test_allowed "git push"          "git push origin main"
+test_allowed "git push --force-with-lease" "git push --force-with-lease origin main"
+test_allowed "npm install"       "npm install express"
+test_allowed "pip install"       "pip install requests"
+test_allowed "ls -la"            "ls -la /home"
+test_allowed "cat file"          "cat README.md"
+test_allowed "DELETE with WHERE" "psql -c 'DELETE FROM users WHERE id = 5'"
+test_allowed "SELECT"            "psql -c 'SELECT * FROM users'"
+test_allowed "echo"              "echo hello world"
+test_allowed "mkdir"             "mkdir -p /tmp/test"
+test_allowed "chmod 644"         "chmod 644 file.txt"
+test_allowed "git commit"        "git commit -m 'fix: stuff'"
+
+echo ""
+
+# ─── Log Output Test ─────────────────────────────────────────
+echo "📝 Log output:"
+LOG="$HOME/.claude/hooks/blocked.log"
+if [ -f "$LOG" ]; then
+  LINES=$(wc -l < "$LOG")
+  echo -e "  $PASS blocked.log has $LINES entries"
+  ((PASSED++))
+  echo "  Sample entry: $(head -1 "$LOG")"
+else
+  echo -e "  $FAIL blocked.log not created"
+  ((FAILED++))
+fi
+
+echo ""
+
+# ─── Results ──────────────────────────────────────────────────
+echo "────────────────────────────────────────"
+echo "Results: $PASSED passed, $FAILED failed"
+
+# Cleanup
+rm -rf "$HOME"
+
+exit $FAILED


### PR DESCRIPTION
## Summary

Bash `pre-tool-use` hook for Claude Code that intercepts and blocks destructive commands before execution. Follows the official Claude Code hooks API format.

## Acceptance Criteria

- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` (timestamp, command, project path)
- [x] Displays clear deny message to Claude explaining why the command was blocked
- [x] Does not interfere with normal bash commands
- [x] README with installation in 2 commands

## Blocked Patterns (12)

| Pattern | Example |
|---------|---------|
| `rm -rf` / `rm -fr` | `rm -rf /home/user` |
| `DROP TABLE/DATABASE` | `psql -c 'DROP TABLE users'` |
| `TRUNCATE TABLE` | `mysql -e 'TRUNCATE TABLE orders'` |
| `DELETE FROM` (no WHERE) | `psql -c 'DELETE FROM users'` |
| `git push --force` / `-f` | `git push -f origin main` |
| `mkfs` | `mkfs.ext4 /dev/sda1` |
| `dd of=/dev/*` | `dd if=/dev/zero of=/dev/sda` |
| `chmod 777` | `chmod 777 /etc/passwd` |
| Fork bomb | `:(){ :\|:& };:` |
| Device overwrite | `> /dev/sda` |

## Smart Allowlist

Safe commands pass through untouched:
- `rm file.txt` (single file, no `-rf`)
- `git push origin main` (normal push)
- `git push --force-with-lease` (safe force push)
- `DELETE FROM users WHERE id = 5` (has WHERE)
- All non-destructive: `ls`, `cat`, `npm`, `pip`, etc.

## Testing — 29/29 pass

```
🛡️ Destructive Command Guard — Test Suite

🔴 Should BLOCK:
  ✓ BLOCKED: rm -rf /
  ✓ BLOCKED: rm -rf /home
  ✓ BLOCKED: rm -fr .
  ✓ BLOCKED: sudo rm -rf
  ✓ BLOCKED: DROP TABLE
  ✓ BLOCKED: DROP DATABASE
  ✓ BLOCKED: TRUNCATE TABLE
  ✓ BLOCKED: DELETE without WHERE
  ✓ BLOCKED: git push --force
  ✓ BLOCKED: git push -f
  ✓ BLOCKED: mkfs
  ✓ BLOCKED: dd of=/dev
  ✓ BLOCKED: chmod 777
  ✓ BLOCKED: fork bomb

🟢 Should ALLOW:
  ✓ ALLOWED: rm single file
  ✓ ALLOWED: rm -r (no -f)
  ✓ ALLOWED: git push
  ✓ ALLOWED: git push --force-with-lease
  ✓ ALLOWED: npm install
  ✓ ALLOWED: pip install
  ✓ ALLOWED: ls -la
  ✓ ALLOWED: cat file
  ✓ ALLOWED: DELETE with WHERE
  ✓ ALLOWED: SELECT
  ✓ ALLOWED: echo
  ✓ ALLOWED: mkdir
  ✓ ALLOWED: chmod 644
  ✓ ALLOWED: git commit

📝 Log output:
  ✓ blocked.log has 14 entries

Results: 29 passed, 0 failed
```

## Install (2 commands)

```bash
cp hooks/guard.sh ~/.claude/hooks/guard.sh && chmod +x ~/.claude/hooks/guard.sh
# Then add PreToolUse config to ~/.claude/settings.json (see README)
```

Closes #3