### PR TITLE
n8n workflow: Weekly Dev Summary with Claude API

### DIFF
--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -1,0 +1,32 @@
+# Generate Structured CHANGELOG from Git History
+
+Automatically generate a categorized `CHANGELOG.md` from your project's git history.
+
+## Setup (3 steps)
+
+1. **Download:** Copy `changelog.sh` to your project root
+2. **Make executable:** `chmod +x changelog.sh`
+3. **Run:** `./changelog.sh`
+
+## Usage
+
+```bash
+# Generate changelog since last tag
+./changelog.sh
+
+# Generate since a specific tag
+./changelog.sh --since v1.2.0
+
+# Custom output file
+./changelog.sh --output CHANGES.md
+```
+
+## How It Works
+
+- Fetches all commits since the last git tag (or all commits if no tags)
+- Auto-categorizes based on conventional commit prefixes and keywords:
+  - **Added**: `feat`, `add`, `new`, `create`, `implement`
+  - **Fixed**: `fix`, `bug`, `patch`, `resolve`
+  - **Changed**: `refactor`, `update`, `change`, `improve`, `enhance`
+  - **Removed**: `remove`, `delete`, `drop`, `deprecate`
+- Outputs a properly formatted CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format

--- a/changelog-generator/changelog.sh
+++ b/changelog-generator/changelog.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# changelog.sh - Generate a structured CHANGELOG.md from git history
+# Automatically categorizes commits into Added/Fixed/Changed/Removed sections
+# Usage: ./changelog.sh [--since TAG] [--output FILE]
+
+set -euo pipefail
+
+# Defaults
+OUTPUT="CHANGELOG.md"
+SINCE_TAG=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --since) SINCE_TAG="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: ./changelog.sh [--since TAG] [--output FILE]"
+            echo "  --since TAG   Generate changelog since this tag (default: last tag)"
+            echo "  --output FILE Output file (default: CHANGELOG.md)"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Get the last tag if not specified
+if [ -z "$SINCE_TAG" ]; then
+    SINCE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+fi
+
+# Get current version info
+CURRENT_DATE=$(date +%Y-%m-%d)
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "project")")
+
+# Build commit range
+if [ -n "$SINCE_TAG" ]; then
+    RANGE="${SINCE_TAG}..HEAD"
+    VERSION_LABEL="Unreleased (since ${SINCE_TAG})"
+else
+    RANGE=""
+    VERSION_LABEL="All Changes"
+fi
+
+# Get commits
+if [ -n "$RANGE" ]; then
+    COMMITS=$(git log "$RANGE" --pretty=format:"%s|||%h|||%an" 2>/dev/null || echo "")
+else
+    COMMITS=$(git log --pretty=format:"%s|||%h|||%an" 2>/dev/null || echo "")
+fi
+
+if [ -z "$COMMITS" ]; then
+    echo "No commits found."
+    exit 0
+fi
+
+# Categorize commits
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    
+    MSG=$(echo "$line" | cut -d'|||' -f1)
+    HASH=$(echo "$line" | sed 's/.*|||//; s/|||.*//')
+    
+    # Lowercase for matching
+    MSG_LOWER=$(echo "$MSG" | tr '[:upper:]' '[:lower:]')
+    
+    # Categorize based on conventional commit prefixes and keywords
+    if echo "$MSG_LOWER" | grep -qE "^(feat|add|new|create|implement|introduce)"; then
+        ADDED="${ADDED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "^(fix|bug|patch|resolve|repair|correct)"; then
+        FIXED="${FIXED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "^(remove|delete|drop|deprecat|clean)"; then
+        REMOVED="${REMOVED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "^(refactor|update|change|improve|enhance|bump|upgrade|modify|rename|move|migrate|optimi)"; then
+        CHANGED="${CHANGED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(add|new|creat|implement|introduc)"; then
+        ADDED="${ADDED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(fix|bug|patch|resolv|repair|correct)"; then
+        FIXED="${FIXED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(remov|delet|drop|deprecat)"; then
+        REMOVED="${REMOVED}\n- ${MSG}"
+    elif echo "$MSG_LOWER" | grep -qE "(refactor|updat|chang|improv|enhanc|modif|renam|migrat|optimi)"; then
+        CHANGED="${CHANGED}\n- ${MSG}"
+    else
+        OTHER="${OTHER}\n- ${MSG}"
+    fi
+done <<< "$COMMITS"
+
+# Generate CHANGELOG.md
+{
+    echo "# Changelog"
+    echo ""
+    echo "## ${VERSION_LABEL} Ã¢â¬â ${CURRENT_DATE}"
+    echo ""
+    
+    if [ -n "$ADDED" ]; then
+        echo "### Added"
+        echo -e "$ADDED"
+        echo ""
+    fi
+    
+    if [ -n "$FIXED" ]; then
+        echo "### Fixed"
+        echo -e "$FIXED"
+        echo ""
+    fi
+    
+    if [ -n "$CHANGED" ]; then
+        echo "### Changed"
+        echo -e "$CHANGED"
+        echo ""
+    fi
+    
+    if [ -n "$REMOVED" ]; then
+        echo "### Removed"
+        echo -e "$REMOVED"
+        echo ""
+    fi
+    
+    if [ -n "$OTHER" ]; then
+        echo "### Other"
+        echo -e "$OTHER"
+        echo ""
+    fi
+    
+} > "$OUTPUT"
+
+echo "Ã¢Åâ¦ CHANGELOG generated: ${OUTPUT}"
+echo "   Version: ${VERSION_LABEL}"
+TOTAL=$(echo "$COMMITS" | wc -l)
+echo "   Total commits: ${TOTAL}"

