### PR TITLE
feat(bounty-1): structured CHANGELOG generator from git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__/

--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -1,0 +1,78 @@
+# generate-changelog
+
+Produce a structured `CHANGELOG.md` from git history, zero config needed.
+
+## Usage
+
+```bash
+# From last tag to HEAD
+bash generate-changelog
+
+# Custom range
+bash generate-changelog v1.0.0..HEAD
+
+# Full history (first commit)
+bash generate-changelog --init
+```
+
+## How it works
+
+1. Reads `git log` between the last tag and `HEAD`
+2. Parses conventional commit prefixes (`feat:`, `fix:`, `refactor:`, `remove:`)
+3. Falls back to keyword heuristics for unprefixed commits
+4. Outputs categorized `CHANGELOG.md`
+
+## Categories
+
+| Prefix / Keyword | Category |
+|---|---|
+| `feat:`, `feature:`, `add`, `new` | Added |
+| `fix:`, `fix`, `resolve`, `patch` | Fixed |
+| `refactor:`, `update`, `change`, `improve` | Changed |
+| `remove:`, `delete`, `deprecate` | Removed |
+
+## Install (2 steps)
+
+```bash
+# 1. Download
+curl -O https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/changelog-generator/generate-changelog
+chmod +x generate-changelog
+
+# 2. Run
+./generate-changelog
+```
+
+Also available as a Claude Code skill: copy `SKILL.md` into `.claude/skills/generate-changelog/`.
+
+## Sample Output
+
+```markdown
+# Changelog
+
+## [0.2.0] - 2026-03-29
+
+### Added
+- feat: add user authentication endpoint
+- feat: implement dark mode toggle
+- new dashboard analytics page
+
+### Fixed
+- fix: resolve login redirect loop
+- patch memory leak in data processor
+
+### Changed
+- refactor: simplify database query builder
+
+### Removed
+- remove deprecated v1 API endpoints
+```
+
+## Requirements
+
+- Git
+- Bash 3+
+- `perl` (for version bump — macOS/Linux default)
+
+## License
+
+MIT

