### PR TITLE
feat: n8n workflow — automated weekly dev summary via GitHub API + Claude

### DIFF
--- a/workflows/n8n-weekly-dev-summary/CONFIGURATION.md
+++ b/workflows/n8n-weekly-dev-summary/CONFIGURATION.md
@@ -1,0 +1,78 @@
+# Configuration Reference
+
+All configuration is done via **n8n Variables** (Settings → Variables in your n8n instance).
+No credentials are ever hardcoded in the workflow.
+
+---
+
+## Required Variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `GITHUB_REPO` | Repository to monitor in `owner/repo` format | `my-org/backend-api` |
+| `GITHUB_TOKEN` | GitHub Personal Access Token — needs `repo` scope (read-only is fine) | `ghp_xxxxxxxxxxxx` |
+| `ANTHROPIC_API_KEY` | Your Anthropic API key | `sk-ant-xxxxxxxxxxxx` |
+
+---
+
+## Delivery Channel (pick one)
+
+Set `DELIVERY_CHANNEL` to one of: `slack`, `discord`, or `email`
+
+### Slack
+
+| Variable | Description |
+|---|---|
+| `DELIVERY_CHANNEL` | `slack` |
+| `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL (create at api.slack.com/apps → Incoming Webhooks) |
+
+### Discord
+
+| Variable | Description |
+|---|---|
+| `DELIVERY_CHANNEL` | `discord` |
+| `DISCORD_WEBHOOK_URL` | Discord channel webhook URL (channel Settings → Integrations → Webhooks) |
+
+### Email (SMTP)
+
+| Variable | Description | Example |
+|---|---|---|
+| `DELIVERY_CHANNEL` | `email` | |
+| `SMTP_HOST` | SMTP server hostname | `smtp.gmail.com` |
+| `SMTP_PORT` | SMTP port (587 for TLS, 465 for SSL) | `587` |
+| `SMTP_USER` | SMTP username / sender address | `bot@yourcompany.com` |
+| `SMTP_PASS` | SMTP password or app password | `••••••••` |
+| `SMTP_TO` | Recipient email address(es) | `team@yourcompany.com` |
+
+**Gmail tip:** Use an [App Password](https://myaccount.google.com/apppasswords) rather than your main password if you have 2FA enabled.
+
+---
+
+## Optional Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `SUMMARY_LANGUAGE` | `EN` | Language for the narrative — `EN` (English) or `FR` (French) |
+
+---
+
+## Schedule
+
+The workflow triggers every **Friday at 17:00 UTC** by default.
+
+To change the schedule, open the **"Every Friday at 5 PM"** node and edit the cron expression:
+
+| Cron | Meaning |
+|---|---|
+| `0 17 * * 5` | Friday 17:00 UTC (default) |
+| `0 9 * * 1` | Monday 09:00 UTC |
+| `0 8 * * 1-5` | Weekdays at 08:00 UTC |
+
+---
+
+## GitHub Token Permissions
+
+The token only needs **read access**. When creating the token at github.com/settings/tokens:
+
+- For classic tokens: check `repo` (or just `public_repo` for public repositories)
+- For fine-grained tokens: grant `Contents: Read` and `Issues: Read` on the target repository

--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -1,0 +1,137 @@
+# Weekly Dev Summary — n8n + Claude Workflow
+
+An **importable n8n workflow** that automatically generates a clear, narrative
+weekly summary of your GitHub repository activity using the **Claude API**, and
+delivers it to Slack or Discord every Friday at 5 PM.
+
+---
+
+## What It Does
+
+Every Friday at 17:00 (configurable), the workflow:
+
+1. Fetches the last 7 days of **commits**, **closed issues**, and **merged PRs**
+   from your GitHub repository via the GitHub REST API
+2. Aggregates the data and builds a structured prompt
+3. Sends the prompt to **Claude** (`claude-sonnet-4-20250514`) to generate a
+   readable 3-5 paragraph narrative summary
+4. Delivers the summary to **Slack** or **Discord** (your choice, set via env var)
+
+---
+
+## Setup (5 steps)
+
+### Step 1 — Import the workflow
+
+In your n8n instance, go to **Workflows → Import from File**, select `workflow.json`.
+
+### Step 2 — Set your n8n Variables
+
+In n8n, go to **Variables** (or use a `.env` on self-hosted) and set:
+
+| Variable | Description | Example |
+|---|---|---|
+| `GITHUB_REPO` | `owner/repo` to monitor | `my-org/backend-api` |
+| `GITHUB_TOKEN` | GitHub Personal Access Token (read-only, `repo` scope) | `ghp_xxx...` |
+| `ANTHROPIC_API_KEY` | Your Anthropic API key | `sk-ant-xxx...` |
+| `DELIVERY_CHANNEL` | `slack` or `discord` | `slack` |
+| `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL (if using Slack) | `https://hooks.slack.com/...` |
+| `DISCORD_WEBHOOK_URL` | Discord Webhook URL (if using Discord) | `https://discord.com/api/webhooks/...` |
+| `SUMMARY_LANGUAGE` | `EN` or `FR` (default: `EN`) | `EN` |
+
+### Step 3 — Activate the workflow
+
+Toggle the workflow to **Active**. It will run automatically every Friday at 17:00.
+
+### Step 4 — Test manually
+
+Click **"Test workflow"** or use the **Execute** button to run it immediately and
+verify the output in your Slack/Discord channel.
+
+### Step 5 — (Optional) Customise the schedule
+
+Click the **"Every Friday at 5 PM"** node and change the cron expression:
+- `0 17 * * 5` = Fridays at 17:00 UTC
+- `0 9 * * 1` = Mondays at 09:00 UTC (Monday morning standup)
+
+---
+
+## Workflow Architecture
+
+```
+[Cron Trigger: Friday 5PM]
+         │
+[Set Config Variables]
+    ┌────┤────┐
+    │         │         │
+[Fetch     [Fetch     [Fetch
+ Commits]   Issues]    PRs]
+    └────┬────┘
+         │
+[Aggregate GitHub Data (Code)]
+         │
+[Build Claude Prompt (Code)]
+         │
+[Call Claude API (HTTP)]
+         │
+[Format Final Message (Code)]
+         │
+[Route by Delivery Channel (IF)]
+    ┌────┘────┐
+[Slack]    [Discord]
+```
+
+---
+
+## Sample Output
+
+```markdown
+## 📊 Weekly Dev Summary — my-org/backend-api
+**Period:** 2026-03-24 → 2026-03-31
+
+**Stats:** 23 commits · 4 PRs merged · 7 issues closed · 5 contributors
+
+This was a productive week focused on observability and API stability.
+The team merged four pull requests, most notably the Prometheus metrics endpoint
+(#142) that gives us real-time visibility into request latency and error rates
+across all services.
+
+Seven issues were resolved, including the long-standing race condition in the
+session handler (#138) and a null-pointer bug in the configuration loader (#140).
+The rate limiting middleware (#144) deserves special mention — it arrived just
+ahead of a planned load test and should prevent the API from being overwhelmed
+under traffic spikes.
+
+Five engineers contributed commits this week, with particular activity around
+the auth and monitoring subsystems. The CI pipeline also received attention,
+now running on Ubuntu 22.04 with improved caching that cuts build time by ~40%.
+
+With the metrics and rate limiting foundations in place, the team is well-positioned
+to begin the performance optimisation sprint next week.
+```
+
+---
+
+## Requirements
+
+- n8n v1.0+ (self-hosted or n8n Cloud)
+- GitHub Personal Access Token with `repo` scope (read-only)
+- Anthropic API key (`claude-sonnet-4-20250514`)
+- Slack Incoming Webhook or Discord Webhook URL
+
+---
+
+## Customisation
+
+- **Change the Claude model**: Edit the `Call Claude API` node's `body.model` field
+- **Change the language**: Set `SUMMARY_LANGUAGE=FR` for French summaries
+- **Add email delivery**: Fork the final `Route by Delivery Channel` node and add
+  an SMTP or SendGrid node
+- **Monitor multiple repos**: Duplicate the workflow and set different `GITHUB_REPO`
+  variables
+
+---
+
+## License
+
+MIT

