### PR TITLE
feat: HOOK — Pre-tool-use hook that blocks destructive bash commands (00)

### DIFF
--- a/skills/pre-tool-hook/README.md
+++ b/skills/pre-tool-hook/README.md
@@ -1,0 +1,46 @@
+# Pre-Tool-Use Hook — Block Destructive Bash Commands
+
+A Claude Code `pre-tool-use` hook that blocks dangerous bash commands before execution.
+
+## Installation (2 Commands)
+
+```bash
+# 1. Download the hook script
+curl -sO https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/skills/pre-tool-hook/pre-tool-hook.py
+chmod +x pre-tool-hook.py
+
+# 2. Register it in Claude Code settings (~/.claude/settings.json)
+# Add this block:
+#   "hooks": {
+#     "pre-tool-use": "/full/path/to/pre-tool-hook.py"
+#   }
+```
+
+## What It Blocks
+
+| Pattern | Description |
+|---------|-------------|
+| `rm -rf /...` | Recursive forced deletion |
+| `DROP TABLE` / `DROP DATABASE` | SQL destruction |
+| `git push --force` | Forced git push |
+| `TRUNCATE TABLE` | SQL table truncation |
+| `DELETE FROM` (no WHERE) | Unsafe bulk delete |
+| `mkfs.*` | Filesystem formatting |
+| `dd ... /dev/` | Direct block device write |
+
+## Log Location
+
+All blocked attempts → `~/.claude/hooks/blocked.log`
+
+```
+[2026-03-29T18:00:00Z] BLOCKED | tool=Bash | project=/path/to/repo | reason=... | command=...
+```
+
+## Requirements
+
+- Python 3.6+
+- Claude Code v1.0+
+
+## Customize
+
+Edit `DANGEROUS_PATTERNS` in `pre-tool-hook.py` to add your own rules.

--- a/skills/pre-tool-hook/SKILL.md
+++ b/skills/pre-tool-hook/SKILL.md
@@ -1,0 +1,34 @@
+# SKILL: Pre-Tool-Use Hook — Block Destructive Bash Commands
+
+## What It Does
+
+A Claude Code `pre-tool-use` hook that intercepts dangerous bash/SQL commands before they execute, blocks them, and logs the attempt.
+
+## How It Works
+
+1. Claude Code calls a tool
+2. The hook (placed in `~/.claude/hooks/`) receives the tool name and arguments
+3. If the command matches a dangerous pattern → **blocked**, logged to `~/.claude/hooks/blocked.log`
+4. If safe → passes through without interference
+
+## Blocked Patterns
+
+| Pattern | Danger |
+|---------|--------|
+| `rm -rf ...` | Recursive forced deletion |
+| `DROP TABLE` / `DROP DATABASE` | SQL destruction |
+| `git push --force` | Forced push to remote |
+| `TRUNCATE TABLE` / `TRUNCATE DATABASE` | SQL table truncation |
+| `DELETE FROM` without `WHERE` | Unconditional bulk delete |
+| `mkfs.*` | Filesystem format |
+| `dd ... /dev/` | Direct block device write |
+
+## Log Format
+
+```
+[2026-03-29T18:00:00Z] BLOCKED | tool=Bash | project=/path/to/repo | reason=Recursive forced deletion | command=rm -rf /tmp/test
+```
+
+## Installation
+
+See `README.md` for 2-command setup.

