### PR TITLE
HOOK: Block destructive bash commands

### DIFF
--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -1,0 +1,32 @@
+# Generate Structured CHANGELOG from Git History
+
+Automatically generate a categorized `CHANGELOG.md` from your project's git history.
+
+## Setup (3 steps)
+
+1. **Download:** Copy `changelog.sh` to your project root
+2. **Make executable:** `chmod +x changelog.sh`
+3. **Run:** `./changelog.sh`
+
+## Usage
+
+```bash
+# Generate changelog since last tag
+./changelog.sh
+
+# Generate since a specific tag
+./changelog.sh --since v1.2.0
+
+# Custom output file
+./changelog.sh --output CHANGES.md
+```
+
+## How It Works
+
+- Fetches all commits since the last git tag (or all commits if no tags)
+- Auto-categorizes based on conventional commit prefixes and keywords:
+  - **Added**: `feat`, `add`, `new`, `create`, `implement`
+  - **Fixed**: `fix`, `bug`, `patch`, `resolve`
+  - **Changed**: `refactor`, `update`, `change`, `improve`, `enhance`
+  - **Removed**: `remove`, `delete`, `drop`, `deprecate`
+- Outputs a properly formatted CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format

--- a/changelog-generator/changelog.sh
+++ b/changelog-generator/changelog.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# changelog.sh - Generate a structured CHANGELOG.md from git history
+# Automatically categorizes commits into Added/Fixed/Changed/Removed sections
+# Usage: ./changelog.sh [--since TAG] [--output FILE]
+
+set -euo pipefail
+
+# Defaults
+OUTPUT="CHANGELOG.md"
+SINCE_TAG=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --since) SINCE_TAG="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: ./changelog.sh [--since TAG] [--output FILE]"
+            echo "  --since TAG   Generate changelog since this tag (default: last tag)"
+            echo "  --output FILE Output file (default: CHANGELOG.md)"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Get the last tag if not specified
+if [ -z "$SINCE_TAG" ]; then
+    SINCE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+fi
+
+# Get current version info
+CURRENT_DATE=$(date +%Y-%m-%d)
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "project")")
+
+# Build commit range
+if [ -n "$SINCE_TAG" ]; then
+    RANGE="${SINCE_TAG}..HEAD"
+    VERSION_LABEL="Unreleased (since ${SINCE_TAG})"
+else
+    RANGE=""
+    VERSION_LABEL="All Changes"
+fi
+
+# Get commits
+if [ -n "$RANGE" ]; then
+    COMMITS=$(git log "$RANGE" --pretty=format:"%s|||%h|||%an" 2>/dev/null || echo "")
+else
+    COMMITS=$(git log --pretty=format:"%s|||%h|||%an" 2>/dev/null || echo "")
+fi
+
+if [ -z "$COMMITS" ]; then
+    echo "No commits found."
+    exit 0
+fi
+
+# Categorize commits
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    
+    MSG=$(echo "$line" | cut -d'|||' -f1)
+    HASH=$(echo "$line" | sed 's/.*|||//; s/|||.*//')
+    
+    # Lowercase for matching
+    MSG_LOWER=$(echo "$MSG" | tr '[:upper:]' '[:lower:]')
+    
+    # Categorize based on conventional commit prefixes and keywords
+    if echo "$MSG_LOWER" | grep -qE "^(feat|add|new|create|implement|introduce)"; then
+        ADDED="${ADDED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "^(fix|bug|patch|resolve|repair|correct)"; then
+        FIXED="${FIXED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "^(remove|delete|drop|deprecat|clean)"; then
+        REMOVED="${REMOVED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "^(refactor|update|change|improve|enhance|bump|upgrade|modify|rename|move|migrate|optimi)"; then
+        CHANGED="${CHANGED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(add|new|creat|implement|introduc)"; then
+        ADDED="${ADDED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(fix|bug|patch|resolv|repair|correct)"; then
+        FIXED="${FIXED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(remov|delet|drop|deprecat)"; then
+        REMOVED="${REMOVED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(refactor|updat|chang|improv|enhanc|modif|renam|migrat|optimi)"; then
+        CHANGED="${CHANGED}\n- ${MSG}"
+    else
+        OTHER="${OTHER}\n- ${MSG}"
+    fi
+done <<< "$COMMITS"
+
+# Generate CHANGELOG.md
+{
+    echo "# Changelog"
+    echo ""
+    echo "## ${VERSION_LABEL} Ã¢â¬â ${CURRENT_DATE}"
+    echo ""
+    
+    if [ -n "$ADDED" ]; then
+        echo "### Added"
+        echo -e "$ADDED"
+        echo ""
+    fi
+    
+    if [ -n "$FIXED" ]; then
+        echo "### Fixed"
+        echo -e "$FIXED"
+        echo ""
+    fi
+    
+    if [ -n "$CHANGED" ]; then
+        echo "### Changed"
+        echo -e "$CHANGED"
+        echo ""
+    fi
+    
+    if [ -n "$REMOVED" ]; then
+        echo "### Removed"
+        echo -e "$REMOVED"
+        echo ""
+    fi
+    
+    if [ -n "$OTHER" ]; then
+        echo "### Other"
+        echo -e "$OTHER"
+        echo ""
+    fi
+    
+} > "$OUTPUT"
+
+echo "Ã¢Åâ¦ CHANGELOG generated: ${OUTPUT}"
+echo "   Version: ${VERSION_LABEL}"
+TOTAL=$(echo "$COMMITS" | wc -l)
+echo "   Total commits: ${TOTAL}"