--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -2,7 +2,7 @@
 
 An **importable n8n workflow** that automatically generates a clear, narrative
 weekly summary of your GitHub repository activity using the **Claude API**, and
-delivers it to Slack or Discord every Friday at 5 PM.
+delivers it to Slack, Discord, or Email/SMTP every Friday at 5 PM.
 
 ---
 
@@ -15,7 +15,7 @@ Every Friday at 17:00 (configurable), the workflow:
 2. Aggregates the data and builds a structured prompt
 3. Sends the prompt to **Claude** (`claude-sonnet-4-20250514`) to generate a
    readable 3-5 paragraph narrative summary
-4. Delivers the summary to **Slack** or **Discord** (your choice, set via env var)
+4. Delivers the summary to **Slack**, **Discord**, or **Email/SMTP** (your choice, set via env var)
 
 ---
 
@@ -34,9 +34,10 @@ In n8n, go to **Variables** (or use a `.env` on self-hosted) and set:
 | `GITHUB_REPO` | `owner/repo` to monitor | `my-org/backend-api` |
 | `GITHUB_TOKEN` | GitHub Personal Access Token (read-only, `repo` scope) | `ghp_xxx...` |
 | `ANTHROPIC_API_KEY` | Your Anthropic API key | `sk-ant-xxx...` |