--- a/n8n-weekly-dev-summary/README.md
+++ b/n8n-weekly-dev-summary/README.md
@@ -1,0 +1,87 @@
+# Weekly Dev Summary — n8n + Claude API
+
+Automated weekly narrative summary of GitHub repo activity, powered by Claude claude-sonnet-4-20250514.
+
+## What It Does
+
+Every Friday at 5 PM, this workflow:
+
+1. Fetches the past week's **commits**, **closed issues**, and **merged PRs** from GitHub
+2. Sends the data to **Claude API** to generate an engaging narrative summary
+3. Posts the summary to a **Discord** channel via webhook
+
+If there's no activity, it skips the Claude call and reports "no activity" instead.
+
+## Setup (5 Steps)
+
+### 1. Import the Workflow
+
+In n8n, go to **Workflows → Import from File** and select `workflow.json`.
+
+### 2. Create GitHub Token Credential
+
+- Go to **Settings → Credentials → Add Credential → Header Auth**
+- Name: `GitHub Token`
+- Header Name: `Authorization`
+- Header Value: `Bearer ghp_YOUR_GITHUB_TOKEN`
+
+Your GitHub token needs `repo` scope (or just `public_repo` for public repos).
+
+### 3. Create Anthropic API Key Credential
+
+- Go to **Settings → Credentials → Add Credential → Header Auth**
+- Name: `Anthropic API Key`
+- Header Name: `x-api-key`
+- Header Value: `sk-ant-YOUR_ANTHROPIC_KEY`
+
+### 4. Set Environment Variables
+
+In n8n **Settings → Environment Variables**, add:
+
+| Variable | Example | Required |
+|---|---|---|
+| `GITHUB_REPO` | `owner/repo-name` | Yes |
+| `SUMMARY_LANGUAGE` | `EN` or `FR` | No (default: EN) |
+| `DISCORD_WEBHOOK_URL` | `https://discord.com/api/webhooks/...` | Yes |
+
+### 5. Activate & Test
+
+- Click **Execute Workflow** to test manually
+- Toggle the workflow **Active** to enable the weekly cron
+
+## Configuration
+
+- **Schedule**: Edit the "Weekly Cron" node to change day/time (default: Friday 5 PM)
+- **Language**: Set `SUMMARY_LANGUAGE` to `FR` for French summaries
+- **Model**: Uses `claude-sonnet-4-20250514` — change in the Claude API node body if needed
+- **Delivery**: Uses Discord webhook. To switch to Slack, replace the webhook URL (Slack incoming webhooks use the same `content` → `text` format — update the JSON body key)
+
+## Workflow Architecture
+
+```
+Cron (Fri 5pm)
+  → Set Variables (repo, language, date range)
+    → [Parallel] Fetch Commits | Fetch Issues | Fetch PRs
+      → Merge All Data
+        → Process & Shape (Code node: filter, dedupe, format)
+          → Has Activity?
+            → YES → Claude API → Extract Text → Discord Webhook
+            → NO  → "No activity" message
+```
+
+## Edge Cases Handled
+
+- **No activity**: Skips Claude API call, avoids wasting tokens
+- **Large repos**: Caps at 100 items per category, truncates to 50 for Claude prompt
+- **Empty/error responses**: Safe array handling in the Code node
+- **Discord message limit**: Truncates summary to 1900 chars
+- **PR vs Issue dedup**: Filters out PRs from the issues endpoint (GitHub returns PRs as issues)
+- **Merged-only PRs**: Only includes actually merged PRs, not just closed ones
+
+## Cost Estimate
+
+~$0.01–0.03 per weekly run (one Claude API call with ~2K input tokens).
+
+## License
+
+MIT

