### PR TITLE
Submission: Destructive command guard hook with logging

### DIFF
--- a/submissions/destructive-command-guard/README.md
+++ b/submissions/destructive-command-guard/README.md
@@ -1,0 +1,101 @@
+# Destructive Command Guard
+
+A Claude Code **pre-tool-use hook** that blocks dangerous bash commands before they execute. Protects against accidental data loss from `rm -rf /`, `DROP TABLE`, force-pushes to main, and more.
+
+## Install (2 commands)
+
+```bash
+# 1. Copy the hook script
+mkdir -p ~/.claude/hooks && curl -fsSL https://raw.githubusercontent.com/mattfo0/claude-builders-bounty/destructive-command-guard/submissions/destructive-command-guard/guard.sh -o ~/.claude/hooks/guard.sh && chmod +x ~/.claude/hooks/guard.sh
+
+# 2. Add the hook to your Claude Code settings (~/.claude/settings.json)
+cat <<'SETTINGS'
+Add this to your ~/.claude/settings.json (create the file if it doesn't exist):
+
+{
+  "hooks": {
+    "pre-tool-use": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+SETTINGS
+```
+
+Or manually: copy `guard.sh` to `~/.claude/hooks/guard.sh` and merge `settings-snippet.json` into `~/.claude/settings.json`.
+
+## What Gets Blocked
+
+| Pattern | Blocked | Allowed |
+|---------|---------|--------|
+| `rm -rf` | `rm -rf /`, `rm -rf ~`, `rm -rf .` | `rm -rf node_modules/`, `rm -rf ./dist` |
+| `DROP TABLE` | All `DROP TABLE` statements | -- |
+| `TRUNCATE` | All `TRUNCATE` statements | -- |
+| `DELETE FROM` | Without a `WHERE` clause | `DELETE FROM users WHERE id = 1` |
+| `git push --force` | To `main`/`master` or bare (no branch) | `git push --force origin feature-branch` |
+
+All pattern matching is **case-insensitive** and handles extra whitespace.
+
+Normal commands (`ls`, `git status`, `npm install`, `cat`, etc.) pass through without interference.
+
+## How It Works
+
+1. Claude Code invokes the hook before every `Bash` tool call, passing JSON on stdin
+2. The hook extracts the command string and checks it against dangerous patterns
+3. If a pattern matches: exits with code **2** (block), prints a message for Claude, and logs to `~/.claude/hooks/blocked.log`
+4. If no pattern matches: exits with code **0** (allow) -- zero overhead for safe commands
+
+### Log Format
+
+Every blocked command is appended to `~/.claude/hooks/blocked.log`:
+
+```
+2026-03-27T15:30:00Z | BLOCKED | rm -rf targeting root... | project=/home/user/myapp | command=rm -rf /
+```
+
+## Customize
+
+**Add your own patterns** by adding a new check block in `guard.sh`. The pattern is simple:
+
+```bash
+if printf '%s' "$NORMALIZED" | grep -iqE '\bYOUR_PATTERN\b'; then
+    block "Reason this is dangerous"
+fi
+```
+
+**Change the log location** by setting `CLAUDE_HOOKS_DIR`:
+
+```bash
+export CLAUDE_HOOKS_DIR=/path/to/logs
+```
+
+## Testing
+
+Run the included test suite:
+
+```bash
+bash test.sh
+```
+
+This validates all blocked and allowed patterns with 35 test cases.
+
+## Files
+
+| File | Purpose |
+|------|--------|
+| `guard.sh` | The hook script (pre-tool-use) |
+| `settings-snippet.json` | Claude Code settings to wire up the hook |
+| `test.sh` | Test suite (35 cases) |
+| `README.md` | This file |
+
+## License
+
+MIT

