### PR TITLE
feat: SKILL + bash script to auto-generate structured CHANGELOG from git history

### DIFF
--- a/skills/changelog/README.md
+++ b/skills/changelog/README.md
@@ -1,0 +1,112 @@
+# changelog.sh — Auto-generate a structured CHANGELOG.md
+
+A zero-dependency bash script (and companion Claude Code `SKILL.md`) that generates
+a properly formatted `CHANGELOG.md` from your git history, categorised into
+**Added / Fixed / Changed / Removed**.
+
+---
+
+## Setup (3 steps or fewer)
+
+```bash
+# Step 1 — copy the script to your project root
+cp changelog.sh /path/to/your/project/
+
+# Step 2 — make it executable
+chmod +x changelog.sh
+
+# Step 3 — run it
+bash changelog.sh
+```
+
+That's it. No `npm install`, no `pip install`, no config files.
+
+---
+
+## Usage
+
+```bash
+# Generate CHANGELOG.md (appends a new section at the top)
+bash changelog.sh
+
+# Preview — print to stdout, don't write any file
+bash changelog.sh --dry-run
+
+# Start from a specific tag
+bash changelog.sh --since v1.0.0
+
+# Label the new section with a version
+bash changelog.sh --version v1.1.0
+
+# Both options combined
+bash changelog.sh --since v1.0.0 --version v1.1.0
+
+# Write to a different file
+bash changelog.sh --output CHANGES.md
+```
+
+---
+
+## How categorisation works
+
+Commits are matched against their subject line:
+
+| Keyword match | Section |
+|---|---|
+| `feat:` / `add` / `new` / `introduce` / `implement` | **Added** |
+| `fix:` / `bug` / `patch` / `hotfix` / `resolve` | **Fixed** |
+| `refactor:` / `change` / `update` / `bump` / `perf` / `chore` | **Changed** |
+| `remove` / `delete` / `drop` / `deprecate` / `revert` | **Removed** |
+| Everything else | **Changed** (safe fallback) |
+
+Conventional-commit type prefixes (`feat:`, `fix(auth):`, etc.) are automatically
+stripped from the display so the output is clean human-readable prose.
+
+---
+
+## Sample output
+
+```markdown
+## [v1.1.0] — 2026-03-31
+
+### Added
+
+- add rate limiting middleware for API endpoints (`a1b2c3d`)
+- introduce Prometheus /metrics endpoint (`e4f5g6h`)
+- new Docker Compose healthcheck for all services (`i7j8k9l`)
+
+### Fixed
+
+- fix race condition in session handler (`m0n1o2p`)
+- correct null pointer when config file is missing (`q3r4s5t`)
+
+### Changed
+
+- upgrade Go dependencies to latest minor versions (`u6v7w8x`)
+- refactor database connection pooling logic (`y9z0a1b`)
+
+### Removed
+
+- remove deprecated /v1/legacy API endpoint (`c2d3e4f`)
+```
+
+---
+
+## Claude Code integration (`/generate-changelog`)
+
+Copy `SKILL.md` to `.claude/skills/changelog/SKILL.md` (or your skill path),
+and use the `/generate-changelog` slash command in Claude Code. Claude will run
+the script for you and offer to commit the result.
+
+---
+
+## Requirements
+
+- bash 4.0+ (ships with every modern Linux/macOS)
+- git
+
+---
+
+## License
+
+MIT

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -1,0 +1,98 @@
+# SKILL: Generate Structured CHANGELOG from Git History
+
+## Trigger
+
+Use this skill when the user asks to:
+- Generate a changelog
+- Create a CHANGELOG.md
+- Summarize recent git commits
+- Run `/generate-changelog`
+
+---
+
+## What This Skill Does
+
+Automatically generates a structured `CHANGELOG.md` from the project's git history by:
+1. Finding the most recent git tag (baseline)
+2. Fetching all commits since that tag
+3. Auto-categorising them into **Added / Fixed / Changed / Removed**
+4. Writing a properly formatted section to `CHANGELOG.md`
+
+---
+
+## Instructions for Claude
+
+When this skill is triggered:
+
+1. **Check that git is available and we're inside a repo:**
+   ```bash
+   git rev-parse --git-dir
+   ```
+   If not a git repo, explain that and stop.
+
+2. **Run the changelog script:**
+   ```bash
+   bash changelog.sh
+   ```
+   Or for a preview without writing the file:
+   ```bash
+   bash changelog.sh --dry-run
+   ```
+
+3. **If the user wants a specific version tag:**
+   ```bash
+   bash changelog.sh --since v1.0.0 --version v1.1.0
+   ```
+
+4. **Show the user the output summary** (lines added per category).
+
+5. **Offer to commit the updated file:**
+   ```bash
+   git add CHANGELOG.md && git commit -m "docs: update CHANGELOG for [version]"
+   ```
+
+---
+
+## Categorisation Rules
+
+| Prefix / keyword in commit subject | Section |
+|---|---|
+| `feat:`, `add`, `new`, `introduce`, `implement` | **Added** |
+| `fix:`, `bug`, `patch`, `hotfix`, `resolve`, `correct` | **Fixed** |
+| `refactor:`, `change`, `update`, `upgrade`, `bump`, `perf`, `style`, `chore`, `docs`, `test`, `ci` | **Changed** |
+| `remove`, `delete`, `drop`, `deprecate`, `revert` | **Removed** |
+| Everything else | **Changed** (safe default) |
+
+---
+
+## Example Output
+
+```markdown
+## [Unreleased] — 2026-03-31
+
+### Added
+
+- add user authentication endpoint (`a1b2c3d`)
+- introduce Prometheus metrics scraping (`e4f5g6h`)
+
+### Fixed
+
+- fix race condition in session handler (`i7j8k9l`)
+- correct null pointer in config loader (`m0n1o2p`)
+
+### Changed
+
+- update dependencies to latest versions (`q3r4s5t`)
+- refactor database connection pooling (`u6v7w8x`)
+
+### Removed
+
+- remove deprecated /v1/legacy endpoint (`y9z0a1b`)
+```
+
+---
+
+## Files
+
+- `changelog.sh` — the main bash script (drop anywhere in the project root)
+- `SKILL.md` — this file (for Claude Code)

