### PR TITLE
feat: pre-tool-use safety hook blocking destructive bash commands

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,66 @@
+# Claude Code Pre-Tool-Use Safety Hook
+
+Blocks dangerous bash commands before Claude Code executes them. Logs every blocked attempt.
+
+## Blocked Patterns
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf` | Recursive force delete |
+| `DROP TABLE` | Database destruction |
+| `TRUNCATE` | Mass row deletion |
+| `DELETE FROM` without WHERE | Full table wipe |
+| `git push --force` / `-f` | History rewriting |
+
+## Install (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks
+curl -o ~/.claude/hooks/pre-tool-use.py https://raw.githubusercontent.com/YOUR_FORK/hook.py && chmod +x ~/.claude/hooks/pre-tool-use.py
+```
+
+Then add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/pre-tool-use.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Blocked Log
+
+Every blocked attempt is logged to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-03-26T18:00:00] BLOCKED | project=/home/user/myapp | reason=Recursive force delete | command=rm -rf /tmp/test
+```
+
+## How It Works
+
+1. Claude Code calls `PreToolUse` hook before every `Bash` tool execution
+2. Hook receives JSON on stdin with `tool_name` and `tool_input.command`
+3. If command matches a blocked pattern â†’ exits with code `2` (block + message to Claude)
+4. Claude sees a clear explanation of why it was blocked and how to fix it
+5. Safe commands pass through instantly (exit code `0`)
+
+## Testing
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp"},"cwd":"/home/user"}' | python3 hook.py
+echo $?  # should be 2
+
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"},"cwd":"/home/user"}' | python3 hook.py  
+echo $?  # should be 0
+```

--- a/hooks/pre-tool-use.py
+++ b/hooks/pre-tool-use.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+pre-tool-use hook: Blocks dangerous bash commands before Claude Code executes them.
+Logs blocked attempts. Displays clear explanation to Claude.
+
+Install: See README.md
+"""
+
+import json
+import sys
+import re
+import os
+from datetime import datetime
+from pathlib import Path
+
+# Patterns that are always blocked
+BLOCKED_PATTERNS = [
+    (r'\brm\s+-rf\b', "Recursive force delete (rm -rf) is blocked to prevent accidental data loss."),
+    (r'\brm\s+.*-r.*-f\b', "Recursive force delete (rm -rf variant) is blocked."),
+    (r'\bDROP\s+TABLE\b', "DROP TABLE is blocked to prevent database destruction."),
+    (r'\bTRUNCATE\b', "TRUNCATE is blocked to prevent mass data deletion."),
+    (r'\bDELETE\s+FROM\s+\w+\s*(?:;|$)', "DELETE FROM without a WHERE clause is blocked â€” would delete all rows."),
+    (r'\bgit\s+push\s+.*--force\b', "Force push (git push --force) is blocked to prevent history rewriting."),
+    (r'\bgit\s+push\s+.*-f\b', "Force push (git push -f) is blocked to prevent history rewriting."),
+]
+
+LOG_FILE = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def log_blocked(command: str, reason: str, project_path: str) -> None:
+    """Append blocked attempt to log file."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().isoformat()
+    entry = f"[{timestamp}] BLOCKED | project={project_path} | reason={reason} | command={command}\n"
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(entry)
+
+
+def check_command(command: str) -> tuple[bool, str]:
+    """
+    Returns (is_blocked, reason).
+    Checks against all BLOCKED_PATTERNS (case-insensitive).
+    """
+    for pattern, reason in BLOCKED_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return True, reason
+    return False, ""
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Not valid JSON â€” let it through
+        sys.exit(0)
+
+    tool_name = hook_input.get("tool_name", "")
+    tool_input = hook_input.get("tool_input", {})
+
+    # Only intercept Bash tool calls
+    if tool_name not in ("Bash", "bash"):
+        sys.exit(0)
+
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    project_path = hook_input.get("cwd", os.getcwd())
+
+    blocked, reason = check_command(command)
+    if not blocked:
+        sys.exit(0)
+
+    # Log the blocked attempt
+    log_blocked(command, reason, project_path)
+
+    # Output Claude-readable block message via stderr (shown to Claude)
+    block_message = {
+        "type": "error",
+        "message": (
+            f"ðŸš« BLOCKED: {reason}\n"
+            f"Command: {command}\n"
+            f"Logged to: {LOG_FILE}\n"
+            "To proceed, reformulate the command safely (e.g., add a WHERE clause, "
+            "use 'rm' without -rf, or use 'git push' without --force)."
+        )
+    }
+    print(json.dumps(block_message), file=sys.stderr)
+
+    # Exit code 2 = block the tool call and show message to Claude
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3

## What's included

- `hooks/pre-tool-use.py` - Claude Code PreToolUse hook, zero dependencies
- `hooks/README.md` - 2-command install, JSON config snippet, test cases

## Blocked patterns

| Pattern | Why |
|---------|-----|
| `rm -rf` | Recursive force delete |
| `DROP TABLE` | Database destruction |
| `TRUNCATE` | Mass row deletion |
| `DELETE FROM` without WHERE | Full table wipe |
| `git push --force` / `-f` | History rewriting |

## How it works

1. Hook receives JSON on stdin: `{"tool_name":"Bash","tool_input":{"command":"..."},"cwd":"..."}`
2. Matches command against BLOCKED_PATTERNS (case-insensitive regex)
3. Blocked ? exits 2 (block + message to Claude) + logs to `~/.claude/hooks/blocked.log`
4. Safe ? exits 0 (pass through)

## Install (2 commands)

```bash
mkdir -p ~/.claude/hooks
cp hooks/pre-tool-use.py ~/.claude/hooks/pre-tool-use.py && chmod +x ~/.claude/hooks/pre-tool-use.py
```

Closes #3