--- a/hooks/block-destructive-bash/README.md
+++ b/hooks/block-destructive-bash/README.md
@@ -1,0 +1,61 @@
+# HOOK: Block Destructive Bash Commands
+
+A Claude Code **PreToolUse** hook that intercepts and blocks dangerous bash commands before they execute.
+
+## Blocked Patterns
+
+| Pattern | Example |
+|---|---|
+| `rm -rf` | `rm -rf /`, `rm -fr /tmp`, `rm -r -f dir` |
+| `DROP TABLE` | `mysql -e 'DROP TABLE users'` |
+| `git push --force` / `-f` | `git push --force origin main` |
+| `TRUNCATE` | `psql -c 'TRUNCATE TABLE users'` |
+| `DELETE FROM` without `WHERE` | `mysql -e 'DELETE FROM users'` |
+
+All SQL patterns are matched case-insensitively. Normal commands (`rm file.txt`, `git push`, `DELETE FROM ... WHERE ...`) pass through unaffected.
+
+## Install (2 commands)
+
+```bash
+cp block-destructive.sh ~/.claude/hooks/block-destructive.sh && chmod +x ~/.claude/hooks/block-destructive.sh
+claude settings set hooks.PreToolUse '[{"matcher":"Bash","hooks":[{"type":"command","command":"bash \"$HOME/.claude/hooks/block-destructive.sh\""}]}]'
+```
+
+## How It Works
+
+1. Claude Code fires a `PreToolUse` event before every Bash tool call
+2. The hook reads the JSON input from stdin, extracts the command
+3. Checks the command against destructive patterns
+4. If matched: logs to `~/.claude/hooks/blocked.log` and returns `permissionDecision: "deny"`
+5. If safe: exits 0 (allow)
+
+## Log Format
+
+Blocked attempts are logged to `~/.claude/hooks/blocked.log`:
+
+```
+2025-01-15T10:30:00Z | BLOCKED | BLOCKED: 'rm -rf' detected. Recursive force deletion is not allowed. | project=/home/user/myproject | command=rm -rf /tmp/build
+```
+
+## Requirements
+
+- `bash`, `jq` (standard on most systems)
+
+## Tests
+
+```bash
+bash test-block-destructive.sh
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `block-destructive.sh` | The hook script |
+| `settings.json` | Example Claude Code settings snippet |
+| `test-block-destructive.sh` | Automated tests |
+| `README.md` | This file |
+
+## License
+
+MIT

--- a/hooks/block-destructive-bash/block-destructive.sh
+++ b/hooks/block-destructive-bash/block-destructive.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# block-destructive.sh — Claude Code PreToolUse hook
+# Blocks dangerous bash commands before execution and logs attempts.
+#
+# Blocked patterns:
+#   - rm -rf (recursive force delete)
+#   - DROP TABLE (SQL table destruction)
+#   - git push --force / -f (force push)
+#   - TRUNCATE (SQL table truncation)
+#   - DELETE FROM without WHERE clause
+#
+# Usage: Configured as a PreToolUse hook in Claude Code settings.
+# Input: JSON on stdin with tool_name and tool_input.command
+# Output: JSON with permissionDecision "deny" if blocked, or exit 0 to allow.
+
+set -euo pipefail
+
+# --- Configuration ---
+LOG_FILE="${HOME}/.claude/hooks/blocked.log"
+
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# --- Read input ---
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+PROJECT_DIR=$(echo "$INPUT" | jq -r '.session.project_directory // .cwd // "unknown"')
+
+# If no command found, allow (not a bash tool call we care about)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# --- Helper: log and deny ---
+deny() {
+  local reason="$1"
+  local timestamp
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  # Log the blocked attempt
+  echo "${timestamp} | BLOCKED | ${reason} | project=${PROJECT_DIR} | command=${COMMAND}" >> "$LOG_FILE"
+
+  # Return deny decision to Claude Code
+  jq -n \
+    --arg reason "$reason" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }'
+  exit 0
+}
+
+# --- Pattern checks ---
+# Each check uses case-insensitive matching where appropriate.
+
+# 1. rm -rf (with any flag ordering like rm -f -r, rm --recursive --force, etc.)
+if echo "$COMMAND" | grep -qE '\brm\b.*-[a-zA-Z]*r[a-zA-Z]*f|\brm\b.*-[a-zA-Z]*f[a-zA-Z]*r|\brm\b.*--recursive.*--force|\brm\b.*--force.*--recursive|\brm\b.*-r\b.*-f\b|\brm\b.*-f\b.*-r\b'; then
+  deny "BLOCKED: 'rm -rf' detected. Recursive force deletion is not allowed."
+fi
+
+# 2. DROP TABLE (SQL — case insensitive)
+if echo "$COMMAND" | grep -qiE '\bDROP\s+TABLE\b'; then
+  deny "BLOCKED: 'DROP TABLE' detected. Dropping database tables is not allowed."
+fi
+
+# 3. git push --force or git push -f
+if echo "$COMMAND" | grep -qE '\bgit\s+push\b.*(\s--force\b|\s-f\b)'; then
+  deny "BLOCKED: 'git push --force' detected. Force pushing is not allowed."
+fi
+
+# 4. TRUNCATE (SQL — case insensitive)
+if echo "$COMMAND" | grep -qiE '\bTRUNCATE\b'; then
+  deny "BLOCKED: 'TRUNCATE' detected. Truncating tables is not allowed."
+fi
+
+# 5. DELETE FROM without WHERE (SQL — case insensitive)
+# Match DELETE FROM ... but ensure no WHERE clause follows
+if echo "$COMMAND" | grep -qiE '\bDELETE\s+FROM\b'; then
+  if ! echo "$COMMAND" | grep -qiE '\bDELETE\s+FROM\b.*\bWHERE\b'; then
+    deny "BLOCKED: 'DELETE FROM' without WHERE clause detected. Unfiltered deletes are not allowed."
+  fi
+fi
+
+# --- All checks passed — allow the command ---
+exit 0

--- a/hooks/block-destructive-bash/settings.json
+++ b/hooks/block-destructive-bash/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/block-destructive.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/block-destructive-bash/test-block-destructive.sh
+++ b/hooks/block-destructive-bash/test-block-destructive.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# test-block-destructive.sh — Tests for the block-destructive hook
+#
+# Runs the hook with simulated Claude Code JSON input and checks results.
+# Requires: jq, bash
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/block-destructive.sh"
+PASS=0
+FAIL=0
+
+# --- Test helpers ---
+run_hook() {
+  local command="$1"
+  local json
+  json=$(jq -n --arg cmd "$command" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd },
+    session: { project_directory: "/tmp/test-project" }
+  }')
+  echo "$json" | bash "$HOOK" 2>/dev/null || true
+}
+
+expect_blocked() {
+  local label="$1"
+  local command="$2"
+  local output
+  output=$(run_hook "$command")
+  if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+    echo "✅ PASS: $label"
+    ((PASS++))
+  else
+    echo "❌ FAIL: $label — expected deny, got: $output"
+    ((FAIL++))
+  fi
+}
+
+expect_allowed() {
+  local label="$1"
+  local command="$2"
+  local output
+  output=$(run_hook "$command")
+  if [ -z "$output" ]; then
+    echo "✅ PASS: $label"
+    ((PASS++))
+  else
+    echo "❌ FAIL: $label — expected allow (empty output), got: $output"
+    ((FAIL++))
+  fi
+}
+
+echo "=== Testing block-destructive.sh ==="
+echo ""
+
+# --- Blocked commands ---
+echo "--- Should BLOCK ---"
+expect_blocked "rm -rf /"               "rm -rf /"
+expect_blocked "rm -rf /tmp/build"      "rm -rf /tmp/build"
+expect_blocked "rm -fr /home"           "rm -fr /home"
+expect_blocked "rm -r -f dir"           "rm -r -f dir"
+expect_blocked "rm -f -r dir"           "rm -f -r dir"
+expect_blocked "sudo rm -rf /"          "sudo rm -rf /"
+expect_blocked "DROP TABLE users"       "mysql -e 'DROP TABLE users'"
+expect_blocked "drop table (lowercase)" "psql -c 'drop table users'"
+expect_blocked "git push --force"       "git push --force origin main"
+expect_blocked "git push -f"            "git push -f origin main"
+expect_blocked "TRUNCATE users"         "mysql -e 'TRUNCATE users'"
+expect_blocked "truncate (lowercase)"   "psql -c 'truncate table users'"
+expect_blocked "DELETE FROM no WHERE"   "mysql -e 'DELETE FROM users'"
+
+# --- Allowed commands ---
+echo ""
+echo "--- Should ALLOW ---"
+expect_allowed "rm single file"         "rm file.txt"
+expect_allowed "rm -r (no -f)"          "rm -r dir/"
+expect_allowed "rm -f (no -r)"          "rm -f file.txt"
+expect_allowed "git push (normal)"      "git push origin main"
+expect_allowed "git push --force-with-lease" "git push --force-with-lease origin main"
+expect_allowed "DELETE FROM with WHERE" "mysql -e 'DELETE FROM users WHERE id=1'"
+expect_allowed "ls -la"                 "ls -la"
+expect_allowed "npm test"               "npm test"
+expect_allowed "echo hello"             "echo hello"
+expect_allowed "grep -r pattern ."      "grep -r pattern ."
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/nextjs-sqlite-claude-md/CLAUDE.md
+++ b/nextjs-sqlite-claude-md/CLAUDE.md
@@ -1,0 +1,210 @@
+# CLAUDE.md â Next.js 15 + SQLite SaaS Project
+
+## Stack & Versions
+
+- **Next.js 15** (App Router only â no Pages Router)
+- **React 19** with Server Components by default
+- **SQLite** via `better-sqlite3` (local dev) / Turso (production)
+- **TypeScript 5.5+** â strict mode, no `any`
+- **Tailwind CSS 4** â utility-first, no CSS modules
+- **Drizzle ORM** â type-safe SQL, no raw queries outside migrations
+
+## Folder Structure
+
+```
+âââ src/
+â   âââ app/                    # Next.js App Router
+â   â   âââ (auth)/             # Route group: login, signup, forgot-password
+â   â   âââ (dashboard)/        # Route group: authenticated pages
+â   â   â   âââ layout.tsx      # Dashboard layout with sidebar
+â   â   â   âââ page.tsx        # Dashboard home
+â   â   â   âââ settings/
+â   â   âââ api/                # API routes (POST/PUT/DELETE only â reads use RSC)
+â   â   âââ layout.tsx          # Root layout
+â   â   âââ page.tsx            # Landing page
+â   âââ components/
+â   â   âââ ui/                 # Reusable primitives (Button, Input, Card)
+â   â   âââ features/           # Feature-specific components (UserAvatar, PricingTable)
+â   âââ db/
+â   â   âââ schema.ts           # Drizzle schema (single source of truth)
+â   â   âââ migrations/         # SQL migration files (sequential, never edited)
+â   â   âââ seed.ts             # Dev seed data
+â   â   âââ index.ts            # DB connection singleton
+â   âââ lib/
+â   â   âââ auth.ts             # Auth helpers (session, middleware)
+â   â   âââ constants.ts        # App-wide constants
+â   â   âââ utils.ts            # Pure utility functions
+â   âââ actions/                # Server Actions (one file per domain)
+â   â   âââ user.actions.ts
+â   â   âââ billing.actions.ts
+â   â   âââ project.actions.ts
+â   âââ types/                  # Shared TypeScript types
+â       âââ index.ts
+âââ drizzle.config.ts
+âââ next.config.ts
+âââ package.json
+```
+
+**Rules:**
+- One `page.tsx` per route. No logic in `page.tsx` â it composes components.
+- Route groups `(name)` for layout sharing. Never nest more than 2 levels deep.
+- `components/ui/` is generic. `components/features/` knows about the domain.
+- `lib/` is pure functions only â no React, no DB, no side effects.
+- `actions/` is the only place Server Actions live. Named `<domain>.actions.ts`.
+
+## Naming Conventions
+
+| What | Convention | Example |
+|------|-----------|---------|
+| Files | `kebab-case` | `user-avatar.tsx` |
+| Components | `PascalCase` | `UserAvatar` |
+| Functions | `camelCase` | `getUserById` |
+| Server Actions | `camelCase`, verb-first | `createProject`, `deleteUser` |
+| DB tables | `snake_case`, plural | `users`, `project_members` |
+| DB columns | `snake_case` | `created_at`, `is_active` |
+| API routes | `route.ts` only | `app/api/webhooks/stripe/route.ts` |
+| Types | `PascalCase`, no `I` prefix | `User`, `ProjectMember` |
+| Constants | `UPPER_SNAKE_CASE` | `MAX_UPLOAD_SIZE` |
+| Env vars | `UPPER_SNAKE_CASE` | `DATABASE_URL` |
+
+## SQL & Migration Conventions
+
+### Schema (Drizzle)
+```typescript
+// src/db/schema.ts â THE source of truth
+export const users = sqliteTable("users", {
+  id: text("id").primaryKey().$defaultFn(() => createId()), // cuid2, never autoincrement
+  email: text("email").notNull().unique(),
+  name: text("name").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+```
+
+**Rules:**
+- **IDs are always `text` with cuid2.** Never `integer` autoincrement. Reason: safe for distributed systems, no enumeration attacks.
+- **Timestamps are `integer` with `mode: "timestamp"`.** SQLite has no native datetime. Unix timestamps are unambiguous.
+- **Every table has `created_at` and `updated_at`.** No exceptions.
+- **Soft delete with `deleted_at` column.** Never hard delete user data.
+
+### Migrations
+```bash
+# Generate migration from schema changes
+npx drizzle-kit generate
+
+# Apply migrations
+npx drizzle-kit migrate
+```
+
+**Rules:**
+- Migrations are **sequential and immutable**. Never edit a committed migration.
+- One migration per logical change. Don't batch unrelated changes.
+- **Always test migrations on a copy of production data** before deploying.
+- Migration files are committed to git. The `migrations/` folder is the migration history.
+
+## Dev Commands
+
+```bash
+npm run dev          # Start Next.js dev server (port 3000)
+npm run db:generate  # Generate migration from schema changes
+npm run db:migrate   # Apply pending migrations
+npm run db:seed      # Seed dev database
+npm run db:studio    # Open Drizzle Studio (DB browser)
+npm run build        # Production build
+npm run lint         # ESLint + type-check
+npm run test         # Vitest
+```
+
+## Component Patterns
+
+### Server Components (default)
+```tsx
+// src/app/(dashboard)/page.tsx
+import { getProjects } from "@/actions/project.actions";
+
+export default async function DashboardPage() {
+  const projects = await getProjects(); // Direct DB access, no API call
+  return <ProjectList projects={projects} />;
+}
+```
+**Why:** Server Components fetch data without client-side waterfalls. No loading spinners for initial data.
+
+### Client Components (opt-in)
+```tsx
+"use client"; // Only when you need interactivity
+
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(c => c + 1)}>{count}</button>;
+}
+```
+**Why:** Client Components add JS bundle size. Only use when you need browser APIs, state, or event handlers.
+
+### Server Actions (mutations)
+```typescript
+// src/actions/project.actions.ts
+"use server";
+
+import { db } from "@/db";
+import { projects } from "@/db/schema";
+import { revalidatePath } from "next/cache";
+
+export async function createProject(formData: FormData) {
+  const name = formData.get("name") as string;
+  await db.insert(projects).values({ name });
+  revalidatePath("/dashboard");
+}
+```
+**Why:** Server Actions colocate mutation logic server-side. No API route boilerplate for form submissions.
+
+### Error Handling
+```tsx
+// src/app/(dashboard)/error.tsx
+"use client";
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div>
+      <h2>Something went wrong</h2>
+      <button onClick={reset}>Try again</button>
+    </div>
+  );
+}
+```
+**Every route group gets an `error.tsx`.** Errors bubble up to the nearest error boundary.
+
+## What We Don't Do (and Why)
+
+| Anti-pattern | Why not | Do this instead |
+|-------------|---------|-----------------|
+| `getServerSideProps` / `getStaticProps` | Pages Router patterns. We use App Router. | Use Server Components + `fetch` or direct DB queries |
+| Raw SQL strings | SQL injection risk, no type safety | Use Drizzle ORM query builder |
+| `useEffect` for data fetching | Client-side waterfalls, loading spinners | Server Components fetch data at render time |
+| API routes for reads | Unnecessary network hop | Server Components read directly from DB |
+| `any` type | Defeats TypeScript's purpose | Use proper types, `unknown` if truly unknown |
+| CSS modules / styled-components | Bundle bloat, naming conflicts | Tailwind utility classes |
+| Prisma | No native SQLite support without adapter, heavier | Drizzle ORM (built for SQLite) |
+| UUID v4 for IDs | 36 chars, not sortable, poor index performance | cuid2 (shorter, sortable, collision-resistant) |
+| `moment` / `dayjs` | Unnecessary dependency | Native `Date` + `Intl.DateTimeFormat` |
+| Barrel exports (`index.ts` re-exporting) | Kills tree-shaking, circular dep risk | Import directly from source file |
+| Storing files in SQLite | BLOB performance degrades | Use S3/R2 + store URL in DB |
+| JWT for sessions | Can't revoke, complexity | Server-side sessions with SQLite storage |
+
+## Environment Variables
+
+```env
+# .env.local (never committed)
+DATABASE_URL=file:./dev.db           # Local SQLite path
+DATABASE_AUTH_TOKEN=                  # Turso auth token (production only)
+NEXTAUTH_SECRET=                     # Random 32+ char string
+NEXTAUTH_URL=http://localhost:3000
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+**Rules:**
+- `.env.local` is gitignored. Always.
+- `.env.example` is committed with dummy values.
+- Access env vars through `process.env` only in `lib/constants.ts`. Never scatter `process.env` calls.