--- a/skills/pre-tool-hook/pre-tool-hook.py
+++ b/skills/pre-tool-hook/pre-tool-hook.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+pre-tool-hook.py — Claude Code pre-tool-use hook that blocks destructive commands.
+Blocks: rm -rf, DROP TABLE, git push --force, TRUNCATE, DELETE without WHERE, etc.
+Logs all blocked attempts to ~/.claude/hooks/blocked.log with timestamp + project.
+"""
+
+import sys
+import json
+import os
+import re
+from datetime import datetime, timezone
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+DANGEROUS_PATTERNS = [
+    (r'rm\s+-rf\s+[/a-zA-Z0-9_\-\.]+', "Recursive forced deletion"),
+    (r'rm\s+-[rf]+\s+/\s', "Deletion at root level"),
+    (r'DROP\s+TABLE', "SQL DROP TABLE statement"),
+    (r'DROP\s+DATABASE', "SQL DROP DATABASE statement"),
+    (r'git\s+push\s+--force', "Forced git push"),
+    (r'git\s+push\s+-f', "Forced git push (-f flag)"),
+    (r'TRUNCATE\s+TABLE', "SQL TRUNCATE TABLE statement"),
+    (r'DELETE\s+FROM\s+\w+\s*;?\s*$', "SQL DELETE without WHERE clause"),
+    (r'DELETE\s+FROM\s+\w+\s+WHERE\s+1\s*=\s*1', "SQL DELETE with always-true WHERE"),
+    (r';\s*rm\s+', "Command injection via rm"),
+    (r'eval\s+\$', "Eval of shell variable — potential injection"),
+    (r'>\s*/dev/sd', "Direct write to block device"),
+    (r'mkfs\.', "Filesystem format command"),
+    (r'dd\s+if=.*of=/dev/', "Direct dd to block device"),
+]
+
+
+def log_blocked(tool_name: str, command: str, reason: str, project: str):
+    """Append blocked attempt to ~/.claude/hooks/blocked.log."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    with open(LOG_FILE, "a") as f:
+        f.write(
+            f"[{timestamp}] BLOCKED | tool={tool_name} | "
+            f"project={project} | reason={reason} | command={command}\n"
+        )
+
+
+def check_command(command: str):
+    """Check if command matches any dangerous pattern. Returns (blocked, reason)."""
+    if not command:
+        return False, ""
+    for pattern, description in DANGEROUS_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return True, description
+    return False, ""
+
+
+def build_block_response(tool_name: str, reason: str) -> str:
+    return json.dumps({
+        "allow": False,
+        "reason": reason,
+        "message": (
+            f"⛔ Tool '{tool_name}' was blocked by pre-tool-use hook.\n"
+            f"Reason: {reason}\n\n"
+            f"This incident has been logged to: {LOG_FILE}\n\n"
+            f"If you need to proceed, consider:\n"
+            f"  1. Using safer alternatives (e.g., 'rm -i' instead of 'rm -rf')\n"
+            f"  2. Breaking the operation into smaller, safer steps\n"
+            f"  3. Consulting your team before bypassing this safeguard"
+        ),
+    })
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        print(json.dumps({"allow": True}))
+        return
+
+    tool_name = data.get("tool_name", "")
+    tool_args = data.get("tool_args", {})
+    project = data.get("project", os.getcwd())
+
+    # Only intercept Bash tool
+    if tool_name != "Bash":
+        print(json.dumps({"allow": True}))
+        return
+
+    command = tool_args.get("command", "") or tool_args.get("description", "")
+    is_blocked, reason = check_command(command)
+
+    if is_blocked:
+        log_blocked(tool_name, command, reason, project)
+        print(build_block_response(tool_name, reason))
+    else:
+        print(json.dumps({"allow": True}))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/pre-tool-hook/test_hook.py
+++ b/skills/pre-tool-hook/test_hook.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Test script to verify pre-tool-hook.py blocks the right commands."""
+
+import json
+import subprocess
+import sys
+import os
+
+# Add the script path
+SCRIPT = os.path.join(os.path.dirname(__file__), "pre-tool-hook.py")
+
+def run_test(command: str, expect_block: bool) -> bool:
+    """Run the hook with a given command and check if it was blocked correctly."""
+    payload = json.dumps({
+        "tool_name": "Bash",
+        "tool_args": {"command": command},
+        "project": "/test/project"
+    })
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=payload.encode(),
+        capture_output=True
+    )
+    try:
+        response = json.loads(result.stdout.decode())
+        allowed = response.get("allow", True)
+        if expect_block and not allowed:
+            print(f"  ✅ Correctly blocked: {command[:50]}")
+            return True
+        elif not expect_block and allowed:
+            print(f"  ✅ Correctly allowed: {command[:50]}")
+            return True
+        else:
+            print(f"  ❌ Unexpected: {command[:50]} (expected {'block' if expect_block else 'allow'})")
+            return False
+    except json.JSONDecodeError:
+        print(f"  ❌ Invalid JSON output for: {command[:50]}")
+        return False
+
+print("Testing pre-tool-hook.py...")
+print()
+
+tests = [
+    # (command, expect_block)
+    ("echo hello", False),
+    ("ls -la", False),
+    ("git status", False),
+    ("git commit -m 'fix bug'", False),
+    ("rm -rf /tmp/test", True),
+    ("rm -rf /var/log/*", True),
+    ("DROP TABLE users", True),
+    ("DROP DATABASE production", True),
+    ("git push --force origin main", True),
+    ("git push -f", True),
+    ("TRUNCATE TABLE sessions", True),
+    ("DELETE FROM users", True),
+    ("DELETE FROM logs WHERE 1=1", True),
+    ("mkfs.ext4 /dev/sda1", True),
+    ("dd if=/dev/zero of=/dev/sdb", True),
+    ("python script.py --flag", False),
+    ("npm install", False),
+]
+
+passed = sum(run_test(cmd, expect) for cmd, expect in tests)
+print()
+print(f"Results: {passed}/{len(tests)} tests passed")
+sys.exit(0 if passed == len(tests) else 1)


### PR DESCRIPTION
## Summary

A Claude Code `pre-tool-use` hook written in Python that intercepts dangerous bash/SQL commands before execution, blocks them with a clear message, and logs each attempt.

## Files Added

- `skills/pre-tool-hook/pre-tool-hook.py` — Main hook script (Python 3.6+)
- `skills/pre-tool-hook/test_hook.py` — 17 unit tests (all passing)
- `skills/pre-tool-hook/SKILL.md` — Claude Code skill description
- `skills/pre-tool-hook/README.md` — Installation in 2 commands

## Acceptance Criteria Met

- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp + project path
- [x] Displays a clear message explaining why the command was blocked
- [x] Does not interfere with normal bash commands (17/17 tests passing)
- [x] README with installation in 2 commands or fewer

## Blocked Patterns

| Pattern | Description |
|---------|-------------|
| `rm -rf ...` | Recursive forced deletion |
| `DROP TABLE/DATABASE` | SQL destruction |
| `git push --force` | Forced git push |
| `TRUNCATE TABLE` | SQL table truncation |
| `DELETE FROM` (no WHERE) | Unconditional bulk delete |
| `mkfs.*` | Filesystem formatting |
| `dd ... /dev/` | Direct block device write |

## Test Results

```
$ python test_hook.py
Results: 17/17 tests passed
```

## Payment

收款地址：eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9