--- a/n8n-weekly-dev-summary/workflow.json
+++ b/n8n-weekly-dev-summary/workflow.json
@@ -1,0 +1,415 @@
+{
+  "name": "Weekly Dev Summary — GitHub + Claude API",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "triggerAtHour": 17,
+              "triggerAtDay": 5
+            }
+          ]
+        }
+      },
+      "id": "cron-trigger",
+      "name": "Weekly Cron (Friday 5pm)",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "repo",
+              "name": "repo",
+              "value": "={{ $env.GITHUB_REPO || 'claude-builders-bounty/claude-builders-bounty' }}",
+              "type": "string"
+            },
+            {
+              "id": "language",
+              "name": "language",
+              "value": "={{ $env.SUMMARY_LANGUAGE || 'EN' }}",
+              "type": "string"
+            },
+            {
+              "id": "since",
+              "name": "since",
+              "value": "={{ new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "set-vars",
+      "name": "Set Variables",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [220, 0]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $json.repo }}/commits?since={{ $json.since }}&per_page=100",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "fetch-commits",
+      "name": "Fetch Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, -200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-token",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Set Variables').item.json.repo }}/issues?state=closed&since={{ $('Set Variables').item.json.since }}&per_page=100",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "fetch-issues",
+      "name": "Fetch Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 0],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-token",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Set Variables').item.json.repo }}/pulls?state=closed&sort=updated&direction=desc&per_page=100",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "fetch-prs",
+      "name": "Fetch Merged PRs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-token",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "multiplex",
+        "mergeByFields": {},
+        "options": {}
+      },
+      "id": "merge-data",
+      "name": "Merge All Data",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [700, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Collect data from all 3 GitHub API responses\nconst allItems = $input.all();\n\n// Helper: safely get array from response (handles empty/error)\nfunction safeArray(data) {\n  if (Array.isArray(data)) return data;\n  if (data && Array.isArray(data.json)) return data.json;\n  return [];\n}\n\n// The merge node gives us items from each input\n// We need to separate commits, issues, and PRs\nconst commits = [];\nconst closedIssues = [];\nconst mergedPRs = [];\n\nconst since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);\n\nfor (const item of allItems) {\n  const d = item.json;\n  if (!d) continue;\n  \n  // Detect type by shape\n  if (d.sha && d.commit) {\n    // It's a commit\n    commits.push({\n      sha: d.sha.substring(0, 7),\n      message: d.commit.message.split('\\n')[0],\n      author: d.commit.author?.name || d.author?.login || 'unknown',\n      date: d.commit.author?.date\n    });\n  } else if (d.pull_request && d.pull_request.merged_at) {\n    // It's a merged PR (from issues endpoint — has pull_request key)\n    // Skip, we handle PRs from the PR endpoint\n  } else if (d.merged_at && new Date(d.merged_at) >= since) {\n    // It's a merged PR from pulls endpoint\n    mergedPRs.push({\n      number: d.number,\n      title: d.title,\n      author: d.user?.login || 'unknown',\n      merged_at: d.merged_at\n    });\n  } else if (d.number && d.state === 'closed' && !d.pull_request) {\n    // It's a closed issue (not a PR)\n    closedIssues.push({\n      number: d.number,\n      title: d.title,\n      closed_by: d.user?.login || 'unknown',\n      labels: (d.labels || []).map(l => l.name).join(', ')\n    });\n  }\n}\n\nconst repo = $('Set Variables').first().json.repo;\nconst language = $('Set Variables').first().json.language;\n\nreturn [{\n  json: {\n    repo,\n    language,\n    commits_count: commits.length,\n    issues_count: closedIssues.length,\n    prs_count: mergedPRs.length,\n    commits: commits.slice(0, 50),\n    closed_issues: closedIssues.slice(0, 50),\n    merged_prs: mergedPRs.slice(0, 50),\n    has_activity: commits.length > 0 || closedIssues.length > 0 || mergedPRs.length > 0\n  }\n}];\n"
+      },
+      "id": "process-data",
+      "name": "Process & Shape Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 0]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-activity",
+              "leftValue": "={{ $json.has_activity }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "check-activity",
+      "name": "Has Activity?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1140, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"You are a developer relations writer. Generate a concise, engaging weekly development summary for the GitHub repository: {{ $json.repo }}.\\n\\nLanguage: {{ $json.language === 'FR' ? 'French' : 'English' }}\\n\\nThis week's activity:\\n- {{ $json.commits_count }} commits\\n- {{ $json.issues_count }} closed issues\\n- {{ $json.prs_count }} merged pull requests\\n\\nCommits:\\n{{ JSON.stringify($json.commits) }}\\n\\nClosed Issues:\\n{{ JSON.stringify($json.closed_issues) }}\\n\\nMerged PRs:\\n{{ JSON.stringify($json.merged_prs) }}\\n\\nWrite a narrative summary with these sections:\\n1. 🏆 Highlights (top 2-3 achievements)\\n2. 📝 Commits Overview\\n3. 🐛 Issues Resolved\\n4. 🔀 Pull Requests Merged\\n5. 📊 Stats (one-liner)\\n\\nKeep it under 500 words. Use markdown formatting. Be specific about what changed — don't be generic.\"\n    }\n  ]\n}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 60000
+        }
+      },
+      "id": "call-claude",
+      "name": "Claude API — Generate Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, -100],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "anthropic-key",
+          "name": "Anthropic API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "summary",
+              "name": "summary",
+              "value": "={{ $json.content[0].text }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "extract-summary",
+      "name": "Extract Summary Text",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1600, -100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.DISCORD_WEBHOOK_URL }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"content\": \"📋 **Weekly Dev Summary — {{ $('Set Variables').first().json.repo }}**\\n\\n{{ $json.summary.substring(0, 1900) }}\"\n}",
+        "options": {}
+      },
+      "id": "send-discord",
+      "name": "Send to Discord",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1820, -100]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "msg",
+              "name": "message",
+              "value": "No activity detected for {{ $json.repo }} this week. Nothing to summarize. 🏖️",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "no-activity",
+      "name": "No Activity This Week",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1380, 100]
+    }
+  ],
+  "connections": {
+    "Weekly Cron (Friday 5pm)": {
+      "main": [
+        [
+          {
+            "node": "Set Variables",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Variables": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed Issues",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Merged PRs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits": {
+      "main": [
+        [
+          {
+            "node": "Merge All Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed Issues": {
+      "main": [
+        [
+          {
+            "node": "Merge All Data",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Fetch Merged PRs": {
+      "main": [
+        [
+          {
+            "node": "Merge All Data",
+            "type": "main",
+            "index": 2
+          }
+        ]
+      ]
+    },
+    "Merge All Data": {
+      "main": [
+        [
+          {
+            "node": "Process & Shape Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process & Shape Data": {
+      "main": [
+        [
+          {
+            "node": "Has Activity?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Activity?": {
+      "main": [
+        [
+          {
+            "node": "Claude API — Generate Summary",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Activity This Week",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude API — Generate Summary": {
+      "main": [
+        [
+          {
+            "node": "Extract Summary Text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Summary Text": {
+      "main": [
+        [
+          {
+            "node": "Send to Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {
+      "name": "weekly-summary"
+    },
+    {
+      "name": "claude-api"
+    }
+  ]
+}

--- a/nextjs-sqlite-claude-md/CLAUDE.md
+++ b/nextjs-sqlite-claude-md/CLAUDE.md
@@ -1,0 +1,210 @@
+# CLAUDE.md â Next.js 15 + SQLite SaaS Project
+
+## Stack & Versions
+
+- **Next.js 15** (App Router only â no Pages Router)
+- **React 19** with Server Components by default
+- **SQLite** via `better-sqlite3` (local dev) / Turso (production)
+- **TypeScript 5.5+** â strict mode, no `any`
+- **Tailwind CSS 4** â utility-first, no CSS modules
+- **Drizzle ORM** â type-safe SQL, no raw queries outside migrations
+
+## Folder Structure
+
+```
+âââ src/
+â   âââ app/                    # Next.js App Router
+â   â   âââ (auth)/             # Route group: login, signup, forgot-password
+â   â   âââ (dashboard)/        # Route group: authenticated pages
+â   â   â   âââ layout.tsx      # Dashboard layout with sidebar
+â   â   â   âââ page.tsx        # Dashboard home
+â   â   â   âââ settings/
+â   â   âââ api/                # API routes (POST/PUT/DELETE only â reads use RSC)
+â   â   âââ layout.tsx          # Root layout
+â   â   âââ page.tsx            # Landing page
+â   âââ components/
+â   â   âââ ui/                 # Reusable primitives (Button, Input, Card)
+â   â   âââ features/           # Feature-specific components (UserAvatar, PricingTable)
+â   âââ db/
+â   â   âââ schema.ts           # Drizzle schema (single source of truth)
+â   â   âââ migrations/         # SQL migration files (sequential, never edited)
+â   â   âââ seed.ts             # Dev seed data
+â   â   âââ index.ts            # DB connection singleton
+â   âââ lib/
+â   â   âââ auth.ts             # Auth helpers (session, middleware)
+â   â   âââ constants.ts        # App-wide constants
+â   â   âââ utils.ts            # Pure utility functions
+â   âââ actions/                # Server Actions (one file per domain)
+â   â   âââ user.actions.ts
+â   â   âââ billing.actions.ts
+â   â   âââ project.actions.ts
+â   âââ types/                  # Shared TypeScript types
+â       âââ index.ts
+âââ drizzle.config.ts
+âââ next.config.ts
+âââ package.json
+```
+
+**Rules:**
+- One `page.tsx` per route. No logic in `page.tsx` â it composes components.
+- Route groups `(name)` for layout sharing. Never nest more than 2 levels deep.
+- `components/ui/` is generic. `components/features/` knows about the domain.
+- `lib/` is pure functions only â no React, no DB, no side effects.
+- `actions/` is the only place Server Actions live. Named `<domain>.actions.ts`.
+
+## Naming Conventions
+
+| What | Convention | Example |
+|------|-----------|---------|
+| Files | `kebab-case` | `user-avatar.tsx` |
+| Components | `PascalCase` | `UserAvatar` |
+| Functions | `camelCase` | `getUserById` |
+| Server Actions | `camelCase`, verb-first | `createProject`, `deleteUser` |
+| DB tables | `snake_case`, plural | `users`, `project_members` |
+| DB columns | `snake_case` | `created_at`, `is_active` |
+| API routes | `route.ts` only | `app/api/webhooks/stripe/route.ts` |
+| Types | `PascalCase`, no `I` prefix | `User`, `ProjectMember` |
+| Constants | `UPPER_SNAKE_CASE` | `MAX_UPLOAD_SIZE` |
+| Env vars | `UPPER_SNAKE_CASE` | `DATABASE_URL` |
+
+## SQL & Migration Conventions
+
+### Schema (Drizzle)
+```typescript
+// src/db/schema.ts â THE source of truth
+export const users = sqliteTable("users", {
+  id: text("id").primaryKey().$defaultFn(() => createId()), // cuid2, never autoincrement
+  email: text("email").notNull().unique(),
+  name: text("name").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+```
+
+**Rules:**
+- **IDs are always `text` with cuid2.** Never `integer` autoincrement. Reason: safe for distributed systems, no enumeration attacks.
+- **Timestamps are `integer` with `mode: "timestamp"`.** SQLite has no native datetime. Unix timestamps are unambiguous.
+- **Every table has `created_at` and `updated_at`.** No exceptions.
+- **Soft delete with `deleted_at` column.** Never hard delete user data.
+
+### Migrations
+```bash
+# Generate migration from schema changes
+npx drizzle-kit generate
+
+# Apply migrations
+npx drizzle-kit migrate
+```
+
+**Rules:**
+- Migrations are **sequential and immutable**. Never edit a committed migration.
+- One migration per logical change. Don't batch unrelated changes.
+- **Always test migrations on a copy of production data** before deploying.
+- Migration files are committed to git. The `migrations/` folder is the migration history.
+
+## Dev Commands
+
+```bash
+npm run dev          # Start Next.js dev server (port 3000)
+npm run db:generate  # Generate migration from schema changes
+npm run db:migrate   # Apply pending migrations
+npm run db:seed      # Seed dev database
+npm run db:studio    # Open Drizzle Studio (DB browser)
+npm run build        # Production build
+npm run lint         # ESLint + type-check
+npm run test         # Vitest
+```
+
+## Component Patterns
+
+### Server Components (default)
+```tsx
+// src/app/(dashboard)/page.tsx
+import { getProjects } from "@/actions/project.actions";
+
+export default async function DashboardPage() {
+  const projects = await getProjects(); // Direct DB access, no API call
+  return <ProjectList projects={projects} />;
+}
+```
+**Why:** Server Components fetch data without client-side waterfalls. No loading spinners for initial data.
+
+### Client Components (opt-in)
+```tsx
+"use client"; // Only when you need interactivity
+
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(c => c + 1)}>{count}</button>;
+}
+```
+**Why:** Client Components add JS bundle size. Only use when you need browser APIs, state, or event handlers.
+
+### Server Actions (mutations)
+```typescript
+// src/actions/project.actions.ts
+"use server";
+
+import { db } from "@/db";
+import { projects } from "@/db/schema";
+import { revalidatePath } from "next/cache";
+
+export async function createProject(formData: FormData) {
+  const name = formData.get("name") as string;
+  await db.insert(projects).values({ name });
+  revalidatePath("/dashboard");
+}
+```
+**Why:** Server Actions colocate mutation logic server-side. No API route boilerplate for form submissions.
+
+### Error Handling
+```tsx
+// src/app/(dashboard)/error.tsx
+"use client";
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div>
+      <h2>Something went wrong</h2>
+      <button onClick={reset}>Try again</button>
+    </div>
+  );
+}
+```
+**Every route group gets an `error.tsx`.** Errors bubble up to the nearest error boundary.
+
+## What We Don't Do (and Why)
+
+| Anti-pattern | Why not | Do this instead |
+|-------------|---------|-----------------|
+| `getServerSideProps` / `getStaticProps` | Pages Router patterns. We use App Router. | Use Server Components + `fetch` or direct DB queries |
+| Raw SQL strings | SQL injection risk, no type safety | Use Drizzle ORM query builder |
+| `useEffect` for data fetching | Client-side waterfalls, loading spinners | Server Components fetch data at render time |
+| API routes for reads | Unnecessary network hop | Server Components read directly from DB |
+| `any` type | Defeats TypeScript's purpose | Use proper types, `unknown` if truly unknown |
+| CSS modules / styled-components | Bundle bloat, naming conflicts | Tailwind utility classes |
+| Prisma | No native SQLite support without adapter, heavier | Drizzle ORM (built for SQLite) |
+| UUID v4 for IDs | 36 chars, not sortable, poor index performance | cuid2 (shorter, sortable, collision-resistant) |
+| `moment` / `dayjs` | Unnecessary dependency | Native `Date` + `Intl.DateTimeFormat` |
+| Barrel exports (`index.ts` re-exporting) | Kills tree-shaking, circular dep risk | Import directly from source file |
+| Storing files in SQLite | BLOB performance degrades | Use S3/R2 + store URL in DB |
+| JWT for sessions | Can't revoke, complexity | Server-side sessions with SQLite storage |
+
+## Environment Variables
+
+```env
+# .env.local (never committed)
+DATABASE_URL=file:./dev.db           # Local SQLite path
+DATABASE_AUTH_TOKEN=                  # Turso auth token (production only)
+NEXTAUTH_SECRET=                     # Random 32+ char string
+NEXTAUTH_URL=http://localhost:3000
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+**Rules:**
+- `.env.local` is gitignored. Always.
+- `.env.example` is committed with dummy values.
+- Access env vars through `process.env` only in `lib/constants.ts`. Never scatter `process.env` calls.


### PR DESCRIPTION
## n8n Workflow: Weekly Dev Summary with Claude API

Automated weekly narrative summary of GitHub repo activity, powered by Claude claude-sonnet-4-20250514.

Closes #5

### What It Does

Every Friday at 5 PM, this workflow:

1. Fetches the past week's **commits**, **closed issues**, and **merged PRs** from GitHub
2. Sends the data to **Claude API** (claude-sonnet-4-20250514) to generate an engaging narrative summary
3. Posts the summary to a **Discord** channel via webhook

### Architecture

```
Cron (Fri 5pm)
  → Set Variables (repo, language, date range)
    → [Parallel] Fetch Commits | Fetch Issues | Fetch PRs
      → Merge All Data
        → Process & Shape (Code node)
          → Has Activity?
            → YES → Claude API → Discord Webhook
            → NO  → "No activity" message
```

### Edge Cases Handled

- **No activity**: Skips Claude API call, avoids wasting tokens
- **Large repos**: Caps at 100 items per category, truncates to 50 for Claude prompt
- **PR vs Issue dedup**: Filters out PRs from the issues endpoint
- **Merged-only PRs**: Only includes actually merged PRs, not just closed ones
- **Discord message limit**: Truncates summary to 1900 chars

### Setup

1. Import `workflow.json` in n8n
2. Create GitHub Token credential (Header Auth)
3. Create Anthropic API Key credential (Header Auth)
4. Set environment variables: `GITHUB_REPO`, `DISCORD_WEBHOOK_URL`, optionally `SUMMARY_LANGUAGE`
5. Activate & test

### Cost

~$0.01–0.03 per weekly run (one Claude API call).

### Files

| File | Purpose |
|---|---|
| `workflow.json` | The n8n workflow (import directly) |
| `README.md` | Full documentation |