### PR DESCRIPTION
## HOOK: Block Destructive Bash Commands

A Claude Code **PreToolUse** hook that intercepts and blocks dangerous bash commands before they execute.

Closes #3

### Blocked Patterns (5)

1. **`rm -rf`** — Recursive force deletion (catches `rm -rf`, `rm -fr`, `rm -r -f`, etc.)
2. **`DROP TABLE`** — SQL table destruction (case-insensitive)
3. **`git push --force / -f`** — Force pushing to remote
4. **`TRUNCATE`** — SQL table truncation (case-insensitive)
5. **`DELETE FROM` without `WHERE`** — Unfiltered SQL deletes (case-insensitive)

### How It Works

- Configured as a `PreToolUse` hook matching the `Bash` tool
- Reads JSON input from stdin, extracts the command
- Checks against destructive patterns using grep
- Returns `permissionDecision: "deny"` if matched, exits 0 (allow) if safe
- Logs all blocked attempts to `~/.claude/hooks/blocked.log`

### Files

| File | Purpose |
|---|---|
| `block-destructive.sh` | The hook script |
| `settings.json` | Example Claude Code settings snippet |
| `test-block-destructive.sh` | 23 automated test cases (13 block + 10 allow) |
| `README.md` | Documentation with install instructions |

### Test Coverage (23 cases)

**Should block (13):** rm -rf /, rm -rf /tmp/build, rm -fr, rm -r -f, rm -f -r, sudo rm -rf, DROP TABLE, drop table, git push --force, git push -f, TRUNCATE, truncate, DELETE FROM (no WHERE)

**Should allow (10):** rm file.txt, rm -r (no -f), rm -f (no -r), git push (normal), git push --force-with-lease, DELETE FROM ... WHERE, ls -la, npm test, echo hello, grep -r

### Install (2 commands)

```bash
cp block-destructive.sh ~/.claude/hooks/block-destructive.sh && chmod +x ~/.claude/hooks/block-destructive.sh
```

```bash
claude settings set hooks.PreToolUse '[{"matcher":"Bash","hooks":[{"type":"command","command":"bash \"$HOME/.claude/hooks/block-destructive.sh\""}]}]'
```

### Requirements

- `bash`, `jq` (standard on most systems)
