### PR TITLE
Submission: CHANGELOG generator skill + standalone bash script

### DIFF
--- a/submissions/changelog-skill/README.md
+++ b/submissions/changelog-skill/README.md
@@ -1,0 +1,97 @@
+# CHANGELOG Generator
+
+A Claude Code skill and standalone bash script that generates a well-formatted `CHANGELOG.md` from your git history, following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) specification.
+
+## Features
+
+- Parses **conventional commits** (`feat:`, `fix:`, `refactor:`, etc.) and maps them to changelog categories
+- Falls back to **keyword analysis** for non-conventional commit messages
+- Detects **breaking changes** from `BREAKING CHANGE:` in commit bodies or `!` in prefixes
+- Preserves existing changelog entries when regenerating
+- Filters out merge commits automatically
+- Handles edge cases: no tags, no commits, empty repos
+
+## Setup (Claude Code Skill)
+
+1. Copy `SKILL.md` into your project's `.claude/skills/` directory (create it if needed):
+   ```bash
+   mkdir -p .claude/skills && cp SKILL.md .claude/skills/generate-changelog.md
+   ```
+2. Start Claude Code in your repository:
+   ```bash
+   claude
+   ```
+3. Run the skill:
+   ```
+   /generate-changelog
+   ```
+
+## Setup (Bash Script)
+
+1. Copy `changelog.sh` to your repository root
+2. Make it executable: `chmod +x changelog.sh`
+3. Run it: `./changelog.sh`
+
+### Bash script options
+
+```
+./changelog.sh                      # Generate CHANGELOG.md
+./changelog.sh --version 2.1.0      # Use a specific version instead of "Unreleased"
+./changelog.sh --stdout              # Print to stdout (don't write file)
+./changelog.sh --output HISTORY.md   # Write to a different filename
+```
+
+## How it works
+
+### Commit categorization
+
+Commits are sorted into four categories from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
+
+| Category | Conventional prefixes | Keyword triggers |
+|----------|----------------------|-----------------|
+| **Added** | `feat:` | add, new, create, introduce, implement, support |
+| **Fixed** | `fix:` | fix, bug, patch, resolve, close, correct, repair |
+| **Changed** | `refactor:`, `perf:`, `style:`, `build:`, `ci:`, `chore:`, `docs:`, `test:` | update, change, improve, bump, migrate, rename, move |
+| **Removed** | `revert:` | remove, delete, drop, deprecate, strip, clean up |
+
+### Version range
+
+The tool automatically detects the latest git tag and only includes commits since that tag. If no tags exist, the full commit history is used.
+
+### Output format
+
+The generated `CHANGELOG.md` follows keepachangelog.com format exactly:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - 2026-03-27
+
+### Added
+- Implement user authentication
+- Support dark mode
+
+### Fixed
+- Correct off-by-one error in pagination
+
+### Changed
+- Update dependencies to latest versions
+```
+
+## Sample output
+
+See [SAMPLE_OUTPUT.md](SAMPLE_OUTPUT.md) for a realistic example generated from a real repository.
+
+## Requirements
+
+- **Bash script:** Git, Bash 3.2+ (macOS default works), standard Unix tools (`sed`, `sort`, `date`)
+- **Claude Code skill:** Claude Code CLI with skill support
+
+## License
+
+MIT

--- a/submissions/changelog-skill/SAMPLE_OUTPUT.md
+++ b/submissions/changelog-skill/SAMPLE_OUTPUT.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - 2026-03-27
+
+### Added
+- Add all products, CI/CD pipeline, and landing page
+- Add Hooks Pack product, SEO blog post, updated distribution links
+- Add individual product landing pages + fix payment link swap bug
+- Add smoke tests, email inbox worker, and security fixes
+- Download auth + price increase + security hardening
+- Stripe test mode for preview environment
+
+### Fixed
+- Add ENVIRONMENT vars to wrangler config for both envs
+- Specify explicit deploy command for wrangler v4 multi-env
+- Use npm as packageManager (not npx)
+- Use wrangler v4 in CI and rename config to .json
+
+### Changed
+- First commit
+- Trigger CI/CD pipeline test
+- Verify CI/CD preview deploy
+
+---
+
+*Generated from [zerodaykit/earn](https://github.com/mattfo0/earn) (13 commits, full history, no tags found).*
+
+*Tool: `changelog.sh --stdout` and `/generate-changelog` Claude Code skill.*

--- a/submissions/changelog-skill/SKILL.md
+++ b/submissions/changelog-skill/SKILL.md
@@ -1,0 +1,115 @@
+# generate-changelog
+
+Generate a professional CHANGELOG.md from git history, following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+## When to use
+
+Use this skill when the user runs `/generate-changelog` or asks to generate, create, or update a changelog from git commits.
+
+## Instructions
+
+You are a changelog generator. Your job is to read the git history of the current repository and produce a well-formatted CHANGELOG.md.
+
+### Step 1: Determine the version range
+
+Run the following command to find the most recent git tag:
+
+```bash
+git describe --tags --abbrev=0 2>/dev/null
+```
+
+- If a tag exists, use it as the starting point. Fetch commits since that tag with:
+  ```bash
+  git log <tag>..HEAD --pretty=format:"%H|||%s|||%b|||%an|||%aI" --no-merges
+  ```
+- If no tag exists, fetch the entire history:
+  ```bash
+  git log --pretty=format:"%H|||%s|||%b|||%an|||%aI" --no-merges
+  ```
+
+Also get the current date for the release header:
+```bash
+date +%Y-%m-%d
+```
+
+### Step 2: Categorize each commit
+
+For each commit message, assign it to exactly one category using these rules, checked in order:
+
+**Conventional Commits (prefix before colon):**
+
+| Prefix | Category |
+|--------|----------|
+| `feat` | Added |
+| `fix` | Fixed |
+| `refactor`, `perf`, `style`, `build`, `ci`, `chore`, `docs`, `test` | Changed |
+| `revert` | Removed |
+
+**Keyword fallback (case-insensitive, for non-conventional commits):**
+
+| Keywords in subject line | Category |
+|--------------------------|----------|
+| `add`, `new`, `create`, `introduce`, `implement`, `support` | Added |
+| `fix`, `bug`, `patch`, `resolve`, `close`, `correct`, `repair` | Fixed |
+| `remove`, `delete`, `drop`, `deprecate`, `strip`, `clean up` | Removed |
+| Everything else (`update`, `change`, `refactor`, `improve`, `bump`, `migrate`, `rename`, `move`, `adjust`, etc.) | Changed |
+
+**Additional rules:**
+- Skip commits whose subject starts with `Merge` (merge commits that slip through).
+- Strip conventional commit prefixes and scope from the displayed text: `feat(auth): add login` becomes `Add login`.
+- Capitalize the first letter of each entry.
+- Remove trailing periods from entries.
+- If a commit body contains `BREAKING CHANGE:` or the prefix has `!` (e.g., `feat!:`), prepend `**BREAKING:** ` to the entry.
+
+### Step 3: Generate the CHANGELOG.md
+
+Use this exact template structure:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+- Entry one
+- Entry two
+
+### Fixed
+- Entry one
+
+### Changed
+- Entry one
+
+### Removed
+- Entry one
+```
+
+**Formatting rules:**
+- Only include category sections that have entries (do not print empty sections).
+- Order categories: Added, Fixed, Changed, Removed.
+- Each entry is a single line starting with `- `.
+- Sort entries alphabetically within each category.
+- If a previous CHANGELOG.md exists in the repo, prepend the new release section after the header and before existing release sections. Preserve all existing content.
+- Use `[Unreleased]` as the version header. If the user specifies a version number, use that instead.
+
+### Step 4: Write the file
+
+Write the generated content to `CHANGELOG.md` in the repository root.
+
+Report a summary to the user:
+- How many commits were processed
+- How many entries in each category
+- The version range covered (tag to HEAD, or full history)
+- Any commits that were skipped (merges) and why
+
+### Edge cases
+
+- **No commits found:** Write a CHANGELOG.md with just the header and an empty `[Unreleased]` section. Tell the user no commits were found.
+- **No tags found:** Process all commits and note in the summary that no tags were found, so the full history was used.
+- **All commits are merge commits:** Same as "no commits found" after filtering.
+- **Existing CHANGELOG.md:** Read it first, preserve previous release sections, only add/update the `[Unreleased]` section at the top.