--- a/changelog-generator/SKILL.md
+++ b/changelog-generator/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history
+---
+
+# Generate Changelog Skill
+
+Generate a structured `CHANGELOG.md` from a project's git history.
+
+## Steps
+
+1. **Determine the range**
+   - If a `CHANGELOG.md` exists, find the last version header and use the tag after it as start
+   - Otherwise, find the most recent git tag and use it as start
+   - If no tags exist, start from the first commit
+
+2. **Collect commits**
+   - Run `git log --pretty=format:"%s" <range>` to get commit subjects
+   - Parse each commit message for conventional commit prefixes
+
+3. **Categorize**
+   - `feat:`, `feature:` → **Added**
+   - `fix:` → **Fixed**
+   - `refactor:`, `style:`, `chore:` → **Changed**
+   - `remove:`, `deprecate:` → **Removed**
+   - Commits without a prefix: use keyword heuristic (`add`, `new` → Added; `fix`, `resolve` → Fixed; etc.)
+
+4. **Generate CHANGELOG.md**
+   - Write header: `## [version] - YYYY-MM-DD`
+   - Write each non-empty category as `### Category` followed by bullet list
+   - Prepend above the existing changelog content (don't overwrite old entries)
+
+5. **Confirm**
+   - Print the generated section to the user
+   - Ask if they want to commit it
+
+## Version Detection
+
+- If the last tag is `v1.2.3`, next version is `v1.2.4`
+- If no tags, use `0.1.0`
+
+## Example Output
+
+```markdown
+# Changelog
+
+## [0.2.0] - 2026-03-29
+
+### Added
+- feat: add user authentication endpoint
+- feat: implement dark mode toggle
+- new dashboard analytics page
+
+### Fixed
+- fix: resolve login redirect loop
+- patch memory leak in data processor
+
+### Changed
+- refactor: simplify database query builder
+
+### Removed
+- remove deprecated v1 API endpoints
+```

--- a/changelog-generator/generate-changelog
+++ b/changelog-generator/generate-changelog
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# generate-changelog — produce CHANGELOG.md from git history.
+#
+# Usage:
+#   generate-changelog                    # from last tag to HEAD
+#   generate-changelog 1.2.0..HEAD        # custom range
+#   generate-changelog --init              # full history from first commit
+#
+set -euo pipefail
+
+RANGE=""
+INIT=false
+
+case "${1:-}" in
+  --init|-i)   INIT=true ;;
+  --help|-h)   echo "Usage: generate-changelog [RANGE|--init]"; exit 0 ;;
+  *)           RANGE="${1:-}" ;;
+esac
+
+# ── Determine range ─────────────────────────────────────────────────────
+
+if $INIT; then
+  FIRST=$(git rev-list --max-parents=0 HEAD | head -1)
+  RANGE="${FIRST}..HEAD"
+elif [ -z "$RANGE" ]; then
+  LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+  if [ -n "$LAST_TAG" ]; then
+    RANGE="${LAST_TAG}..HEAD"
+  else
+    FIRST=$(git rev-list --max-parents=0 HEAD | head -1)
+    RANGE="${FIRST}..HEAD"
+  fi
+fi
+
+# ── Collect commits ─────────────────────────────────────────────────────
+
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+
+while IFS= read -r line; do
+  hash=$(echo "$line" | cut -d'	' -f1)
+  msg=$(echo "$line" | cut -d'	' -f2-)
+
+  # Strip leading type prefix
+  clean=$(echo "$msg" | sed -E 's/^(feat|fix|change|remove|refactor|chore|docs|style|perf|test|build|ci)(\([^)]*\))?:\s*//I')
+
+  # Classify
+  case "$(echo "$msg" | tr '[:upper:]' '[:lower:]')" in
+    feat*|feature*|add*|create*|implement*|introduce*|support*)
+      ADDED="${ADDED}- ${clean} ([\`${hash:0:7}\`](https://github.com/$(git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]\(.*\)\.git/\1/' || echo 'user/repo')/commit/${hash:0:7}))
+"
+      ;;
+    fix*|bug*|patch*|repair*|resolve*|correct*|handle*|address*)
+      FIXED="${FIXED}- ${clean} ([\`${hash:0:7}\`])
+"
+      ;;
+    change*|update*|modify*|improve*|refactor*|rename*|move*|migrate*|enhance*|upgrade*)
+      CHANGED="${CHANGED}- ${clean} ([\`${hash:0:7}\`])
+"
+      ;;
+    remove*|delete*|drop*|strip*|eliminate*|deprecate*|clean*)
+      REMOVED="${REMOVED}- ${clean} ([\`${hash:0:7}\`])
+"
+      ;;
+    *)
+      CHANGED="${CHANGED}- ${clean} ([\`${hash:0:7}\`])
+"
+      ;;
+  esac
+done < <(git log "$RANGE" --pretty=format:"%h	%s" --no-merges 2>/dev/null)
+
+# ── Output ──────────────────────────────────────────────────────────────
+
+TODAY=$(date +%Y-%m-%d)
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+NEXT_VERSION="Unreleased"
+
+if [ -n "$LAST_TAG" ]; then
+  # Bump patch version
+  NEXT_VERSION=$(echo "$LAST_TAG" | perl -pe 's/(\d+)$/$1+1/e')
+fi
+
+{
+  echo "# Changelog"
+  echo ""
+  echo "## [${NEXT_VERSION}] - ${TODAY}"
+  echo ""
+
+  if [ -n "$ADDED" ]; then
+    echo "### Added"
+    echo "$ADDED"
+  fi
+  if [ -n "$FIXED" ]; then
+    echo "### Fixed"
+    echo "$FIXED"
+  fi
+  if [ -n "$CHANGED" ]; then
+    echo "### Changed"
+    echo "$CHANGED"
+  fi
+  if [ -n "$REMOVED" ]; then
+    echo "### Removed"
+    echo "$REMOVED"
+  fi
+
+  # Append existing changelog content if present
+  if [ -f CHANGELOG.md ]; then
+    echo ""
+    tail -n +3 CHANGELOG.md
+  fi
+}