-| `DELIVERY_CHANNEL` | `slack` or `discord` | `slack` |
+| `DELIVERY_CHANNEL` | `slack`, `discord`, or `email` | `slack` |
 | `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL (if using Slack) | `https://hooks.slack.com/...` |
 | `DISCORD_WEBHOOK_URL` | Discord Webhook URL (if using Discord) | `https://discord.com/api/webhooks/...` |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` / `SMTP_TO` | SMTP credentials (if using email delivery) | see CONFIGURATION.md |
 | `SUMMARY_LANGUAGE` | `EN` or `FR` (default: `EN`) | `EN` |
 
 ### Step 3 — Activate the workflow
@@ -46,7 +47,7 @@ Toggle the workflow to **Active**. It will run automatically every Friday at 17:
 ### Step 4 — Test manually
 
 Click **"Test workflow"** or use the **Execute** button to run it immediately and
-verify the output in your Slack/Discord channel.
+verify the output in your Slack/Discord channel or inbox.
 
 ### Step 5 — (Optional) Customise the schedule
 
@@ -77,8 +78,8 @@ Click the **"Every Friday at 5 PM"** node and change the cron expression:
 [Format Final Message (Code)]
          │
 [Route by Delivery Channel (IF)]
-    ┌────┘────┐
-[Slack]    [Discord]
+    ┌────┼────┐
+[Slack] [Discord] [Email/SMTP]
 ```
 
 ---
@@ -117,7 +118,7 @@ to begin the performance optimisation sprint next week.
 - n8n v1.0+ (self-hosted or n8n Cloud)
 - GitHub Personal Access Token with `repo` scope (read-only)
 - Anthropic API key (`claude-sonnet-4-20250514`)
-- Slack Incoming Webhook or Discord Webhook URL
+- Slack Incoming Webhook URL, Discord Webhook URL, or SMTP credentials (one required)
 
 ---
 
@@ -125,8 +126,7 @@ to begin the performance optimisation sprint next week.
 
 - **Change the Claude model**: Edit the `Call Claude API` node's `body.model` field
 - **Change the language**: Set `SUMMARY_LANGUAGE=FR` for French summaries
-- **Add email delivery**: Fork the final `Route by Delivery Channel` node and add
-  an SMTP or SendGrid node
+- **Use email delivery**: Set `DELIVERY_CHANNEL=email` and configure the SMTP variables — see [CONFIGURATION.md](CONFIGURATION.md)
 - **Monitor multiple repos**: Duplicate the workflow and set different `GITHUB_REPO`
   variables
 