--- a/skills/changelog/changelog.sh
+++ b/skills/changelog/changelog.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# changelog.sh — Auto-generate a structured CHANGELOG.md from git history
+#
+# Usage:
+#   bash changelog.sh              # write CHANGELOG.md
+#   bash changelog.sh --dry-run    # print to stdout, don't write file
+#   bash changelog.sh --since v1.2 # start from a specific tag
+#   bash changelog.sh --help
+#
+# The script fetches all commits since the most recent git tag (or the very
+# first commit if no tag exists) and categorises them using conventional-commit
+# keywords into: Added / Fixed / Changed / Removed.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+OUTPUT_FILE="CHANGELOG.md"
+DRY_RUN=false
+SINCE_TAG=""
+VERSION_LABEL=""
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()  { echo -e "${CYAN}ℹ${RESET}  $*"; }
+ok()    { echo -e "${GREEN}✓${RESET}  $*"; }
+warn()  { echo -e "${YELLOW}⚠${RESET}  $*" >&2; }
+die()   { echo -e "${RED}✗${RESET}  $*" >&2; exit 1; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)       DRY_RUN=true; shift ;;
+    --since)         SINCE_TAG="$2"; shift 2 ;;
+    --output|-o)     OUTPUT_FILE="$2"; shift 2 ;;
+    --version)       VERSION_LABEL="$2"; shift 2 ;;
+    --help|-h)
+      cat <<EOF
+Usage: bash changelog.sh [OPTIONS]
+
+OPTIONS:
+  --dry-run          Print the changelog to stdout instead of writing a file
+  --since <tag>      Start from a specific tag (default: last tag in repo)
+  --output <file>    Output file path (default: CHANGELOG.md)
+  --version <label>  Version label for the new section (default: Unreleased)
+  --help             Show this help
+
+EXAMPLES:
+  bash changelog.sh
+  bash changelog.sh --dry-run
+  bash changelog.sh --since v1.0.0 --version v1.1.0
+EOF
+      exit 0 ;;
+    *)
+      die "Unknown argument: $1  (run with --help for usage)" ;;
+  esac
+done
+
+# ── Sanity checks ─────────────────────────────────────────────────────────────
+command -v git &>/dev/null || die "git is not installed."
+git rev-parse --git-dir &>/dev/null 2>&1 || die "Not inside a git repository."
+
+# ── Determine the start ref ───────────────────────────────────────────────────
+if [[ -n "$SINCE_TAG" ]]; then
+  LAST_TAG="$SINCE_TAG"
+  git rev-parse --verify "$LAST_TAG^{}" &>/dev/null \
+    || die "Tag '$LAST_TAG' not found in this repository."
+else
+  LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+fi
+
+if [[ -z "$LAST_TAG" ]]; then
+  warn "No git tags found. Generating changelog from the very first commit."
+  GIT_RANGE=""
+else
+  info "Generating changelog since tag: ${BOLD}${LAST_TAG}${RESET}"
+  GIT_RANGE="${LAST_TAG}..HEAD"
+fi
+
+# ── Version label ─────────────────────────────────────────────────────────────
+[[ -z "$VERSION_LABEL" ]] && VERSION_LABEL="Unreleased"
+TODAY=$(date +%Y-%m-%d)
+
+# ── Fetch commits ──────────────────────────────────────────────────────────────
+# Format: <short-hash> <subject>
+mapfile -t COMMITS < <(
+  git log ${GIT_RANGE} --no-merges --pretty=format:"%h %s" 2>/dev/null || true
+)
+
+if [[ ${#COMMITS[@]} -eq 0 ]]; then
+  warn "No commits found since ${LAST_TAG:-the beginning}. Nothing to generate."
+  exit 0
+fi
+
+info "Found ${#COMMITS[@]} commit(s) to categorise."
+
+# ── Categorisation arrays ──────────────────────────────────────────────────────
+declare -a ADDED=()
+declare -a FIXED=()
+declare -a CHANGED=()
+declare -a REMOVED=()
+declare -a OTHER=()
+
+categorise() {
+  local hash="$1"
+  local subject="$2"
+
+  # Strip conventional-commit type prefix for cleaner display
+  local clean_subject
+  clean_subject=$(echo "$subject" \
+    | sed -E 's/^(feat|fix|refactor|chore|docs|style|test|perf|ci|build|revert)(\([^)]*\))?[!]?:\s*//' \
+    | sed -E 's/^[[:upper:]]/\l&/')   # lowercase first char for consistent style
+
+  local lower_subject="${subject,,}"   # bash lowercase
+
+  case "$lower_subject" in
+    feat*|add*|new*|introduce*|implement*|"feature"*)
+      ADDED+=("- ${clean_subject} (\`${hash}\`)")
+      ;;
+    fix*|bug*|patch*|hotfix*|correct*|resolve*|repair*)
+      FIXED+=("- ${clean_subject} (\`${hash}\`)")
+      ;;
+    remove*|delete*|drop*|deprecate*|revert*)
+      REMOVED+=("- ${clean_subject} (\`${hash}\`)")
+      ;;
+    refactor*|change*|update*|upgrade*|migrate*|improve*|enhance*|bump*|perf*|style*|chore*|docs*|test*|ci*|build*)
+      CHANGED+=("- ${clean_subject} (\`${hash}\`)")
+      ;;
+    *)
+      # Fallback: try to infer from keywords anywhere in subject
+      if echo "$lower_subject" | grep -qE '\b(add|new|feat|creat|introduc|implement)\b'; then
+        ADDED+=("- ${clean_subject} (\`${hash}\`)")
+      elif echo "$lower_subject" | grep -qE '\b(fix|bug|patch|hotfix|resolv|repair|correct)\b'; then
+        FIXED+=("- ${clean_subject} (\`${hash}\`)")
+      elif echo "$lower_subject" | grep -qE '\b(remov|delet|drop|deprecat|revert)\b'; then
+        REMOVED+=("- ${clean_subject} (\`${hash}\`)")
+      else
+        CHANGED+=("- ${clean_subject} (\`${hash}\`)")
+      fi
+      ;;
+  esac
+}
+
+for commit in "${COMMITS[@]}"; do
+  hash="${commit%% *}"
+  subject="${commit#* }"
+  categorise "$hash" "$subject"
+done
+
+# ── Build the new section ─────────────────────────────────────────────────────
+build_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  if [[ ${#items[@]} -gt 0 ]]; then
+    echo ""
+    echo "### $title"
+    echo ""
+    for item in "${items[@]}"; do
+      echo "$item"
+    done
+  fi
+}
+
+NEW_SECTION=""
+NEW_SECTION+="## [${VERSION_LABEL}] — ${TODAY}"$'\n'
+
+NEW_SECTION+="$(build_section "Added"   "${ADDED[@]+"${ADDED[@]}"}")"
+NEW_SECTION+="$(build_section "Fixed"   "${FIXED[@]+"${FIXED[@]}"}")"
+NEW_SECTION+="$(build_section "Changed" "${CHANGED[@]+"${CHANGED[@]}"}")"
+NEW_SECTION+="$(build_section "Removed" "${REMOVED[@]+"${REMOVED[@]}"}")"
+
+# ── Output ────────────────────────────────────────────────────────────────────
+HEADER="# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
+
+"
+
+if $DRY_RUN; then
+  echo -e "${HEADER}${NEW_SECTION}"
+else
+  # Prepend new section to existing CHANGELOG.md (or create fresh)
+  if [[ -f "$OUTPUT_FILE" ]]; then
+    # Strip the static header if it already exists to avoid duplication
+    EXISTING=$(tail -n +8 "$OUTPUT_FILE" 2>/dev/null || cat "$OUTPUT_FILE")
+    printf '%s\n%s\n\n%s' "$HEADER" "$NEW_SECTION" "$EXISTING" > "$OUTPUT_FILE"
+    ok "Updated ${OUTPUT_FILE} (new section prepended)."
+  else
+    printf '%s\n%s\n' "$HEADER" "$NEW_SECTION" > "$OUTPUT_FILE"
+    ok "Created ${OUTPUT_FILE}."
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Summary:${RESET}"
+echo "  Added:   ${#ADDED[@]}"
+echo "  Fixed:   ${#FIXED[@]}"
+echo "  Changed: ${#CHANGED[@]}"
+echo "  Removed: ${#REMOVED[@]}"
+echo ""

--- a/skills/changelog/sample_output.md
+++ b/skills/changelog/sample_output.md
@@ -1,0 +1,51 @@
+# Sample Output — Tested on Real Git Repo
+
+## Test setup
+
+Created a git repo with 8 commits spanning a `v1.0.0` tag:
+- 3 commits before the tag (feat, fix, refactor)
+- 4 commits after the tag (feat, add, remove, update)
+
+## Command run
+
+```bash
+bash changelog.sh --dry-run --version v1.1.0
+```
+
+## Output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
+
+## [v1.1.0] — 2026-03-31
+
+### Added
+
+- add rate limiting middleware for API (`b0e197c`)
+- introduce Prometheus metrics endpoint (`e03282f`)
+
+### Changed
+
+- update CI workflow to use Ubuntu 22.04 (`0a88a82`)
+
+### Removed
+
+- remove deprecated /v1/legacy endpoint (`2c194a4`)
+```
+
+## Summary
+
+```
+Added:   2
+Fixed:   0
+Changed: 1
+Removed: 1
+```
+
+All 4 commits since the `v1.0.0` tag were correctly fetched and categorised.
+Conventional-commit prefixes (`feat:`, `fix:`, etc.) were automatically stripped.


### PR DESCRIPTION
## Summary

- Adds `skills/changelog/changelog.sh` — zero-dependency bash script (bash 4+, no external deps)
- Adds `skills/changelog/SKILL.md` — Claude Code skill that triggers `/generate-changelog`
- Auto-categorises commits into Added / Fixed / Changed / Removed via conventional-commit keyword matching
- Strips conventional-commit prefixes for clean human-readable output

## What's included

- `skills/changelog/changelog.sh` — the bash script
- `skills/changelog/SKILL.md` — Claude Code skill
- `skills/changelog/README.md` — setup in 3 steps
- `skills/changelog/sample_output.md` — tested output on a real repo

## Usage

```bash
bash changelog.sh
bash changelog.sh --dry-run
bash changelog.sh --since v1.0.0 --version v1.1.0
```

## How categorisation works

- feat / add / new → Added
- fix / bug / patch → Fixed
- refactor / update / bump → Changed
- remove / delete / revert → Removed

## Sample output

```markdown
## [v1.1.0] — 2026-03-31

### Added
- add rate limiting middleware for API (b0e197c)
- introduce Prometheus metrics endpoint (e03282f)

### Changed
- update CI workflow to use Ubuntu 22.04 (0a88a82)

### Removed
- remove deprecated /v1/legacy endpoint (2c194a4)
```

Closes #1