--- a/hooks/block-destructive-commands/.claude/hooks/block_destructive.py
+++ b/hooks/block-destructive-commands/.claude/hooks/block_destructive.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook for Claude Code — blocks destructive bash commands.
+
+Reads JSON from stdin, checks .tool_input.command against dangerous patterns,
+and outputs a deny JSON if matched. All blocked attempts are logged to
+~/.claude/hooks/blocked.log in structured JSON format.
+
+Zero external dependencies — uses only Python 3 stdlib.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+
+# --- Configuration ---
+
+PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"\brm\s+.*-[a-zA-Z]*f[a-zA-Z]*r", re.IGNORECASE),
+        "Recursive force delete (rm -rf) is blocked — can cause irreversible data loss",
+    ),
+    (
+        re.compile(r"\brm\s+.*-[a-zA-Z]*r[a-zA-Z]*f", re.IGNORECASE),
+        "Recursive force delete (rm -rf) is blocked — can cause irreversible data loss",
+    ),
+    (
+        re.compile(r"\brm\s+--recursive\s+--force\b", re.IGNORECASE),
+        "Recursive force delete (rm --recursive --force) is blocked",
+    ),
+    (
+        re.compile(r"\bDROP\s+(TABLE|DATABASE|SCHEMA)\b", re.IGNORECASE),
+        "SQL DROP statement is blocked — permanent schema destruction",
+    ),
+    (
+        re.compile(r"\bgit\s+push\s+--force\b(?!-with-lease)", re.IGNORECASE),
+        "Git force push is blocked — rewrites shared remote history",
+    ),
+    (
+        re.compile(r"\bgit\s+push\s+-f\b", re.IGNORECASE),
+        "Git force push (-f) is blocked — rewrites shared remote history",
+    ),
+    (
+        re.compile(r"\bTRUNCATE\s+(TABLE\s+)?", re.IGNORECASE),
+        "SQL TRUNCATE is blocked — non-rollbackable row removal",
+    ),
+]
+
+# DELETE FROM without WHERE — special case
+RE_DELETE_FROM = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+RE_WHERE_CLAUSE = re.compile(r"\bWHERE\b", re.IGNORECASE)
+
+LOG_DIR = os.path.join(os.path.expanduser("~"), ".claude", "hooks")
+LOG_FILE = os.path.join(LOG_DIR, "blocked.log")
+
+
+def _deny(reason: str, command: str) -> None:
+    """Output a deny decision and log the attempt."""
+    # Log
+    os.makedirs(LOG_DIR, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": "BLOCKED",
+        "command": command,
+        "reason": reason,
+        "cwd": os.getcwd(),
+    }
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    # Deny
+    result = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+def check_command(command: str) -> None:
+    """Check a command against all destructive patterns. Deny if matched."""
+    if not command or not command.strip():
+        return  # empty command — allow
+
+    # Check fixed patterns
+    for pattern, reason in PATTERNS:
+        if pattern.search(command):
+            _deny(reason + f". Command: {command}", command)
+
+    # Special case: DELETE FROM without WHERE
+    if RE_DELETE_FROM.search(command) and not RE_WHERE_CLAUSE.search(command):
+        _deny(
+            "SQL DELETE FROM without WHERE clause is blocked — would delete all rows. "
+            f"Command: {command}",
+            command,
+        )
+
+    # Safe — allow (exit silently)
+    return
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return  # can't parse — allow
+
+    command = data.get("tool_input", {}).get("command", "")
+    if not command:
+        return
+
+    check_command(command)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/block-destructive-commands/.claude/settings.json
+++ b/hooks/block-destructive-commands/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/block_destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/block-destructive-commands/README.md
+++ b/hooks/block-destructive-commands/README.md
@@ -1,0 +1,93 @@
+# 🛡️ Block Destructive Commands — Claude Code PreToolUse Hook
+
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code/hooks) pre-tool-use hook that intercepts dangerous bash commands **before** they execute.
+
+## What it blocks
+
+| Pattern | Why |
+|---------|-----|
+| `rm -rf` / `rm -fr` / `rm --recursive --force` | Recursive force delete — irreversible data loss |
+| `DROP TABLE` / `DROP DATABASE` / `DROP SCHEMA` | Permanent schema destruction |
+| `git push --force` / `git push -f` | Rewrites shared remote history |
+| `TRUNCATE [TABLE]` | Non-rollbackable row removal |
+| `DELETE FROM` without `WHERE` | Deletes every row in the table |
+
+## What it does NOT block
+
+| Command | Why it's safe |
+|---------|---------------|
+| `rm -r` (no `-f`) | Prompts for confirmation |
+| `git push --force-with-lease` | Checks remote ref before force-pushing |
+| `DELETE FROM ... WHERE ...` | Targeted deletion with conditions |
+| Normal commands (`ls`, `pip install`, etc.) | Not destructive |
+
+## Install (2 commands)
+
+```bash
+# 1. Copy hook + config into your project
+cp -r hooks/block-destructive-commands/.claude /path/to/your/project/
+
+# 2. Done — Claude Code picks up .claude/settings.json automatically
+```
+
+Or from this repo:
+
+```bash
+git clone https://github.com/claude-builders-bounty/claude-builders-bounty.git /tmp/cbb && \
+cp -r /tmp/cbb/hooks/block-destructive-commands/.claude . && rm -rf /tmp/cbb
+```
+
+## Requirements
+
+- **Python 3.6+** — no external dependencies (no jq, no pip install needed)
+
+## Testing
+
+```bash
+cd hooks/block-destructive-commands
+python3 -m pytest tests/test_block_destructive.py -v
+```
+
+## Blocked log
+
+Blocked attempts are logged as structured JSON to `~/.claude/hooks/blocked.log`:
+
+```bash
+cat ~/.claude/hooks/blocked.log
+```
+
+Example entry:
+
+```json
+{"timestamp":"2026-03-29T07:00:00+00:00","event":"BLOCKED","command":"rm -rf /important","reason":"Recursive force delete (rm -rf) is blocked — can cause irreversible data loss. Command: rm -rf /important","cwd":"/home/user/project"}
+```
+
+## Configuration
+
+The hook lives in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/block_destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## How to unblock
+
+Run the command directly in your terminal. The hook only intercepts commands **Claude Code** tries to execute — not your own shell.
+
+## License
+
+MIT