--- a/submissions/destructive-command-guard/guard.sh
+++ b/submissions/destructive-command-guard/guard.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# guard.sh — Claude Code pre-tool-use hook
+# Blocks destructive bash commands before execution.
+#
+# Exit codes (Claude Code hook protocol):
+#   0 = allow the command
+#   2 = block the command (hook rejects it)
+#
+# Reads JSON from stdin: { "tool_name": "Bash", "tool_input": { "command": "..." } }
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+LOG_FILE="${CLAUDE_HOOKS_DIR:-$HOME/.claude/hooks}/blocked.log"
+PROJECT_DIR="${PWD}"
+
+# ---------------------------------------------------------------------------
+# Read tool invocation from stdin
+# ---------------------------------------------------------------------------
+INPUT="$(cat)"
+
+# Extract tool name — only intercept Bash tool calls
+TOOL_NAME="$(printf '%s' "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    exit 0
+fi
+
+# Extract the command string from tool_input.command
+# Use python3 if available for robust JSON parsing, fall back to grep/sed
+if command -v python3 &>/dev/null; then
+    COMMAND="$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)" || COMMAND=""
+fi
+
+# Fallback: regex extraction if python3 failed or is unavailable
+if [[ -z "${COMMAND:-}" ]]; then
+    COMMAND="$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+fi
+
+# If we still have no command, allow (nothing to check)
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Normalize: collapse whitespace for pattern matching
+# ---------------------------------------------------------------------------
+NORMALIZED="$(printf '%s' "$COMMAND" | tr -s '[:space:]' ' ')"
+
+# ---------------------------------------------------------------------------
+# Helper: block a command, log it, print reason, exit 2
+# ---------------------------------------------------------------------------
+block() {
+    local reason="$1"
+    local timestamp
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$LOG_FILE")"
+
+    # Append to log file
+    printf '%s | BLOCKED | %s | project=%s | command=%s\n' \
+        "$timestamp" "$reason" "$PROJECT_DIR" "$COMMAND" >> "$LOG_FILE"
+
+    # Print human-readable message for Claude
+    cat <<EOF
+BLOCKED: $reason
+
+The following command was prevented from executing:
+  $COMMAND
+
+This hook blocks destructive commands to protect your system and data.
+The attempt has been logged to $LOG_FILE.
+If this is intentional, temporarily disable the hook in your Claude Code settings.
+EOF
+
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Pattern checks (case-insensitive via shell options)
+# ---------------------------------------------------------------------------
+
+# --- rm -rf dangerous paths ---
+# Block: rm -rf /, rm -rf ~, rm -rf .  (with optional flags mixed in)
+# Allow: rm -rf node_modules/, rm -rf ./dist, rm -rf /tmp/build, etc.
+if printf '%s' "$NORMALIZED" | grep -iqE '\brm\b[[:space:]]+-[a-z]*r[a-z]*f[^[:alnum:]]|rm\b[[:space:]]+-[a-z]*f[a-z]*r[^[:alnum:]]'; then
+    # Extract the target path(s) after rm and its flags
+    # Check for dangerous root/home/cwd targets
+    if printf '%s' "$NORMALIZED" | grep -iqE '\brm\b[[:space:]]+-[a-z]*rf[[:space:]]+(/[[:space:]]|/\*|~[[:space:]]|~\/[[:space:]]|\.[[:space:]]|\.\*|/\"|/'"'"')'; then
+        block "rm -rf targeting root (/), home (~), or current directory (.) is extremely dangerous"
+    fi
+    if printf '%s' "$NORMALIZED" | grep -iqE '\brm\b[[:space:]]+-[a-z]*fr[[:space:]]+(/[[:space:]]|/\*|~[[:space:]]|~\/[[:space:]]|\.[[:space:]]|\.\*|/\"|/'"'"')'; then
+        block "rm -rf targeting root (/), home (~), or current directory (.) is extremely dangerous"
+    fi
+    # Also catch: rm -rf / at end of line (no trailing space)
+    if printf '%s' "$NORMALIZED" | grep -iqE '\brm\b[[:space:]]+-[a-z]*r[a-z]*f[[:space:]]+(/|~|\.)$'; then
+        block "rm -rf targeting root (/), home (~), or current directory (.) is extremely dangerous"
+    fi
+fi
+
+# --- DROP TABLE ---
+if printf '%s' "$NORMALIZED" | grep -iqE '\bDROP[[:space:]]+TABLE\b'; then
+    block "DROP TABLE detected — this would permanently destroy database tables"
+fi
+
+# --- TRUNCATE ---
+if printf '%s' "$NORMALIZED" | grep -iqE '\bTRUNCATE\b'; then
+    block "TRUNCATE detected — this would delete all rows from a table"
+fi
+
+# --- DELETE FROM without WHERE ---
+if printf '%s' "$NORMALIZED" | grep -iqE '\bDELETE[[:space:]]+FROM\b'; then
+    if ! printf '%s' "$NORMALIZED" | grep -iqE '\bDELETE[[:space:]]+FROM\b.*\bWHERE\b'; then
+        block "DELETE FROM without a WHERE clause — this would delete all rows from a table"
+    fi
+fi
+
+# --- git push --force to main/master ---
+# Catches: git push --force, git push -f, git push --force-with-lease
+# Only blocks when targeting main or master (or no branch specified, which defaults to current)
+if printf '%s' "$NORMALIZED" | grep -iqE '\bgit[[:space:]]+push\b.*(\s--force\b|\s--force-with-lease\b|\s-f\b)'; then
+    # Check if explicitly targeting a non-main/master branch
+    # If targeting main/master or no explicit branch, block
+    if printf '%s' "$NORMALIZED" | grep -iqE '\bgit[[:space:]]+push\b.*\b(main|master)\b'; then
+        block "git push --force to main/master — force-pushing to protected branches can destroy shared history"
+    fi
+    # If no remote branch specified at all (bare force push), also block
+    if printf '%s' "$NORMALIZED" | grep -iqE '\bgit[[:space:]]+push[[:space:]]+--force[[:space:]]*$|\bgit[[:space:]]+push[[:space:]]+-f[[:space:]]*$'; then
+        block "git push --force with no explicit branch — could force-push to main/master"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# All checks passed — allow the command
+# ---------------------------------------------------------------------------
+exit 0

--- a/submissions/destructive-command-guard/settings-snippet.json
+++ b/submissions/destructive-command-guard/settings-snippet.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "pre-tool-use": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/submissions/destructive-command-guard/test.sh
+++ b/submissions/destructive-command-guard/test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# test.sh — Validates guard.sh against dangerous and safe commands
+#
+# Usage: bash test.sh
+#
+# Runs guard.sh with simulated tool inputs and checks exit codes.
+# Exit code 0 = all tests passed, 1 = some tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/guard.sh"
+PASS=0
+FAIL=0
+
+# Use a temp log file so tests don't pollute the real log
+export CLAUDE_HOOKS_DIR="$(mktemp -d)"
+trap 'rm -rf "$CLAUDE_HOOKS_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: run guard.sh with a simulated Bash tool input
+# ---------------------------------------------------------------------------
+run_test() {
+    local description="$1"
+    local command="$2"
+    local expected_exit="$3"  # 0 = should allow, 2 = should block
+
+    local input
+    input=$(printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$command")
+
+    local actual_exit
+    printf '%s' "$input" | bash "$GUARD" >/dev/null 2>&1
+    actual_exit=$?
+
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        printf '  PASS: %s\n' "$description"
+        ((PASS++))
+    else
+        printf '  FAIL: %s (expected exit %d, got %d)\n' "$description" "$expected_exit" "$actual_exit"
+        ((FAIL++))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run guard.sh with a non-Bash tool (should always allow)
+# ---------------------------------------------------------------------------
+run_non_bash_test() {
+    local description="$1"
+    local tool_name="$2"
+
+    local input
+    input=$(printf '{"tool_name":"%s","tool_input":{"command":"rm -rf /"}}' "$tool_name")
+
+    local actual_exit
+    printf '%s' "$input" | bash "$GUARD" >/dev/null 2>&1
+    actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        printf '  PASS: %s\n' "$description"
+        ((PASS++))
+    else
+        printf '  FAIL: %s (expected exit 0, got %d)\n' "$description" "$actual_exit"
+        ((FAIL++))
+    fi
+}
+
+echo "=== Destructive Command Guard — Test Suite ==="
+echo ""
+
+# --- Non-Bash tools should pass through ---
+echo "[Non-Bash tools]"
+run_non_bash_test "Read tool is not intercepted" "Read"
+run_non_bash_test "Edit tool is not intercepted" "Edit"
+run_non_bash_test "Grep tool is not intercepted" "Grep"
+echo ""
+
+# --- rm -rf dangerous targets ---
+echo "[rm -rf dangerous targets — should BLOCK]"
+run_test "rm -rf /" "rm -rf /" 2
+run_test "rm -rf ~" "rm -rf ~" 2
+run_test "rm -rf ." "rm -rf ." 2
+run_test "rm -rf / with extra spaces" "rm  -rf  /" 2
+run_test "rm -rf /*" "rm -rf /*" 2
+echo ""
+
+echo "[rm -rf safe targets — should ALLOW]"
+run_test "rm -rf node_modules/" "rm -rf node_modules/" 0
+run_test "rm -rf ./dist" "rm -rf ./dist" 0
+run_test "rm -rf /tmp/build" "rm -rf /tmp/build" 0
+run_test "rm -rf specific-dir" "rm -rf some-directory" 0
+echo ""
+
+# --- DROP TABLE ---
+echo "[DROP TABLE — should BLOCK]"
+run_test "DROP TABLE users" "sqlite3 test.db 'DROP TABLE users'" 2
+run_test "drop table (lowercase)" "psql -c 'drop table users'" 2
+run_test "DROP TABLE with IF EXISTS" "mysql -e 'DROP TABLE IF EXISTS temp'" 2
+echo ""
+
+# --- TRUNCATE ---
+echo "[TRUNCATE — should BLOCK]"
+run_test "TRUNCATE TABLE users" "psql -c 'TRUNCATE TABLE users'" 2
+run_test "truncate (lowercase)" "mysql -e 'truncate logs'" 2
+echo ""
+
+# --- DELETE FROM ---
+echo "[DELETE FROM — should BLOCK without WHERE]"
+run_test "DELETE FROM users (no WHERE)" "psql -c 'DELETE FROM users'" 2
+run_test "delete from (lowercase, no WHERE)" "sqlite3 db 'delete from logs'" 2
+echo ""
+
+echo "[DELETE FROM with WHERE — should ALLOW]"
+run_test "DELETE FROM users WHERE id=1" "psql -c 'DELETE FROM users WHERE id = 1'" 0
+run_test "delete from with where (lowercase)" "sqlite3 db 'delete from logs where age > 30'" 0
+echo ""
+
+# --- git push --force ---
+echo "[git push --force — should BLOCK]"
+run_test "git push --force origin main" "git push --force origin main" 2
+run_test "git push -f origin master" "git push -f origin master" 2
+run_test "git push --force (bare)" "git push --force" 2
+run_test "git push -f (bare)" "git push -f" 2
+echo ""
+
+echo "[git push safe variants — should ALLOW]"
+run_test "git push origin main (no force)" "git push origin main" 0
+run_test "git push (no force)" "git push" 0
+run_test "git push --force origin feature-branch" "git push --force origin feature-branch" 0
+echo ""
+
+# --- Normal commands should pass ---
+echo "[Normal commands — should ALLOW]"
+run_test "ls -la" "ls -la" 0
+run_test "git status" "git status" 0
+run_test "npm install" "npm install" 0
+run_test "cat file.txt" "cat file.txt" 0
+run_test "mkdir -p /tmp/test" "mkdir -p /tmp/test" 0
+run_test "echo hello world" "echo hello world" 0
+echo ""
+
+# --- Check that log file was created ---
+echo "[Logging]"
+if [[ -f "$CLAUDE_HOOKS_DIR/blocked.log" ]]; then
+    LINES="$(wc -l < "$CLAUDE_HOOKS_DIR/blocked.log" | tr -d ' ')"
+    printf '  PASS: blocked.log exists with %s entries\n' "$LINES"
+    ((PASS++))
+else
+    printf '  FAIL: blocked.log was not created\n'
+    ((FAIL++))
+fi
+echo ""
+
+# --- Summary ---
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Pre-tool-use hook (bash) that blocks destructive commands before Claude Code executes them. Submission for bounty [#3](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3).

### What it blocks

| Pattern | Behavior |
|---------|----------|
| `rm -rf /`, `rm -rf ~`, `rm -rf .` | Blocked (but `rm -rf node_modules/` is allowed) |
| `DROP TABLE` | All instances blocked |
| `TRUNCATE` | All instances blocked |
| `DELETE FROM` without `WHERE` | Blocked (with `WHERE` is allowed) |
| `git push --force` to main/master | Blocked (force-push to feature branches is allowed) |

### Key features

- **Case-insensitive** matching with whitespace normalization
- **Robust JSON parsing** via python3 with grep/sed fallback
- **Structured logging** to `~/.claude/hooks/blocked.log` with ISO timestamp, reason, project path, and command
- **Clear block messages** explaining what was blocked and why
- **Zero interference** with normal commands — only intercepts `Bash` tool calls
- **35-case test suite** covering all blocked patterns, allowed variants, non-Bash tools, and logging

### Install (2 commands)

```bash
mkdir -p ~/.claude/hooks && curl -fsSL https://raw.githubusercontent.com/mattfo0/claude-builders-bounty/destructive-command-guard/submissions/destructive-command-guard/guard.sh -o ~/.claude/hooks/guard.sh && chmod +x ~/.claude/hooks/guard.sh
```

Then add the hook config from `settings-snippet.json` to `~/.claude/settings.json`.

### Files

- `submissions/destructive-command-guard/guard.sh` — The hook script
- `submissions/destructive-command-guard/settings-snippet.json` — Claude Code settings snippet
- `submissions/destructive-command-guard/test.sh` — Test suite (35 cases, all passing)
- `submissions/destructive-command-guard/README.md` — Full documentation

Closes #3