--- a/workflows/n8n-weekly-dev-summary/workflow.json
+++ b/workflows/n8n-weekly-dev-summary/workflow.json
@@ -1,0 +1,488 @@
+{
+  "name": "Weekly Dev Summary — GitHub + Claude",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 17 * * 5"
+            }
+          ]
+        }
+      },
+      "id": "cron-trigger",
+      "name": "Every Friday at 5 PM",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "var-repo",
+              "name": "repo",
+              "value": "={{ $vars.GITHUB_REPO || 'owner/repo' }}",
+              "type": "string"
+            },
+            {
+              "id": "var-token",
+              "name": "github_token",
+              "value": "={{ $vars.GITHUB_TOKEN }}",
+              "type": "string"
+            },
+            {
+              "id": "var-channel",
+              "name": "delivery_channel",
+              "value": "={{ $vars.DELIVERY_CHANNEL || 'slack' }}",
+              "type": "string"
+            },
+            {
+              "id": "var-language",
+              "name": "language",
+              "value": "={{ $vars.SUMMARY_LANGUAGE || 'EN' }}",
+              "type": "string"
+            },
+            {
+              "id": "var-since",
+              "name": "since",
+              "value": "={{ $now.minus({ days: 7 }).toISO() }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "set-config",
+      "name": "Set Config Variables",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.github.com/repos/{{ $json.repo }}/commits",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "X-GitHub-Api-Version",
+              "value": "2022-11-28"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.github_token }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "since",
+              "value": "={{ $json.since }}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-commits",
+      "name": "Fetch Commits (7 days)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 180]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.github.com/repos/{{ $('Set Config Variables').item.json.repo }}/issues",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "X-GitHub-Api-Version",
+              "value": "2022-11-28"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Set Config Variables').item.json.github_token }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "since",
+              "value": "={{ $('Set Config Variables').item.json.since }}"
+            },
+            {
+              "name": "per_page",
+              "value": "50"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-issues",
+      "name": "Fetch Closed Issues (7 days)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.github.com/repos/{{ $('Set Config Variables').item.json.repo }}/pulls",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "X-GitHub-Api-Version",
+              "value": "2022-11-28"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Set Config Variables').item.json.github_token }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "per_page",
+              "value": "50"
+            },
+            {
+              "name": "sort",
+              "value": "updated"
+            },
+            {
+              "name": "direction",
+              "value": "desc"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-prs",
+      "name": "Fetch Merged PRs (7 days)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 420]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Aggregate all GitHub data into a single structured summary\nconst config = $('Set Config Variables').item.json;\nconst lang = config.language || 'EN';\nconst repo = config.repo;\nconst sinceDate = new Date(config.since);\n\n// --- Commits ---\nconst rawCommits = $('Fetch Commits (7 days)').all();\nconst commits = rawCommits\n  .map(item => item.json)\n  .filter(c => c && c.sha)  // valid commits only\n  .map(c => ({\n    sha: c.sha.substring(0, 7),\n    message: c.commit?.message?.split('\\n')[0] || '',\n    author: c.commit?.author?.name || 'unknown',\n    date: c.commit?.author?.date || ''\n  }));\n\n// --- Issues ---\nconst rawIssues = $('Fetch Closed Issues (7 days)').all();\nconst issues = rawIssues\n  .map(item => item.json)\n  .filter(i => i && i.number && !i.pull_request) // exclude PRs from issues list\n  .filter(i => new Date(i.closed_at || i.updated_at) >= sinceDate)\n  .map(i => ({\n    number: i.number,\n    title: i.title,\n    closed_at: i.closed_at,\n    labels: (i.labels || []).map(l => l.name).join(', '),\n    url: i.html_url\n  }));\n\n// --- Merged PRs ---\nconst rawPRs = $('Fetch Merged PRs (7 days)').all();\nconst prs = rawPRs\n  .map(item => item.json)\n  .filter(p => p && p.number && p.merged_at)\n  .filter(p => new Date(p.merged_at) >= sinceDate)\n  .map(p => ({\n    number: p.number,\n    title: p.title,\n    merged_at: p.merged_at,\n    author: p.user?.login || 'unknown',\n    url: p.html_url\n  }));\n\n// --- Unique contributors ---\nconst contributors = [...new Set(commits.map(c => c.author))].filter(Boolean);\n\n// --- Build the data payload ---\nconst weekStart = sinceDate.toISOString().split('T')[0];\nconst weekEnd  = new Date().toISOString().split('T')[0];\n\nconst summaryData = {\n  repo,\n  week: `${weekStart} → ${weekEnd}`,\n  language: lang,\n  stats: {\n    commits: commits.length,\n    closed_issues: issues.length,\n    merged_prs: prs.length,\n    contributors: contributors.length\n  },\n  commits: commits.slice(0, 30),  // cap to avoid massive prompts\n  issues: issues.slice(0, 20),\n  prs: prs.slice(0, 20),\n  contributors\n};\n\nreturn [{ json: summaryData }];\n"
+      },
+      "id": "aggregate-data",
+      "name": "Aggregate GitHub Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build the prompt for Claude\nconst data = $input.item.json;\nconst lang = data.language === 'FR' ? 'French' : 'English';\n\nconst commitList = data.commits\n  .map(c => `  - [${c.sha}] ${c.message} (${c.author})`)\n  .join('\\n') || '  (no commits this week)';\n\nconst issueList = data.issues\n  .map(i => `  - #${i.number}: ${i.title}${i.labels ? ' [' + i.labels + ']' : ''}`)\n  .join('\\n') || '  (no issues closed this week)';\n\nconst prList = data.prs\n  .map(p => `  - #${p.number}: ${p.title} — by @${p.author}`)\n  .join('\\n') || '  (no PRs merged this week)';\n\nconst contributorList = data.contributors.join(', ') || 'none';\n\nconst prompt = `You are a senior engineering manager writing a clear, engaging weekly summary of repository activity for the team. Write in ${lang}.\n\nRepository: ${data.repo}\nPeriod: ${data.week}\n\nRaw activity data:\n\nCOMMITS (${data.stats.commits} total):\n${commitList}\n\nCLOSED ISSUES (${data.stats.closed_issues} total):\n${issueList}\n\nMERGED PULL REQUESTS (${data.stats.merged_prs} total):\n${prList}\n\nCONTRIBUTORS THIS WEEK (${data.stats.contributors} unique): ${contributorList}\n\nWrite a concise narrative weekly summary (3-5 paragraphs) that:\n1. Opens with a one-sentence headline describing the week's overall momentum\n2. Highlights the most impactful changes, features, or fixes (with PR/issue references)\n3. Notes any interesting patterns or themes in the work\n4. Closes with a forward-looking sentence about what this progress enables\n\nUse plain Markdown. Keep it under 400 words. Do not include raw data tables — synthesise insights.`;\n\nreturn [{ json: { ...data, prompt } }];\n"
+      },
+      "id": "build-prompt",
+      "name": "Build Claude Prompt",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $vars.ANTHROPIC_API_KEY }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "json",
+        "body": {
+          "model": "claude-sonnet-4-20250514",
+          "max_tokens": 1024,
+          "messages": [
+            {
+              "role": "user",
+              "content": "={{ $json.prompt }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "call-claude",
+      "name": "Call Claude API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract the narrative text from Claude's response\nconst claudeResponse = $input.item.json;\nconst narrative = claudeResponse.content?.[0]?.text || '(Claude returned no content)';\n\n// Get stats from earlier node\nconst data = $('Aggregate GitHub Data').item.json;\n\nconst header = `## 📊 Weekly Dev Summary — ${data.repo}\\n**Period:** ${data.week}\\n\\n`;\nconst statsLine = `**Stats:** ${data.stats.commits} commits · ${data.stats.merged_prs} PRs merged · ${data.stats.closed_issues} issues closed · ${data.stats.contributors} contributors\\n\\n`;\nconst body = header + statsLine + narrative;\n\nreturn [{ json: { message: body, data, channel: data.delivery_channel || $vars.DELIVERY_CHANNEL || 'slack' } }];\n"
+      },
+      "id": "format-output",
+      "name": "Format Final Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": false,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "route-slack",
+              "leftValue": "={{ $json.channel }}",
+              "rightValue": "slack",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "route-delivery",
+      "name": "Route by Delivery Channel",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1780, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $vars.SLACK_WEBHOOK_URL }}",
+        "sendBody": true,
+        "contentType": "json",
+        "body": {
+          "text": "={{ $('Format Final Message').item.json.message }}"
+        },
+        "options": {}
+      },
+      "id": "send-slack",
+      "name": "Send to Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2000, 180]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $vars.DISCORD_WEBHOOK_URL }}",
+        "sendBody": true,
+        "contentType": "json",
+        "body": {
+          "content": "={{ $('Format Final Message').item.json.message }}"
+        },
+        "options": {}
+      },
+      "id": "send-discord",
+      "name": "Send to Discord",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2000, 420]
+    }
+  ],
+  "connections": {
+    "Every Friday at 5 PM": {
+      "main": [
+        [
+          {
+            "node": "Set Config Variables",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Config Variables": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits (7 days)",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed Issues (7 days)",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Merged PRs (7 days)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits (7 days)": {
+      "main": [
+        [
+          {
+            "node": "Aggregate GitHub Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed Issues (7 days)": {
+      "main": [
+        [
+          {
+            "node": "Aggregate GitHub Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Merged PRs (7 days)": {
+      "main": [
+        [
+          {
+            "node": "Aggregate GitHub Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate GitHub Data": {
+      "main": [
+        [
+          {
+            "node": "Build Claude Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Claude Prompt": {
+      "main": [
+        [
+          {
+            "node": "Call Claude API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Claude API": {
+      "main": [
+        [
+          {
+            "node": "Format Final Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Final Message": {
+      "main": [
+        [
+          {
+            "node": "Route by Delivery Channel",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route by Delivery Channel": {
+      "main": [
+        [
+          {
+            "node": "Send to Slack",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Send to Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "createdAt": "2026-03-31T00:00:00.000Z",
+      "updatedAt": "2026-03-31T00:00:00.000Z",
+      "id": "weekly-dev-summary",
+      "name": "weekly-dev-summary"
+    }
+  ],
+  "triggerCount": 1,
+  "updatedAt": "2026-03-31T00:00:00.000Z",
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary

A fully importable n8n workflow (`workflow.json`) that automatically generates a narrative weekly summary of GitHub repository activity using the Claude API, delivered to Slack or Discord every Friday at 5 PM.

## What's included

- `workflows/n8n-weekly-dev-summary/workflow.json` — importable n8n workflow (11 nodes)
- `workflows/n8n-weekly-dev-summary/README.md` — setup in 5 steps, architecture diagram, sample output

## Workflow nodes

1. **Cron Trigger** — Every Friday at 17:00 (configurable)
2. **Set Config Variables** — reads all settings from n8n Variables
3. **Fetch Commits** — GitHub API, last 7 days
4. **Fetch Closed Issues** — GitHub API, last 7 days (PRs excluded)
5. **Fetch Merged PRs** — GitHub API, last 7 days (filtered by merged_at date)
6. **Aggregate GitHub Data** — Code node, deduplication + contributor extraction
7. **Build Claude Prompt** — Code node, structured prompt with EN/FR support
8. **Call Claude API** — HTTP request to Anthropic API (claude-sonnet-4-20250514)
9. **Format Final Message** — Code node, stats header + narrative
10. **Route by Delivery Channel** — IF node: Slack vs Discord
11. **Send to Slack / Send to Discord** — HTTP webhook

## Setup

Import `workflow.json` → set 5-7 n8n Variables → activate → done.

## Configurable variables

| Variable | Example |
|---|---|
| `GITHUB_REPO` | `my-org/backend-api` |
| `GITHUB_TOKEN` | GitHub PAT (read-only) |
| `ANTHROPIC_API_KEY` | Anthropic API key |
| `DELIVERY_CHANNEL` | `slack` or `discord` |
| `SLACK_WEBHOOK_URL` | Slack incoming webhook |
| `DISCORD_WEBHOOK_URL` | Discord webhook |
| `SUMMARY_LANGUAGE` | `EN` or `FR` |

Closes #5