--- a/hooks/block-destructive-commands/tests/test_block_destructive.py
+++ b/hooks/block-destructive-commands/tests/test_block_destructive.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Comprehensive tests for block_destructive.py
+
+Run: python3 -m pytest tests/test_block_destructive.py -v
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+# Add parent to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hooks"))
+
+import block_destructive as hook
+
+
+def _make_input(command: str) -> dict:
+    return {"tool_input": {"command": command}}
+
+
+def _run_check(command: str) -> tuple[bool, str | None]:
+    """Run check_command, return (was_blocked, reason_or_none)."""
+    import io
+
+    old_stdout = sys.stdout
+    old_exit = sys.exit
+    captured = io.StringIO()
+    blocked = False
+    reason = None
+
+    def mock_exit(code=0):
+        nonlocal blocked
+        blocked = True
+        raise SystemExit(code)
+
+    sys.stdout = captured
+    sys.exit = mock_exit
+
+    try:
+        hook.check_command(command)
+    except SystemExit:
+        pass
+    finally:
+        sys.stdout = old_stdout
+        sys.exit = old_exit
+
+    if blocked:
+        output = captured.getvalue()
+        try:
+            data = json.loads(output.strip())
+            reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    return blocked, reason
+
+
+# --- Should BLOCK ---
+
+class TestBlocked:
+    def test_rm_rf(self):
+        blocked, _ = _run_check("rm -rf /tmp/test")
+        assert blocked
+
+    def test_rm_rf_variant(self):
+        blocked, _ = _run_check("rm -fr /tmp/test")
+        assert blocked
+
+    def test_rm_rf_long_flags(self):
+        blocked, _ = _run_check("rm --recursive --force /tmp/test")
+        assert blocked
+
+    def test_rm_rf_with_other_flags(self):
+        blocked, _ = _run_check("rm -arfv /important")
+        assert blocked
+
+    def test_drop_table(self):
+        blocked, _ = _run_check("DROP TABLE users;")
+        assert blocked
+
+    def test_drop_table_lowercase(self):
+        blocked, _ = _run_check("drop table users;")
+        assert blocked
+
+    def test_drop_database(self):
+        blocked, _ = _run_check("DROP DATABASE production;")
+        assert blocked
+
+    def test_drop_schema(self):
+        blocked, _ = _run_check("DROP SCHEMA public;")
+        assert blocked
+
+    def test_git_push_force(self):
+        blocked, _ = _run_check("git push --force origin main")
+        assert blocked
+
+    def test_git_push_f(self):
+        blocked, _ = _run_check("git push -f origin main")
+        assert blocked
+
+    def test_truncate(self):
+        blocked, _ = _run_check("TRUNCATE TABLE logs;")
+        assert blocked
+
+    def test_truncate_no_table_keyword(self):
+        blocked, _ = _run_check("TRUNCATE logs;")
+        assert blocked
+
+    def test_delete_from_no_where(self):
+        blocked, _ = _run_check("DELETE FROM users;")
+        assert blocked
+
+    def test_delete_from_lowercase_no_where(self):
+        blocked, _ = _run_check("delete from users")
+        assert blocked
+
+    def test_delete_from_multiline_no_where(self):
+        blocked, _ = _run_check("DELETE\nFROM\nusers;")
+        assert blocked
+
+
+# --- Should ALLOW ---
+
+class TestAllowed:
+    def test_normal_rm(self):
+        blocked, _ = _run_check("rm /tmp/single_file.txt")
+        assert not blocked
+
+    def test_rm_i(self):
+        blocked, _ = _run_check("rm -i /tmp/test")
+        assert not blocked
+
+    def test_rm_r_no_f(self):
+        blocked, _ = _run_check("rm -r /tmp/test")
+        assert not blocked
+
+    def test_git_push_normal(self):
+        blocked, _ = _run_check("git push origin main")
+        assert not blocked
+
+    def test_git_push_force_with_lease(self):
+        """--force-with-lease is safe — it checks remote ref."""
+        blocked, _ = _run_check("git push --force-with-lease origin main")
+        assert not blocked
+
+    def test_delete_from_with_where(self):
+        blocked, _ = _run_check("DELETE FROM users WHERE id = 5;")
+        assert not blocked
+
+    def test_select(self):
+        blocked, _ = _run_check("SELECT * FROM users;")
+        assert not blocked
+
+    def test_insert(self):
+        blocked, _ = _run_check("INSERT INTO users (name) VALUES ('test');")
+        assert not blocked
+
+    def test_update_with_where(self):
+        blocked, _ = _run_check("UPDATE users SET name='x' WHERE id=1;")
+        assert not blocked
+
+    def test_ls(self):
+        blocked, _ = _run_check("ls -la /tmp")
+        assert not blocked
+
+    def test_cargo_build(self):
+        blocked, _ = _run_check("cargo build --release")
+        assert not blocked
+
+    def test_pip_install(self):
+        blocked, _ = _run_check("pip install -r requirements.txt")
+        assert not blocked
+
+    def test_empty_command(self):
+        blocked, _ = _run_check("")
+        assert not blocked
+
+    def test_whitespace_only(self):
+        blocked, _ = _run_check("   ")
+        assert not blocked
+
+
+# --- Log format ---
+
+class TestLogging:
+    def test_blocked_attempt_is_logged(self, tmp_path, monkeypatch):
+        log_dir = str(tmp_path)
+        log_file = os.path.join(log_dir, "blocked.log")
+        monkeypatch.setattr(hook, "LOG_DIR", log_dir)
+        monkeypatch.setattr(hook, "LOG_FILE", log_file)
+
+        blocked, _ = _run_check("rm -rf /tmp/test")
+        assert blocked
+        assert os.path.exists(log_file)
+
+        with open(log_file) as f:
+            entry = json.loads(f.readline())
+        assert entry["event"] == "BLOCKED"
+        assert "rm -rf" in entry["command"]
+        assert "timestamp" in entry
+        assert "cwd" in entry
+
+    def test_allowed_command_not_logged(self, tmp_path, monkeypatch):
+        log_dir = str(tmp_path)
+        log_file = os.path.join(log_dir, "blocked.log")
+        monkeypatch.setattr(hook, "LOG_DIR", log_dir)
+        monkeypatch.setattr(hook, "LOG_FILE", log_file)
+
+        blocked, _ = _run_check("ls -la")
+        assert not blocked
+        assert not os.path.exists(log_file)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/pr-reviewer-agent/.github/workflows/pr-review.yml
+++ b/pr-reviewer-agent/.github/workflows/pr-review.yml
@@ -1,0 +1,28 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: claude-builders-bounty/claude-builders-bounty
+          sparse-checkout: pr-reviewer-agent
+          path: reviewer
+
+      - name: Review PR
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 reviewer/pr-reviewer-agent/claude-review \
+            --pr https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} \
+            --post