--- a/submissions/changelog-skill/changelog.sh
+++ b/submissions/changelog-skill/changelog.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# changelog.sh — Generate a CHANGELOG.md from git history
+# Follows Keep a Changelog (https://keepachangelog.com/en/1.1.0/)
+#
+# Usage:
+#   ./changelog.sh                  # Auto-detect tag range, write CHANGELOG.md
+#   ./changelog.sh --version 1.2.0  # Use a specific version header
+#   ./changelog.sh --stdout          # Print to stdout instead of writing file
+#   ./changelog.sh --help            # Show usage
+#
+# Compatible with Bash 3.2+ (macOS default) and GNU Bash 4+/5+.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Portable lowercase function (works on Bash 3.2)
+# ---------------------------------------------------------------------------
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+to_upper_first() {
+  local first rest
+  first="$(echo "${1:0:1}" | tr '[:lower:]' '[:upper:]')"
+  rest="${1:1}"
+  echo "${first}${rest}"
+}
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+VERSION_LABEL="Unreleased"
+OUTPUT_FILE="CHANGELOG.md"
+STDOUT_ONLY=false
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version|-v)
+      VERSION_LABEL="$2"; shift 2 ;;
+    --output|-o)
+      OUTPUT_FILE="$2"; shift 2 ;;
+    --stdout)
+      STDOUT_ONLY=true; shift ;;
+    --help|-h)
+      echo "Usage: changelog.sh [OPTIONS]"
+      echo ""
+      echo "Options:"
+      echo "  --version, -v VERSION   Set the version header (default: Unreleased)"
+      echo "  --output, -o FILE       Output file path (default: CHANGELOG.md)"
+      echo "  --stdout                Print to stdout instead of writing a file"
+      echo "  --help, -h              Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Verify we are inside a git repository
+# ---------------------------------------------------------------------------
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo "Error: not inside a git repository." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# ---------------------------------------------------------------------------
+# Determine commit range
+# ---------------------------------------------------------------------------
+LATEST_TAG=""
+RANGE=""
+RANGE_DESC="full history (no tags found)"
+if LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+  RANGE="${LATEST_TAG}..HEAD"
+  RANGE_DESC="${LATEST_TAG} to HEAD"
+fi
+
+TODAY="$(date +%Y-%m-%d)"
+
+# ---------------------------------------------------------------------------
+# Collect commits
+# Use NUL byte as record separator to handle multi-line bodies safely.
+# We extract the subject (%s) and body (%b) separated by |||, then NUL.
+# ---------------------------------------------------------------------------
+DELIM='|||'
+
+tmp_added="$(mktemp)"
+tmp_fixed="$(mktemp)"
+tmp_changed="$(mktemp)"
+tmp_removed="$(mktemp)"
+tmp_raw="$(mktemp)"
+trap 'rm -f "$tmp_added" "$tmp_fixed" "$tmp_changed" "$tmp_removed" "$tmp_raw"' EXIT
+
+# Fetch raw log with NUL-separated records
+if [[ -n "$RANGE" ]]; then
+  git log "$RANGE" --pretty=format:"%s${DELIM}%b%x00" --no-merges > "$tmp_raw" 2>/dev/null || true
+else
+  git log --pretty=format:"%s${DELIM}%b%x00" --no-merges > "$tmp_raw" 2>/dev/null || true
+fi
+
+skip_count=0
+total_count=0
+
+# Process NUL-separated records
+while IFS= read -r -d '' record; do
+  [[ -z "$record" ]] && continue
+
+  # Subject is everything before the first |||
+  subject="${record%%${DELIM}*}"
+  body="${record#*${DELIM}}"
+
+  # Trim whitespace and newlines from subject
+  subject="$(echo "$subject" | tr -d '\n\r' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+  [[ -z "$subject" ]] && continue
+
+  # Skip merge commits
+  if echo "$subject" | grep -qE '^Merge[d]? '; then
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  total_count=$((total_count + 1))
+
+  # Detect breaking changes
+  breaking=""
+  if echo "$body" | grep -q "BREAKING CHANGE:" 2>/dev/null; then
+    breaking="**BREAKING:** "
+  fi
+
+  # --- Categorize ---
+  category=""
+  display="$subject"
+
+  # Try conventional commit pattern: type(scope)!: description
+  if echo "$subject" | grep -qE '^[a-zA-Z]+(\(.*\))?(!)?: '; then
+    cc_type="$(echo "$subject" | sed -E 's/^([a-zA-Z]+)(\(.*\))?(!)?: .*/\1/')"
+    cc_type="$(to_lower "$cc_type")"
+    display="$(echo "$subject" | sed -E 's/^[a-zA-Z]+(\(.*\))?(!)?: //')"
+
+    # Check for ! in prefix
+    if echo "$subject" | grep -qE '^[a-zA-Z]+(\(.*\))?!: '; then
+      breaking="**BREAKING:** "
+    fi
+
+    case "$cc_type" in
+      feat)     category="Added" ;;
+      fix)      category="Fixed" ;;
+      revert)   category="Removed" ;;
+      refactor|perf|style|build|ci|chore|docs|test)
+                category="Changed" ;;
+    esac
+  fi
+
+  # Keyword fallback for non-conventional or unrecognized types
+  if [[ -z "$category" ]]; then
+    subj_lower="$(to_lower "$subject")"
+    if echo "$subj_lower" | grep -qEi '(^|\W)(add|new|create|introduce|implement|support)(\W|$)'; then
+      category="Added"
+    elif echo "$subj_lower" | grep -qEi '(^|\W)(fix|bug|patch|resolve|close[sd]?|correct|repair)(\W|$)'; then
+      category="Fixed"
+    elif echo "$subj_lower" | grep -qEi '(^|\W)(remove|delete|drop|deprecate|strip|clean ?up)(\W|$)'; then
+      category="Removed"
+    else
+      category="Changed"
+    fi
+  fi
+
+  # Clean up display text
+  display="$(echo "$display" | sed 's/^[[:space:]]*//')"
+  if [[ -n "$display" ]]; then
+    display="$(to_upper_first "$display")"
+  fi
+  # Remove trailing period
+  display="${display%.}"
+
+  entry="${breaking}${display}"
+
+  case "$category" in
+    Added)   echo "$entry" >> "$tmp_added" ;;
+    Fixed)   echo "$entry" >> "$tmp_fixed" ;;
+    Changed) echo "$entry" >> "$tmp_changed" ;;
+    Removed) echo "$entry" >> "$tmp_removed" ;;
+  esac
+
+done < "$tmp_raw"
+
+# ---------------------------------------------------------------------------
+# Sort entries alphabetically and deduplicate within each category
+# ---------------------------------------------------------------------------
+for f in "$tmp_added" "$tmp_fixed" "$tmp_changed" "$tmp_removed"; do
+  if [[ -s "$f" ]]; then
+    sort -fu "$f" -o "$f"
+  fi
+done
+
+count_lines() {
+  if [[ -s "$1" ]]; then
+    wc -l < "$1" | tr -d ' '
+  else
+    echo "0"
+  fi
+}
+
+added_count="$(count_lines "$tmp_added")"
+fixed_count="$(count_lines "$tmp_fixed")"
+changed_count="$(count_lines "$tmp_changed")"
+removed_count="$(count_lines "$tmp_removed")"
+
+# ---------------------------------------------------------------------------
+# Build the new release section
+# ---------------------------------------------------------------------------
+new_section="## [${VERSION_LABEL}] - ${TODAY}"$'\n'
+
+append_section() {
+  local header="$1"
+  local file="$2"
+  if [[ -s "$file" ]]; then
+    new_section+=$'\n'"### ${header}"$'\n'
+    while IFS= read -r entry; do
+      [[ -n "$entry" ]] && new_section+="- ${entry}"$'\n'
+    done < "$file"
+  fi
+}
+
+append_section "Added"   "$tmp_added"
+append_section "Fixed"   "$tmp_fixed"
+append_section "Changed" "$tmp_changed"
+append_section "Removed" "$tmp_removed"
+
+# ---------------------------------------------------------------------------
+# Build full CHANGELOG.md content
+# ---------------------------------------------------------------------------
+HEADER="# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"
+
+EXISTING_FILE="${REPO_ROOT}/${OUTPUT_FILE}"
+
+if [[ -f "$EXISTING_FILE" ]]; then
+  existing_body="$(sed -n '/^## /,$p' "$EXISTING_FILE")"
+  if [[ -n "$existing_body" ]]; then
+    full_content="${HEADER}
+${new_section}
+${existing_body}"
+  else
+    full_content="${HEADER}
+${new_section}"
+  fi
+else
+  full_content="${HEADER}
+${new_section}"
+fi
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+if $STDOUT_ONLY; then
+  echo "$full_content"
+else
+  echo "$full_content" > "$EXISTING_FILE"
+  echo "Wrote ${OUTPUT_FILE}" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "" >&2
+echo "--- Summary ---" >&2
+echo "Range:   ${RANGE_DESC}" >&2
+echo "Commits: ${total_count} processed, ${skip_count} merge commits skipped" >&2
+echo "Added:   ${added_count}" >&2
+echo "Fixed:   ${fixed_count}" >&2
+echo "Changed: ${changed_count}" >&2
+echo "Removed: ${removed_count}" >&2


