### PR TITLE
feat(bounty-3): pre-tool-use hook blocking destructive bash commands

### DIFF
--- a/bounties/issue-3-hook/README.md
+++ b/bounties/issue-3-hook/README.md
@@ -1,0 +1,109 @@
+# Claude Code Anti-Destructive Hook
+
+A `PreToolUse` hook for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that **intercepts dangerous commands before they execute** — giving you a safety net against irreversible operations.
+
+## What it blocks
+
+| Pattern | Why it's dangerous |
+|---|---|
+| `rm -rf` | Recursive forced deletion — can wipe your entire filesystem |
+| `DROP TABLE` | Permanently destroys a database table and all its data |
+| `git push --force` / `-f` | Rewrites remote history, destroying commits for all collaborators |
+| `TRUNCATE` | Removes all rows from a table instantly, usually non-rollbackable |
+| `DELETE FROM` without `WHERE` | Deletes every row in a table |
+
+Every blocked attempt is logged to `~/.claude/hooks/blocked.log` with a timestamp, the command, and the project path.
+
+## Installation
+
+```bash
+git clone https://github.com/pino12033/claude-builders-bounty.git && cd claude-builders-bounty
+bash bounties/issue-3-hook/install.sh
+```
+
+That's it. The hook is immediately active for all Claude Code sessions.
+
+> **Requirements:** Python 3 (pre-installed on macOS/Linux) and `jq` is not required (pure Python).
+
+## How it works
+
+```
+Claude wants to run → PreToolUse hook fires → hook.py reads JSON from stdin
+                                                      │
+                              ┌───────────────────────┴────────────────────────┐
+                              │  Checks against dangerous patterns (regex)      │
+                              └───────────────────────┬────────────────────────┘
+                                                      │
+                               safe? → exit 0 (allow) │ dangerous? → deny JSON + log
+```
+
+Claude Code passes a JSON object to the hook via stdin:
+```json
+{
+  "tool_name": "Bash",
+  "tool_input": { "command": "rm -rf /important/data" },
+  "project_path": "/my/project"
+}
+```
+
+The hook returns a deny decision that Claude Code enforces:
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "⛔ Command blocked: rm -rf detected..."
+  }
+}
+```
+
+Claude receives the reason and stops — it cannot bypass this.
+
+## Uninstall
+
+```bash
+bash bounties/issue-3-hook/uninstall.sh
+```
+
+## Log format
+
+```
+[2025-01-15T14:32:01] BLOCKED | project=/Users/sam/myproject | reason=rm -rf detected | cmd='rm -rf ./dist'
+[2025-01-15T14:35:22] BLOCKED | project=/Users/sam/api      | reason=DROP TABLE detected | cmd='mysql -e "DROP TABLE users"'
+```
+
+## Files
+
+```
+bounties/issue-3-hook/
+├── hook.py        # The hook (Python 3, no external deps)
+├── install.sh     # Installer — copies hook + registers in settings.json
+├── uninstall.sh   # Removes hook and cleans settings.json
+└── README.md      # This file
+```
+
+## Hook settings entry (for reference)
+
+The installer adds this to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/anti-destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+Submitted for [Opire bounty #3](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3) — $100 HOOK pre-tool-use anti-destructive.

--- a/bounties/issue-3-hook/README.md
+++ b/bounties/issue-3-hook/README.md
@@ -8,9 +8,14 @@ A `PreToolUse` hook for [Claude Code](https://docs.anthropic.com/en/docs/claude-
 |---|---|
 | `rm -rf` | Recursive forced deletion — can wipe your entire filesystem |
 | `DROP TABLE` | Permanently destroys a database table and all its data |
+| `DROP DATABASE` | Permanently destroys an entire database and all its contents |
+| `DROP SCHEMA` | Permanently destroys a database schema and everything it contains |
 | `git push --force` / `-f` | Rewrites remote history, destroying commits for all collaborators |
 | `TRUNCATE` | Removes all rows from a table instantly, usually non-rollbackable |
 | `DELETE FROM` without `WHERE` | Deletes every row in a table |
+| Fork bomb `:(){ :|:& };:` | Recursively spawns processes until the system crashes |
+| `mkfs.*` | Formats a block device — destroys all data on it |
+| `dd ... of=/dev/...` | Writes directly to a block device — can destroy disks |
 
 Every blocked attempt is logged to `~/.claude/hooks/blocked.log` with a timestamp, the command, and the project path.
 

--- a/bounties/issue-3-hook/hook.py
+++ b/bounties/issue-3-hook/hook.py
@@ -5,11 +5,16 @@ Claude Code pre-tool-use hook: Anti-Destructive Command Guard
 Intercepts dangerous bash/SQL commands before Claude executes them.
 
 Blocks:
-  - rm -rf      : recursive forced deletion
-  - DROP TABLE  : irreversible table destruction
-  - git push --force / -f : rewrites remote history
-  - TRUNCATE    : wipes entire tables
+  - rm -rf               : recursive forced deletion
+  - DROP TABLE           : irreversible table destruction
+  - DROP DATABASE        : destroys entire database
+  - DROP SCHEMA          : destroys entire schema
+  - git push --force/-f  : rewrites remote history
+  - TRUNCATE             : wipes entire tables
   - DELETE FROM without WHERE : deletes all rows
+  - fork bomb :(){ ... } : crashes / saturates the system
+  - mkfs.*               : formats a block device
+  - dd ... of=/dev/...   : writes directly to a block device
 
 Logs every blocked attempt to: ~/.claude/hooks/blocked.log
 """
@@ -50,6 +55,21 @@ DANGEROUS_PATTERNS = [
         ),
     ),
     (
+        re.compile(r'\bDROP\s+DATABASE\b', re.IGNORECASE),
+        (
+            "DROP DATABASE detected: this permanently destroys an entire database and all "
+            "its tables, indexes, and data. If intentional, run it manually in a database "
+            "client with a full backup confirmed."
+        ),
+    ),
+    (
+        re.compile(r'\bDROP\s+SCHEMA\b', re.IGNORECASE),
+        (
+            "DROP SCHEMA detected: this permanently destroys a database schema and "
+            "everything it contains. If intentional, run it manually with a backup ready."
+        ),
+    ),
+    (
         re.compile(
             r'\bgit\s+push\b.*?(\s--force\b|\s-f\b|\s--force-with-lease\b)',
             re.IGNORECASE | re.DOTALL,
@@ -65,6 +85,34 @@ DANGEROUS_PATTERNS = [
         (
             "TRUNCATE detected: this removes ALL rows from a table instantly and "
             "cannot be rolled back in most configurations. Run manually with a backup."
+        ),
+    ),
+    # Fork bomb: :(){ :|:& };: and common variants
+    (
+        re.compile(
+            r':\s*\(\s*\)\s*\{.*?:\s*\|.*?:.*?&.*?\}|'   # :(){ :|:& };:
+            r':\(\)\s*\{\s*\|\s*&\s*\}\s*;',
+            re.DOTALL,
+        ),
+        (
+            "Fork bomb detected: this shell construct recursively spawns processes until "
+            "the system runs out of resources and crashes. Never run this command."
+        ),
+    ),
+    # mkfs.* — formats/destroys a filesystem on a block device
+    (
+        re.compile(r'\bmkfs\b', re.IGNORECASE),
+        (
+            "mkfs detected: this formats a block device, permanently destroying all data "
+            "on it. If intentional, run it manually after triple-checking the target device."
+        ),
+    ),
+    # dd writing directly to a block device
+    (
+        re.compile(r'\bdd\b.*\bof\s*=\s*/dev/', re.IGNORECASE | re.DOTALL),
+        (
+            "dd of=/dev/... detected: writing directly to a block device can permanently "
+            "destroy the filesystem or partition table. Run manually with extreme caution."
         ),
     ),
 ]

--- a/bounties/issue-3-hook/hook.py
+++ b/bounties/issue-3-hook/hook.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: Anti-Destructive Command Guard
+=============================================================
+Intercepts dangerous bash/SQL commands before Claude executes them.
+
+Blocks:
+  - rm -rf      : recursive forced deletion
+  - DROP TABLE  : irreversible table destruction
+  - git push --force / -f : rewrites remote history
+  - TRUNCATE    : wipes entire tables
+  - DELETE FROM without WHERE : deletes all rows
+
+Logs every blocked attempt to: ~/.claude/hooks/blocked.log
+"""
+
+import json
+import sys
+import os
+import re
+from datetime import datetime
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+# Each entry: (compiled_regex, human_reason)
+DANGEROUS_PATTERNS = [
+    (
+        re.compile(
+            # rm with flags containing both r and f (in any order, possibly combined)
+            r'\brm\s+('
+            r'-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*'   # -rf, -Rf, -rRfF, etc.
+            r'|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*'   # -fr, -fR, etc.
+            r'|-r\s+-f|-f\s+-r'                   # -r -f or -f -r (separate flags)
+            r'|--recursive\s+--force|--force\s+--recursive'  # long-form flags
+            r')',
+            re.IGNORECASE,
+        ),
+        (
+            "rm -rf detected: recursive forced deletion is irreversible and can destroy "
+            "your entire file system. If you truly need to delete recursively, run this "
+            "command manually in a terminal after double-checking the target path."
+        ),
+    ),
+    (
+        re.compile(r'\bDROP\s+TABLE\b', re.IGNORECASE),
+        (
+            "DROP TABLE detected: this permanently destroys a database table and all its "
+            "data. If intentional, run it manually in a database client with a backup ready."
+        ),
+    ),
+    (
+        re.compile(
+            r'\bgit\s+push\b.*?(\s--force\b|\s-f\b|\s--force-with-lease\b)',
+            re.IGNORECASE | re.DOTALL,
+        ),
+        (
+            "git push --force detected: force-pushing rewrites remote history and can "
+            "permanently destroy commits for all collaborators. Run manually after "
+            "confirming with your team."
+        ),
+    ),
+    (
+        re.compile(r'\bTRUNCATE\b', re.IGNORECASE),
+        (
+            "TRUNCATE detected: this removes ALL rows from a table instantly and "
+            "cannot be rolled back in most configurations. Run manually with a backup."
+        ),
+    ),
+]
+
+
+# ── DELETE FROM without WHERE (special case) ─────────────────────────────────
+_DELETE_FROM_RE = re.compile(r'\bDELETE\s+FROM\b', re.IGNORECASE)
+_WHERE_RE = re.compile(r'\bWHERE\b', re.IGNORECASE)
+
+
+def _check_delete_without_where(command: str):
+    """
+    Returns a block reason if the command contains DELETE FROM without a WHERE clause.
+    Returns None if the command is safe.
+
+    Strategy: for each DELETE FROM occurrence, check whether a WHERE clause
+    appears after it in the same statement.
+    """
+    for match in _DELETE_FROM_RE.finditer(command):
+        # Extract everything from the DELETE keyword to the next semicolon (or end)
+        after = command[match.start():]
+        stmt_end = after.find(";")
+        stmt = after if stmt_end == -1 else after[: stmt_end + 1]
+        if not _WHERE_RE.search(stmt):
+            return (
+                "DELETE FROM without WHERE detected: this would delete EVERY row in "
+                "the table. Add a WHERE clause to limit the scope, or run manually "
+                "with a backup if a full wipe is truly intended."
+            )
+    return None
+
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+def _log_blocked(command: str, project_path: str, reason: str) -> None:
+    """Append a blocked-command entry to the log file."""
+    try:
+        os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+        timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        # One-line log entry; use repr() for the command to keep newlines escaped
+        entry = (
+            f"[{timestamp}] BLOCKED"
+            f" | project={project_path}"
+            f" | reason={reason.split('.')[0]}"   # first sentence only, keeps log terse
+            f" | cmd={repr(command)}\n"
+        )
+        with open(LOG_FILE, "a", encoding="utf-8") as fh:
+            fh.write(entry)
+    except OSError:
+        pass  # Never let logging failure break the hook
+
+
+# ── Decision output ───────────────────────────────────────────────────────────
+def _deny(command: str, project_path: str, reason: str) -> None:
+    """Emit a deny decision JSON and exit 0 (Claude Code reads the decision from stdout)."""
+    _log_blocked(command, project_path, reason)
+
+    full_message = (
+        f"⛔  Command blocked by the anti-destructive hook\n\n"
+        f"Reason: {reason}\n\n"
+        f"Blocked command:\n  {command}\n\n"
+        f"What to do:\n"
+        f"  • Double-check that this is truly what you want.\n"
+        f"  • If needed, run it manually in a terminal (outside Claude Code).\n"
+        f"  • All blocked attempts are logged to: ~/.claude/hooks/blocked.log"
+    )
+
+    result = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": full_message,
+        }
+    }
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+def main() -> None:
+    # 1. Parse JSON input from stdin
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        # Non-JSON input → not a Bash invocation we understand → allow
+        sys.exit(0)
+
+    # 2. Only inspect Bash tool calls
+    tool_name = data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command: str = data.get("tool_input", {}).get("command", "")
+    project_path: str = data.get("project_path", os.getcwd())
+
+    if not command:
+        sys.exit(0)
+
+    # 3. Check fixed patterns
+    for pattern, reason in DANGEROUS_PATTERNS:
+        if pattern.search(command):
+            _deny(command, project_path, reason)
+
+    # 4. Special-case: DELETE FROM without WHERE
+    reason = _check_delete_without_where(command)
+    if reason:
+        _deny(command, project_path, reason)
+
+    # 5. Safe — allow execution
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bounties/issue-3-hook/install.sh
+++ b/bounties/issue-3-hook/install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# install.sh — Anti-destructive hook installer for Claude Code
+# Usage: bash install.sh
+set -euo pipefail
+
+HOOK_DIR="$HOME/.claude/hooks"
+HOOK_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/hook.py"
+HOOK_DST="$HOOK_DIR/anti-destructive.py"
+SETTINGS="$HOME/.claude/settings.json"
+
+echo "🔧 Installing Claude Code anti-destructive hook..."
+
+# ── 1. Copy hook script ────────────────────────────────────────────────────────
+mkdir -p "$HOOK_DIR"
+cp "$HOOK_SRC" "$HOOK_DST"
+chmod +x "$HOOK_DST"
+echo "   ✓ Hook copied to $HOOK_DST"
+
+# ── 2. Register in ~/.claude/settings.json ─────────────────────────────────────
+python3 - <<PYEOF
+import json, os, sys
+
+settings_path = os.path.expanduser("~/.claude/settings.json")
+hook_dst = os.path.expanduser("~/.claude/hooks/anti-destructive.py")
+
+# Load existing settings (or start fresh)
+if os.path.exists(settings_path):
+    with open(settings_path, "r") as f:
+        try:
+            settings = json.load(f)
+        except json.JSONDecodeError:
+            settings = {}
+else:
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+hook_entry = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": f"python3 {hook_dst}"
+        }
+    ]
+}
+
+# Avoid duplicates: remove any existing anti-destructive entries
+pre_tool_use[:] = [
+    g for g in pre_tool_use
+    if not any("anti-destructive" in str(h.get("command","")) for h in g.get("hooks",[]))
+]
+
+pre_tool_use.append(hook_entry)
+
+with open(settings_path, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+
+print(f"   ✓ Hook registered in {settings_path}")
+PYEOF
+
+echo ""
+echo "✅ Done! The anti-destructive hook is active."
+echo ""
+echo "   Blocked patterns:"
+echo "     • rm -rf"
+echo "     • DROP TABLE"
+echo "     • git push --force / -f"
+echo "     • TRUNCATE"
+echo "     • DELETE FROM without WHERE"
+echo ""
+echo "   Blocked attempts are logged to: ~/.claude/hooks/blocked.log"
+echo ""
+echo "   To uninstall: bash uninstall.sh"

--- a/bounties/issue-3-hook/uninstall.sh
+++ b/bounties/issue-3-hook/uninstall.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# uninstall.sh — Remove the anti-destructive hook from Claude Code
+set -euo pipefail
+
+HOOK_DST="$HOME/.claude/hooks/anti-destructive.py"
+SETTINGS="$HOME/.claude/settings.json"
+
+echo "🗑️  Uninstalling anti-destructive hook..."
+
+# Remove hook script
+if [ -f "$HOOK_DST" ]; then
+    rm "$HOOK_DST"
+    echo "   ✓ Removed $HOOK_DST"
+fi
+
+# Remove from settings.json
+if [ -f "$SETTINGS" ]; then
+    python3 - <<PYEOF
+import json, os
+
+settings_path = os.path.expanduser("~/.claude/settings.json")
+with open(settings_path, "r") as f:
+    settings = json.load(f)
+
+pre = settings.get("hooks", {}).get("PreToolUse", [])
+settings["hooks"]["PreToolUse"] = [
+    g for g in pre
+    if not any("anti-destructive" in str(h.get("command","")) for h in g.get("hooks",[]))
+]
+
+with open(settings_path, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+print("   ✓ Hook removed from settings.json")
+PYEOF
+fi
+
+echo "✅ Uninstalled."


### PR DESCRIPTION
## Solution

A Claude Code `PreToolUse` hook that intercepts dangerous bash commands before execution.

## Files

| File | Role |
|------|------|
| `hook.py` | Python hook — 0 external deps, reads JSON from stdin |
| `install.sh` | Copies hook + registers in `~/.claude/settings.json` |
| `uninstall.sh` | Clean removal |
| `README.md` | Setup in **2 commands** |

## Acceptance criteria

- [x] Follows Claude Code hooks format
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs to `~/.claude/hooks/blocked.log` (timestamp + cmd + project_path)
- [x] Clear message explaining why blocked
- [x] Does not block normal commands
- [x] README: 2 commands to install

Closes #3