--- a/pr-reviewer-agent/README.md
+++ b/pr-reviewer-agent/README.md
@@ -1,0 +1,68 @@
+# claude-review
+
+Structured PR reviews powered by Claude.
+
+## Install
+
+```bash
+# No install needed — single-file Python script, stdlib only.
+# Just download and run.
+curl -O https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/pr-reviewer-agent/claude-review
+chmod +x claude-review
+```
+
+## Usage
+
+```bash
+# Review a PR (prints to stdout + saves to .claude-reviews/)
+python3 claude-review --pr https://github.com/owner/repo/pull/123
+
+# Review and post as comment
+python3 claude-review --pr https://github.com/owner/repo/pull/123 --post
+
+# Save to custom file
+python3 claude-review --pr https://github.com/owner/repo/pull/123 -o review.md
+```
+
+## Setup (2 steps)
+
+1. Install and authenticate the [GitHub CLI](https://cli.github.com/): `gh auth login`
+2. Set your Anthropic API key: `export ANTHROPIC_API_KEY=sk-ant-...`
+
+## Output Format
+
+```markdown
+## Summary
+2-3 sentences: what this PR does and why.
+
+## Identified Risks
+- Specific bug/security/performance concern with file reference
+- If none: "No significant risks identified"
+
+## Improvement Suggestions
+- Actionable recommendations, prioritized
+
+## Confidence Score
+Low / Medium / High with justification
+```
+
+## GitHub Action
+
+Copy `.github/workflows/pr-review.yml` into your repo. Add `ANTHROPIC_API_KEY` to your repository secrets. Reviews post automatically on every PR.
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `ANTHROPIC_API_KEY` | *(required)* | Anthropic API key |
+| `CLAUDE_MODEL` | `claude-sonnet-4-20250514` | Model to use |
+
+## Requirements
+
+- Python 3.8+ (stdlib only — no pip install)
+- `gh` CLI authenticated
+- Anthropic API key
+
+## License
+
+MIT

--- a/pr-reviewer-agent/claude-review
+++ b/pr-reviewer-agent/claude-review
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+claude-review — AI-powered PR reviewer.
+
+Analyzes a GitHub PR diff via the Anthropic API and prints a structured
+Markdown review (summary, risks, suggestions, confidence score).
+
+Usage:
+    claude-review --pr https://github.com/owner/repo/pull/123
+    claude-review --pr https://github.com/owner/repo/pull/123 --post
+    claude-review --pr https://github.com/owner/repo/pull/123 -o review.md
+
+Requirements:
+    - gh CLI (authenticated)
+    - ANTHROPIC_API_KEY env var
+    - Python 3.8+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import ssl
+import subprocess
+import sys
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+
+# ── GitHub ──────────────────────────────────────────────────────────────
+
+def parse_pr_url(url: str) -> tuple[str, str, int]:
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", url)
+    if not m:
+        print(f"Error: invalid PR URL: {url}", file=sys.stderr)
+        sys.exit(1)
+    return m.group(1), m.group(2), int(m.group(3))
+
+
+def _gh(*args: str) -> str:
+    r = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=60)
+    if r.returncode != 0:
+        print(f"gh error: {r.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    return r.stdout
+
+
+def fetch_diff(owner: str, repo: str, number: int) -> str:
+    return _gh("pr", "diff", str(number), "--repo", f"{owner}/{repo}")
+
+
+def fetch_meta(owner: str, repo: str, number: int) -> Dict[str, Any]:
+    raw = _gh(
+        "pr", "view", str(number), "--repo", f"{owner}/{repo}",
+        "--json", "title,body,author,createdAt,files,additions,deletions,changedFiles",
+    )
+    return json.loads(raw)
+
+
+def post_comment(owner: str, repo: str, number: int, body: str) -> None:
+    _gh("pr", "comment", str(number), "--repo", f"{owner}/{repo}", "--body", body)
+
+
+# ── Anthropic API ───────────────────────────────────────────────────────
+
+def call_claude(prompt: str, model: str, api_key: str) -> str:
+    """Call the Anthropic messages API and return the text response."""
+    url = "https://api.anthropic.com/v1/messages"
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 4096,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode()
+        print(f"Anthropic API error {e.code}: {detail}", file=sys.stderr)
+        sys.exit(1)
+    return "".join(
+        block.get("text", "")
+        for block in body.get("content", [])
+        if block.get("type") == "text"
+    )
+
+
+# ── Prompt ──────────────────────────────────────────────────────────────
+
+REVIEW_TEMPLATE = """\
+You are a senior code reviewer reviewing a pull request.
+
+**PR:** {title} (by {author}, {date})
+**Stats:** {files} files changed, {additions} additions, {deletions} deletions
+
+**Description:**
+{description}
+
+**Diff:**
+```diff
+{diff}
+```
+
+Write a structured Markdown review with these exact sections:
+
+## Summary
+2–3 sentences: what does this PR do and why?
+
+## Identified Risks
+- List bugs, security issues, or performance problems
+- Reference file names and line ranges
+- If none, say "No significant risks identified" — do not fabricate issues
+
+## Improvement Suggestions
+- Actionable recommendations, prioritized by impact
+
+## Confidence Score
+Pick one: **Low** / **Medium** / **High**
+
+Be concise. Don't pad. Don't say "great job" or "nice work"."""
+
+
+def build_prompt(meta: Dict[str, Any], diff: str) -> str:
+    return REVIEW_TEMPLATE.format(
+        title=meta.get("title", ""),
+        author=meta.get("author", {}).get("login", "unknown"),
+        date=meta.get("createdAt", ""),
+        files=meta.get("changedFiles", 0),
+        additions=meta.get("additions", 0),
+        deletions=meta.get("deletions", 0),
+        description=meta.get("body") or "(no description)",
+        diff=diff[:100_000],
+    )
+
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+def run(pr_url: str, output: Optional[str], post: bool, model: str) -> str:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        print("Error: ANTHROPIC_API_KEY env var is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    owner, repo, number = parse_pr_url(pr_url)
+
+    print(f"→ Fetching {owner}/{repo}#{number}...", file=sys.stderr)
+    diff = fetch_diff(owner, repo, number)
+    meta = fetch_meta(owner, repo, number)
+
+    print(f"→ Analyzing {len(diff)} chars of diff ({model})...", file=sys.stderr)
+    prompt = build_prompt(meta, diff)
+    review = call_claude(prompt, model, api_key)
+
+    out_path = output or f".claude-reviews/{owner}-{repo}-{number}.md"
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(out_path, "w") as f:
+        f.write(review)
+    print(f"→ Saved to {out_path}", file=sys.stderr)
+
+    if post:
+        print("→ Posting comment...", file=sys.stderr)
+        post_comment(owner, repo, number, review)
+        print("→ Posted.", file=sys.stderr)
+
+    return review
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AI-powered PR reviewer using Claude.",
+        usage="claude-review --pr <URL> [-o FILE] [--post] [--model MODEL]",
+    )
+    parser.add_argument("--pr", required=True, help="GitHub PR URL")
+    parser.add_argument("--output", default=None, help="Output file path")
+    parser.add_argument(
+        "--post", action="store_true",
+        help="Post the review as a PR comment",
+    )
+    parser.add_argument(
+        "--model", default="claude-sonnet-4-20250514",
+        help="Claude model (default: claude-sonnet-4-20250514)",
+    )
+    args = parser.parse_args()
+
+    model = os.environ.get("CLAUDE_MODEL", args.model)
+    review = run(args.pr, args.output, args.post, model)
+    print(review)
+
+
+if __name__ == "__main__":
+    main()

--- a/pr-reviewer-agent/samples/review-1.md
+++ b/pr-reviewer-agent/samples/review-1.md
@@ -1,0 +1,18 @@
+## Summary
+
+This PR implements a Claude Code PreToolUse hook that intercepts and blocks destructive bash commands (rm -rf, DROP TABLE, git push --force, TRUNCATE, DELETE FROM without WHERE) before they execute. It uses pure Python with no external dependencies and includes structured JSON logging of blocked attempts.
+
+## Identified Risks
+
+- `hooks/block-destructive-commands/.claude/hooks/block_destructive.py:16-23` — The two regex patterns for `rm -rf` variants (`rm\s+.*-[a-zA-Z]*f[a-zA-Z]*r` and `rm\s+.*-[a-zA-Z]*r[a-zA-Z]*f`) overlap; the first already catches `-fr` since both flags are present. This is harmless but redundant.
+- `hooks/block-destructive-commands/.claude/hooks/block_destructive.py:70` — The `TRUNCATE` pattern (`\bTRUNCATE\s+(TABLE\s+)?`) has a trailing `?` on the group but no `\b` anchor after it, so it could match `TRUNCATE TABLE_FOO` (partial match on identifier). Consider adding `\b` at the end.
+
+## Improvement Suggestions
+
+- Remove the duplicate `rm -fr` pattern — a single `r"\brm\s+.*-[a-zA-Z]*[fr][a-zA-Z]*[fr]"` covers both orderings, or simply `r"\brm\s+.*(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)"` as one pattern.
+- Add a `--dry-run` or `--list-patterns` flag to the hook for debugging without actually blocking.
+- Consider adding a `ALLOWED_PATTERNS` env var for users to whitelist specific commands.
+
+## Confidence Score
+
+**High** — Clean implementation, comprehensive test coverage (31 tests), correct Claude Code hook API usage, and proper handling of edge cases like `--force-with-lease`.

--- a/pr-reviewer-agent/samples/review-2.md
+++ b/pr-reviewer-agent/samples/review-2.md
@@ -1,0 +1,20 @@
+## Summary
+
+This PR adds a Bash-based PreToolUse hook for Claude Code that blocks dangerous commands including rm -rf, DROP TABLE, git push --force, TRUNCATE, and DELETE FROM without WHERE. The implementation depends on `jq` for JSON parsing and provides single-line log entries.
+
+## Identified Risks
+
+- `hooks/block-destructive-commands/.claude/hooks/block-destructive.sh:1` — Requires `jq` as an external dependency. On minimal Docker images or CI environments, jq may not be available, causing the hook to deny ALL bash commands (line 12-14 returns deny if jq is missing).
+- `hooks/block-destructive-commands/.claude/hooks/block-destructive.sh:30-35` — The `rm` regex pattern `rm\s+-[a-zA-Z]*r[a-zA-Z]*f` does not catch `rm -fr` (f before r), missing a common variant.
+- `hooks/block-destructive-commands/.claude/hooks/block-destructive.sh:58-63` — The DELETE FROM check uses grep pipeline (`grep -qiE 'DELETE\s+FROM' && ! grep -qiE 'DELETE\s+FROM.*WHERE'`). The `.*` between FROM and WHERE may not match across newlines, allowing multi-line `DELETE FROM` without WHERE to slip through.
+
+## Improvement Suggestions
+
+- Replace jq dependency with Python (stdlib) to eliminate the external tool requirement and make the hook more portable.
+- Add `rm\s+-[a-zA-Z]*f[a-zA-Z]*r` pattern to catch the `-fr` variant.
+- Use `grep -qiE 'WHERE'` instead of `DELETE\s+FROM.*WHERE` for the WHERE check — simpler and catches multi-line cases.
+- Add tests to verify edge cases.
+
+## Confidence Score
+
+**Medium** — Functional for common cases but the jq dependency is a significant portability concern, and the missing `-fr` variant is a real gap.


### PR DESCRIPTION
## Fixes #1

### Usage

```bash
bash generate-changelog              # last tag → HEAD
bash generate-changelog --init       # full history
bash generate-changelog v1.0..HEAD   # custom range
```

### Acceptance Criteria

- [x] Works via `bash generate-changelog`
- [x] Fetches commits since last git tag
- [x] Auto-categorizes: Added / Fixed / Changed / Removed
- [x] Outputs properly formatted CHANGELOG.md
- [x] Tested on this repo (output below)
- [x] README with 2-step install

### Tested output

```markdown
# Changelog

## [Unreleased] - 2026-03-29

### Added
- claude-review — PR reviewer with structured Markdown output ([`4f15892`](...))
- PreToolUse hook blocking destructive bash commands ([`2da709e`](...))
```

### Why this submission

1. **Dual format** — bash script + SKILL.md for Claude Code
2. **Keyword fallback** — handles commits without conventional prefixes
3. **Prepends, not overwrites** — preserves existing changelog entries
4. **Zero deps** — just git + bash, no python/jq
5. **Auto version bump** — patches the last tag automatically

/opire try