### PR DESCRIPTION
## Summary

CHANGELOG generator that works as both a Claude Code `/generate-changelog` skill and a standalone `bash changelog.sh` script. Addresses bounty Issue #1 ($50).

### What's included

| File | Purpose |
|------|---------|
| `SKILL.md` | Claude Code skill — invoke with `/generate-changelog` |
| `changelog.sh` | Standalone bash script — no dependencies beyond git and coreutils |
| `README.md` | Setup instructions (3 steps for each approach) |
| `SAMPLE_OUTPUT.md` | Real output generated from a live GitHub repo (13 commits) |

### How it works

1. **Detects version range** — finds the latest git tag and fetches commits since that tag (or full history if no tags exist)
2. **Categorizes commits** into Added / Fixed / Changed / Removed using a two-tier system:
   - **Conventional Commits** first: `feat:` -> Added, `fix:` -> Fixed, `refactor:/perf:/chore:/docs:/test:` -> Changed, `revert:` -> Removed
   - **Keyword fallback** for non-conventional commits: scans subject for words like "add", "fix", "remove", "update", etc.
3. **Generates CHANGELOG.md** following [keepachangelog.com](https://keepachangelog.com/en/1.1.0/) format exactly
4. **Preserves existing entries** — if a CHANGELOG.md already exists, new release section is prepended while keeping prior releases intact

### Edge cases handled

- No git tags (uses full history)
- No commits after filtering (writes header-only changelog)
- Merge commits (filtered out via `--no-merges` + subject-line check)
- Multi-line commit bodies (NUL-byte record separation)
- Breaking changes (`BREAKING CHANGE:` in body or `!` in prefix)
- Bash 3.2 compatibility (macOS default — no Bash 4+ features used)
- Duplicate entries (deduplicated via `sort -fu`)

### Bounty checklist

- [x] Works via `/generate-changelog` command (SKILL.md)
- [x] Works via `bash changelog.sh` (standalone script)
- [x] Fetches commits since the last git tag
- [x] Auto-categorizes into Added / Fixed / Changed / Removed
- [x] Outputs properly formatted CHANGELOG.md
- [x] Tested on a real GitHub repo (see SAMPLE_OUTPUT.md)
- [x] README with setup instructions in 3 steps or fewer
- [x] Accepted stack: Bash + native Claude Code SKILL.md

## Test plan

- [ ] Clone repo, copy `changelog.sh` to any git project, run `./changelog.sh --stdout` and verify output format
- [ ] Copy `SKILL.md` to `.claude/skills/generate-changelog.md`, open Claude Code, run `/generate-changelog`
- [ ] Test on repo with tags: `git tag v1.0.0 HEAD~5 && ./changelog.sh --stdout` — should only show last 5 commits
- [ ] Test on empty repo: `git init /tmp/empty && cd /tmp/empty && bash changelog.sh` — should produce header-only output
- [ ] Test `--version 2.0.0` flag — version header should read `[2.0.0]` instead of `[Unreleased]`