### PR TITLE
feat: PR review agent CLI + GitHub Action with inline comments

### DIFF
--- a/bounty-4-pr-review-agent/.github/workflows/claude-review.yml
+++ b/bounty-4-pr-review-agent/.github/workflows/claude-review.yml
@@ -1,0 +1,32 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run Claude PR Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x ./bounty-4-pr-review-agent/claude-review
+          ./bounty-4-pr-review-agent/claude-review \
+            --pr "${{ github.repository }}/${{ github.event.pull_request.number }}" \
+            --post \
+            --inline

--- a/bounty-4-pr-review-agent/README.md
+++ b/bounty-4-pr-review-agent/README.md
@@ -1,0 +1,113 @@
+# Claude Code PR Review Agent
+
+A CLI tool + GitHub Action that reviews any GitHub Pull Request using the Anthropic API
+and outputs a structured Markdown analysis — with optional **inline per-line comments**
+posted directly to the PR via the GitHub Reviews API.
+
+## Features
+
+- **CLI + GitHub Action** — use standalone or as automated CI
+- **Structured output** — Summary, Identified Risks, Improvement Suggestions, Confidence Score
+- **Inline comments** — posts per-line review notes using the GitHub Reviews API (`--inline`)
+  so each comment appears anchored to the exact changed line, not just the PR thread
+- **Smart diff truncation** — handles large diffs (>80 KB) gracefully
+- **Post-to-PR** — `--post` adds the review as a PR comment or inline review
+- **JSON output** — `--json` for pipeline integration
+- **Zero dependencies** — Python 3 stdlib only (`urllib`, `json`, `re`, `argparse`)
+
+## Quick Start
+
+### 1. Set environment variables
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."    # Required
+export GITHUB_TOKEN="ghp_..."            # Required for --post; optional for public repos
+```
+
+### 2. Run a review
+
+```bash
+# Full URL
+./claude-review --pr https://github.com/facebook/react/pull/28000
+
+# Shorthand
+./claude-review --pr owner/repo/123
+
+# Post summary as PR comment
+./claude-review --pr owner/repo/123 --post
+
+# Post summary + inline per-line comments
+./claude-review --pr owner/repo/123 --post --inline
+
+# JSON output for pipelines
+./claude-review --pr owner/repo/123 --json
+```
+
+### 3. GitHub Action (automated)
+
+Copy `.github/workflows/claude-review.yml` to your repo.
+Add `ANTHROPIC_API_KEY` as a repository secret.
+
+Every new PR (and push to an existing PR) will receive an automated review with
+inline comments on the changed lines.
+
+## Output Format
+
+```markdown
+# Code Review — owner/repo#123
+
+## Summary
+2–3 sentences describing the nature and purpose of the changes.
+
+## Identified Risks
+- **Security / High** — description, affected file:line
+- **Logic / Low** — description
+
+## Improvement Suggestions
+1. Concrete suggestion with code snippet if applicable.
+2. Another suggestion.
+
+## Confidence Score
+**High** — one-sentence justification.
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--pr <ref>` | GitHub PR URL or `owner/repo/number` (required) |
+| `--post` | Post review as GitHub PR comment or review |
+| `--inline` | Also post inline per-line comments (requires `--post`) |
+| `--model <m>` | Claude model (default: `claude-sonnet-4-20250514`) |
+| `--json` | JSON output instead of Markdown |
+| `--help` | Show help |
+
+## What makes this different
+
+Most PR review scripts send the raw diff to the API and post a single comment.
+This agent:
+
+1. **Parses the unified diff to extract hunk positions** so inline comments are
+   anchored to the exact line in the diff view — the same way human reviewers
+   leave comments in the GitHub UI.
+
+2. **Makes two API calls**: one for the narrative summary (the structured Markdown
+   report) and one specifically for inline suggestions (NDJSON output mapped back
+   to diff positions). This produces tighter, more actionable feedback than a
+   single prompt trying to do both.
+
+3. **Uses the GitHub Reviews API** (`POST /pulls/:number/reviews`) so all inline
+   comments appear as a single review event, keeping the PR timeline clean.
+
+## Sample Reviews
+
+See the [`examples/`](examples/) directory for two real review outputs:
+
+- [`review-pr-350.md`](examples/review-pr-350.md) — review of a pre-tool-use security hook
+- [`review-pr-351.md`](examples/review-pr-351.md) — review of a CHANGELOG generation skill
+
+## Requirements
+
+- Python 3.6+ (stdlib only — no `pip install` needed)
+- An Anthropic API key with Messages API access
+- A GitHub token with `repo` scope (optional for public repos without `--post`)

--- a/bounty-4-pr-review-agent/claude-review
+++ b/bounty-4-pr-review-agent/claude-review
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""
+claude-review — Claude Code PR Review Agent
+Reviews a GitHub PR using the Anthropic API and posts structured Markdown feedback.
+
+Usage:
+  claude-review --pr https://github.com/owner/repo/pull/123
+  claude-review --pr owner/repo/123
+  claude-review --pr owner/repo/123 --post
+  claude-review --pr owner/repo/123 --inline
+  claude-review --pr owner/repo/123 --post --inline
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+import urllib.request
+import urllib.error
+from dataclasses import dataclass
+from typing import Optional
+
+VERSION = "1.0.0"
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+MAX_DIFF_BYTES = 80_000  # ~80 KB keeps us well within context limits
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers
+# ---------------------------------------------------------------------------
+
+def gh_get(path: str, token: str) -> dict:
+    url = f"https://api.github.com{path}"
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "claude-review/1.0",
+    })
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"GitHub API error {e.code} for {path}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def gh_get_raw(path: str, accept: str, token: str) -> str:
+    url = f"https://api.github.com{path}"
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": accept,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "claude-review/1.0",
+    })
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"GitHub API error {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def gh_post(path: str, payload: dict, token: str) -> dict:
+    url = f"https://api.github.com{path}"
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, method="POST", headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "claude-review/1.0",
+    })
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"GitHub API error {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic helpers
+# ---------------------------------------------------------------------------
+
+def call_claude(prompt: str, api_key: str, model: str) -> str:
+    url = "https://api.anthropic.com/v1/messages"
+    payload = {
+        "model": model,
+        "max_tokens": 4096,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, method="POST", headers={
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    })
+    try:
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read())
+            return result["content"][0]["text"]
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"Anthropic API error {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# PR parsing
+# ---------------------------------------------------------------------------
+
+def parse_pr_ref(ref: str) -> tuple[str, str, int]:
+    """Return (owner, repo, pr_number) from URL or owner/repo/number."""
+    # Full URL: https://github.com/owner/repo/pull/123
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", ref)
+    if m:
+        return m.group(1), m.group(2), int(m.group(3))
+    # Short form: owner/repo/123
+    m = re.match(r"([^/]+)/([^/]+)/(\d+)$", ref)
+    if m:
+        return m.group(1), m.group(2), int(m.group(3))
+    print(f"Cannot parse PR reference: {ref}", file=sys.stderr)
+    print("Expected: https://github.com/owner/repo/pull/123  or  owner/repo/123", file=sys.stderr)
+    sys.exit(1)
+
+
+@dataclass
+class PRInfo:
+    owner: str
+    repo: str
+    number: int
+    title: str
+    body: str
+    author: str
+    base_branch: str
+    head_branch: str
+    diff: str
+    files: list[dict]
+    additions: int
+    deletions: int
+    changed_files: int
+
+
+def fetch_pr(owner: str, repo: str, number: int, token: str) -> PRInfo:
+    pr = gh_get(f"/repos/{owner}/{repo}/pulls/{number}", token)
+    diff = gh_get_raw(
+        f"/repos/{owner}/{repo}/pulls/{number}",
+        "application/vnd.github.diff",
+        token,
+    )
+    files = gh_get(f"/repos/{owner}/{repo}/pulls/{number}/files", token)
+
+    # Truncate diff if too large, keeping the most relevant parts
+    if len(diff.encode()) > MAX_DIFF_BYTES:
+        diff = diff.encode()[:MAX_DIFF_BYTES].decode("utf-8", errors="replace")
+        diff += "\n\n[... diff truncated — showing first 80 KB ...]"
+
+    return PRInfo(
+        owner=owner,
+        repo=repo,
+        number=number,
+        title=pr.get("title", ""),
+        body=pr.get("body") or "",
+        author=pr.get("user", {}).get("login", "unknown"),
+        base_branch=pr.get("base", {}).get("ref", ""),
+        head_branch=pr.get("head", {}).get("ref", ""),
+        diff=diff,
+        files=files if isinstance(files, list) else [],
+        additions=pr.get("additions", 0),
+        deletions=pr.get("deletions", 0),
+        changed_files=pr.get("changed_files", 0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inline comment helpers
+# ---------------------------------------------------------------------------
+
+def parse_diff_positions(diff: str) -> list[dict]:
+    """
+    Parse the unified diff and return a list of hunk positions suitable for
+    GitHub pull_request review inline comments.
+
+    Each entry: {path, position, line (absolute), side, snippet}
+    """
+    positions = []
+    current_file = None
+    position = 0  # 1-based position within the diff hunk
+
+    for raw_line in diff.splitlines():
+        # New file in diff
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[6:]
+            position = 0
+            continue
+        if raw_line.startswith("---") or raw_line.startswith("diff "):
+            continue
+        if raw_line.startswith("@@"):
+            position = 0  # reset hunk position counter
+            # Extract new file start line from @@ -a,b +c,d @@
+            m = re.search(r"\+(\d+)", raw_line)
+            _new_start = int(m.group(1)) if m else 1
+            position += 1
+            continue
+        if current_file is None:
+            continue
+        if raw_line.startswith("+") or raw_line.startswith(" "):
+            position += 1
+            if raw_line.startswith("+"):
+                positions.append({
+                    "path": current_file,
+                    "position": position,
+                    "snippet": raw_line[1:].strip(),
+                })
+        # Lines starting with "-" are context for GitHub but don't advance position
+
+    return positions
+
+
+def build_inline_review_prompt(pr: PRInfo, positions: list[dict]) -> str:
+    file_list = "\n".join(f"  - {f['filename']} (+{f['additions']} -{f['deletions']})"
+                          for f in pr.files[:20])
+
+    pos_sample = json.dumps(positions[:50], indent=2)
+
+    return textwrap.dedent(f"""
+    You are a senior software engineer reviewing a GitHub Pull Request.
+
+    ## PR Details
+    - **Title**: {pr.title}
+    - **Author**: {pr.author}
+    - **Branch**: `{pr.head_branch}` → `{pr.base_branch}`
+    - **Stats**: +{pr.additions} -{pr.deletions} across {pr.changed_files} files
+
+    ## PR Description
+    {pr.body or "(no description provided)"}
+
+    ## Changed Files
+    {file_list}
+
+    ## Diff (added lines with their diff positions)
+    ```json
+    {pos_sample}
+    ```
+
+    Full diff:
+    ```diff
+    {pr.diff[:40000]}
+    ```
+
+    ## Task
+    Identify up to 8 specific lines in the diff that warrant an inline comment.
+    For each, output a JSON object on its own line (NDJSON):
+
+    {{"path": "src/foo.ts", "position": 12, "body": "**[Risk]** This value is user-controlled and not sanitized — consider `encodeURIComponent()` before use."}}
+
+    Rules:
+    - Only reference positions that exist in the positions array above.
+    - Categories: [Risk], [Suggestion], [Nitpick], [Question]
+    - Be specific — quote the exact code concern.
+    - Do NOT emit any other text. Output ONLY the NDJSON lines.
+    """).strip()
+
+
+def build_summary_review_prompt(pr: PRInfo) -> str:
+    file_list = "\n".join(f"  - {f['filename']} (+{f['additions']} -{f['deletions']})"
+                          for f in pr.files[:20])
+
+    return textwrap.dedent(f"""
+    You are a senior software engineer reviewing a GitHub Pull Request.
+    Provide a thorough, structured code review in Markdown.
+
+    ## PR Details
+    - **Title**: {pr.title}
+    - **Author**: {pr.author}
+    - **Branch**: `{pr.head_branch}` → `{pr.base_branch}`
+    - **Stats**: +{pr.additions} -{pr.deletions} across {pr.changed_files} files
+
+    ## PR Description
+    {pr.body or "(no description provided)"}
+
+    ## Changed Files
+    {file_list}
+
+    ## Diff
+    ```diff
+    {pr.diff}
+    ```
+
+    ## Output Format (Markdown, use exactly these headings)
+
+    # Code Review — {pr.owner}/{pr.repo}#{pr.number}
+
+    ## Summary
+    2–3 sentences describing the nature and purpose of the changes.
+
+    ## Identified Risks
+    Bullet list. Each item: risk type (Security / Logic / Performance / Data Loss / None),
+    description, and affected file:line if known.
+    If none: write "No significant risks identified."
+
+    ## Improvement Suggestions
+    Numbered list. Concrete, actionable, with code snippets where helpful.
+    If none: write "No suggestions — changes look good."
+
+    ## Confidence Score
+    One of: **Low** / **Medium** / **High**
+    One sentence justification.
+
+    Be direct and useful. Avoid generic praise.
+    """).strip()
+
+
+# ---------------------------------------------------------------------------
+# Output & posting
+# ---------------------------------------------------------------------------
+
+def post_review_comment(pr: PRInfo, body: str, token: str) -> str:
+    result = gh_post(
+        f"/repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments",
+        {"body": body},
+        token,
+    )
+    return result.get("html_url", "")
+
+
+def post_inline_comments(pr: PRInfo, inline_json: str, summary: str, token: str) -> str:
+    """
+    Create a pull request review with inline comments + summary body.
+    Uses the Reviews API so all inline comments appear in one review event.
+    """
+    comments = []
+    for line in inline_json.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            if "path" in obj and "position" in obj and "body" in obj:
+                comments.append({
+                    "path": obj["path"],
+                    "position": obj["position"],
+                    "body": obj["body"],
+                })
+        except json.JSONDecodeError:
+            continue  # skip malformed lines
+
+    payload = {
+        "body": summary,
+        "event": "COMMENT",
+        "comments": comments,
+    }
+    result = gh_post(
+        f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/reviews",
+        payload,
+        token,
+    )
+    return result.get("html_url", "")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=f"claude-review v{VERSION} — AI-powered PR review agent",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""
+        Examples:
+          claude-review --pr https://github.com/facebook/react/pull/28000
+          claude-review --pr owner/repo/123 --post
+          claude-review --pr owner/repo/123 --post --inline
+          claude-review --pr owner/repo/123 --model claude-opus-4-5-20251001
+        """),
+    )
+    parser.add_argument("--pr", required=True, metavar="URL|owner/repo/number",
+                        help="GitHub PR URL or owner/repo/number")
+    parser.add_argument("--post", action="store_true",
+                        help="Post review as a GitHub PR comment")
+    parser.add_argument("--inline", action="store_true",
+                        help="Add per-line inline comments in addition to summary")
+    parser.add_argument("--model", default=DEFAULT_MODEL,
+                        help=f"Claude model (default: {DEFAULT_MODEL})")
+    parser.add_argument("--json", dest="json_output", action="store_true",
+                        help="Output review as JSON instead of Markdown")
+    parser.add_argument("--version", action="version", version=f"claude-review {VERSION}")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_API_KEY")
+    if not api_key:
+        print("Error: ANTHROPIC_API_KEY (or CLAUDE_API_KEY) environment variable not set.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    gh_token = os.environ.get("GITHUB_TOKEN", "")
+    if not gh_token and args.post:
+        print("Error: GITHUB_TOKEN is required when using --post.", file=sys.stderr)
+        sys.exit(1)
+
+    owner, repo, number = parse_pr_ref(args.pr)
+    print(f"Fetching PR {owner}/{repo}#{number} …", file=sys.stderr)
+    pr = fetch_pr(owner, repo, number, gh_token or "")
+
+    print(f"Generating summary review via {args.model} …", file=sys.stderr)
+    summary_prompt = build_summary_review_prompt(pr)
+    summary = call_claude(summary_prompt, api_key, args.model)
+
+    inline_json: Optional[str] = None
+    if args.inline:
+        print("Generating inline comments …", file=sys.stderr)
+        positions = parse_diff_positions(pr.diff)
+        inline_prompt = build_inline_review_prompt(pr, positions)
+        inline_json = call_claude(inline_prompt, api_key, args.model)
+
+    if args.json_output:
+        out = {
+            "pr": f"{owner}/{repo}#{number}",
+            "title": pr.title,
+            "summary": summary,
+        }
+        if inline_json:
+            comments = []
+            for line in inline_json.strip().splitlines():
+                try:
+                    comments.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+            out["inline_comments"] = comments
+        print(json.dumps(out, indent=2))
+        return
+
+    # Plain Markdown output
+    print(summary)
+    if inline_json:
+        print("\n---\n## Inline Comments (raw NDJSON)\n")
+        print(inline_json)
+
+    if args.post:
+        if gh_token and args.inline and inline_json:
+            url = post_inline_comments(pr, inline_json, summary, gh_token)
+            print(f"\nReview with inline comments posted: {url}", file=sys.stderr)
+        elif gh_token:
+            url = post_review_comment(pr, summary, gh_token)
+            print(f"\nReview comment posted: {url}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/bounty-4-pr-review-agent/examples/review-pr-350.md
+++ b/bounty-4-pr-review-agent/examples/review-pr-350.md
@@ -1,0 +1,61 @@
+# Code Review — claude-builders-bounty/claude-builders-bounty#350
+
+> **Reviewed with:** `claude-review --pr claude-builders-bounty/claude-builders-bounty/350`
+
+---
+
+## Summary
+
+This PR adds a pre-tool-use security hook for Claude Code that intercepts destructive
+bash commands (recursive deletes, force-pushes, DDL statements) before execution.
+The implementation is a self-contained Python 3 script using only stdlib, paired with
+a README that covers installation, registration in `settings.json`, and manual test
+cases. The hook follows an allow-by-default strategy, blocking only the five explicitly
+enumerated patterns.
+
+## Identified Risks
+
+- **Logic / Medium** — `pre_tool_use_guard.py` uses `re.search()` (substring match)
+  for all patterns. A command like `echo "git push --force"` or a comment inside a
+  heredoc would trigger a false positive. Consider matching against the full token
+  sequence or requiring the pattern to appear outside of quoted strings.
+  _Affected:_ `hooks/pre_tool_use_guard/pre_tool_use_guard.py`
+
+- **Logic / Low** — The `DELETE FROM <table>` pattern whitelists the presence of a
+  `WHERE` clause by checking `not re.search(r"\bWHERE\b", cmd, re.IGNORECASE)`.
+  This means `DELETE FROM users WHERE 1=1` (deletes all rows) is silently allowed.
+  A stricter heuristic would check for a meaningful predicate, not just the keyword.
+  _Affected:_ `hooks/pre_tool_use_guard/pre_tool_use_guard.py`
+
+- **Data / Low** — The blocked-commands log path (`~/.claude/hooks/blocked.log`) is
+  hardcoded. On multi-user systems or when `HOME` is non-standard, this may fail
+  silently (the hook exits 0 on log-write errors, which is correct behavior, but the
+  failure is invisible). A startup warning if the log directory isn't writable would
+  improve observability.
+
+## Improvement Suggestions
+
+1. **Add a pattern for `chmod 777`** — granting world-write permissions is a common
+   mistake that belongs in the same destructive-command category.
+
+2. **Expose an allow-list** — power users may want to permit `rm -rf ./build` in CI
+   contexts. A `~/.claude/hooks/allowlist.json` checked before blocking would make
+   the hook usable in automation without disabling it entirely.
+
+3. **README install script has a placeholder URL** — the `curl` command references
+   `<your-fork>` which will fail as-is:
+   ```bash
+   # Before
+   curl -fsSL https://raw.githubusercontent.com/<your-fork>/pre_tool_use_guard.py
+   # After — use the canonical upstream URL
+   curl -fsSL https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/hooks/pre_tool_use_guard/pre_tool_use_guard.py
+   ```
+
+4. **Test for `TRUNCATE` with schema-qualified names** — `TRUNCATE public.users` would
+   bypass the current regex if it only matches bare `TRUNCATE <word>`.
+
+## Confidence Score
+
+**High** — The change is narrowly scoped, well-documented, and the logic is
+straightforward enough to reason about completely from the diff. Risks noted are
+edge-cases, not fundamental design flaws.

--- a/bounty-4-pr-review-agent/examples/review-pr-351.md
+++ b/bounty-4-pr-review-agent/examples/review-pr-351.md
@@ -1,0 +1,64 @@
+# Code Review — claude-builders-bounty/claude-builders-bounty#351
+
+> **Reviewed with:** `claude-review --pr claude-builders-bounty/claude-builders-bounty/351`
+
+---
+
+## Summary
+
+This PR adds a zero-dependency bash script (`changelog.sh`) that generates a
+categorised `CHANGELOG.md` from git history, plus a Claude Code skill file
+(`SKILL.md`) that exposes it as a `/generate-changelog` slash command.
+Categorisation is keyword-based (conventional commits supported), the script is
+idempotent (prepends new sections), and all options are surfaced via clean CLI flags.
+
+## Identified Risks
+
+- **Logic / Medium** — The categorisation relies on substring matching against commit
+  subject lines with no precedence order. A commit like `fix: remove deprecated auth`
+  contains both `fix:` (→ Fixed) and `remove` (→ Removed). Whichever branch is
+  evaluated first wins, which may produce surprising output. Explicit precedence
+  (feat > fix > remove > change) would make the behavior deterministic.
+  _Affected:_ `skills/changelog/changelog.sh`
+
+- **Data / Low** — `--since` accepts any string and passes it directly to
+  `git log --since="$SINCE"`. An argument like `--since "$(rm -rf ~)"` is a
+  command injection vector if the script is ever called from a web UI or CI
+  with user-controlled input. Validate that `$SINCE` matches a tag/date pattern
+  before interpolation.
+  _Affected:_ `skills/changelog/changelog.sh`
+
+- **Logic / Low** — The `--dry-run` flag prints to stdout but the script also
+  writes progress messages to stdout (not stderr). In pipelines
+  (`bash changelog.sh --dry-run | downstream-tool`) the progress messages will
+  be mixed into the CHANGELOG content. Route progress/status messages to stderr.
+
+## Improvement Suggestions
+
+1. **Support `--format keep-scope`** — conventional commits like `fix(auth): ...`
+   currently strip `fix(auth):` entirely. Many teams want the scope preserved:
+   `(auth) correct null pointer when config is missing`. A flag to control this
+   would widen adoption.
+
+2. **Add a `--tag` flag that creates a git tag after writing the CHANGELOG** —
+   the natural follow-up action after generating `## [v1.1.0]` is
+   `git tag v1.1.0`. Rolling this into the script eliminates a manual step and
+   is consistent with how `npm version` and `standard-version` work.
+
+3. **SKILL.md trigger list is incomplete** — users who type "update changelog" or
+   "what changed since last release" won't activate the skill. Add aliases:
+   ```markdown
+   - Update the changelog
+   - What changed since the last release?
+   - Create release notes
+   ```
+
+4. **The README sample output uses placeholder hashes** — `a1b2c3d`, `e4f5g6h`, etc.
+   Using real hashes from this repo (even from the bounty repo's own history) would
+   make the example more credible and testable.
+
+## Confidence Score
+
+**High** — Focused, self-contained change with clear scope. The identified risks are
+mostly edge cases in adversarial or pipeline contexts, not problems for the typical
+interactive use case.

--- a/templates/nextjs-sqlite-saas/CLAUDE.md
+++ b/templates/nextjs-sqlite-saas/CLAUDE.md
@@ -1,0 +1,402 @@
+# CLAUDE.md — Next.js 15 + SQLite SaaS
+
+Opinionated instructions for working on this codebase. Every rule has a reason.
+Follow these without asking for clarification on new features or bug fixes.
+
+---
+
+## Stack
+
+| Layer | Choice | Version | Why this, not the alternative |
+|---|---|---|---|
+| Framework | Next.js App Router | 15.x | Server Components eliminate client-side data-fetching boilerplate; PPR for instant shells |
+| Language | TypeScript | 5.x strict | Strict null checks prevent the majority of runtime errors in DB-heavy code |
+| Database | SQLite via `better-sqlite3` | 9.x | Synchronous API fits Next.js Server Components naturally; zero-infra for indie SaaS |
+| DB (cloud) | Turso (libSQL) | latest | Use when deploying to edge or multi-region; API-compatible with `better-sqlite3` |
+| Auth | `better-auth` | 1.x | Built for Next.js App Router; supports OAuth + magic link without a separate service |
+| Validation | Zod | 3.x | Single schema used for both DB input and API boundary validation |
+| Payments | Stripe | latest | Webhook-driven; never trust client-side success callbacks |
+| Styles | Tailwind CSS | 4.x | Utility-first keeps components self-contained; no CSS files to maintain |
+| Testing | Vitest + Playwright | latest | Vitest is faster than Jest for TS projects; Playwright for auth/payment flows |
+| Runtime | Node.js | 22.x LTS | Required for `better-sqlite3` native bindings; do not use edge runtime for DB routes |
+
+---
+
+## Folder Structure
+
+```
+src/
+├── app/
+│   ├── (auth)/                 # Login, register, reset-password (unauthenticated)
+│   ├── (dashboard)/            # Protected pages — always wrap in auth check
+│   │   ├── layout.tsx          # Single auth guard here — never repeat in child pages
+│   │   └── settings/
+│   ├── api/                    # Route handlers only — no business logic here
+│   │   ├── webhooks/
+│   │   │   └── stripe/route.ts # Must verify Stripe signature before any DB write
+│   │   └── ...
+│   ├── layout.tsx
+│   └── page.tsx
+├── components/
+│   ├── ui/                     # Primitives (Button, Input, Modal) — no data fetching
+│   └── features/               # Feature components — may accept server-fetched props
+├── lib/
+│   ├── db/
+│   │   ├── client.ts           # Singleton DB connection — import this, never open raw
+│   │   ├── migrations/         # SQL files only, numbered, never modified after merge
+│   │   └── queries/            # Typed query functions — one file per domain
+│   ├── auth/
+│   │   └── config.ts           # better-auth config — auth logic lives only here
+│   ├── stripe/
+│   │   └── client.ts           # Stripe SDK singleton + webhook helpers
+│   ├── schemas/                # Zod schemas shared between server and client
+│   └── utils/                  # Pure functions, no side effects, no imports from lib/db
+├── scripts/
+│   ├── migrate.ts              # Run with: pnpm db:migrate
+│   └── seed.ts                 # Run with: pnpm db:seed (dev only)
+└── types/
+    └── index.ts                # Global type augmentations (e.g. Session extension)
+```
+
+**Rules:**
+- `app/api/` route handlers call `lib/db/queries/` — never call `lib/db/client.ts` directly from a route handler.
+- `components/ui/` must never import from `lib/db/` or `lib/auth/`.
+- `lib/utils/` must never import from `lib/db/`, `lib/auth/`, or `lib/stripe/`.
+
+---
+
+## Dev Commands
+
+```bash
+pnpm dev           # Next.js dev server (http://localhost:3000)
+pnpm build         # Production build
+pnpm lint          # ESLint
+pnpm typecheck     # tsc --noEmit
+pnpm test          # Vitest unit + integration
+pnpm test:e2e      # Playwright end-to-end
+pnpm db:migrate    # Apply all pending migrations
+pnpm db:seed       # Seed dev data (never run in production)
+pnpm db:studio     # Open Drizzle Studio / sqlite-web for DB inspection
+pnpm stripe:listen # Forward Stripe webhooks to localhost (requires Stripe CLI)
+```
+
+Always run `pnpm typecheck` before committing changes that touch `lib/` or `app/api/`.
+
+---
+
+## Database & Migration Rules
+
+### Connection singleton (`lib/db/client.ts`)
+
+```typescript
+import Database from 'better-sqlite3';
+import path from 'path';
+
+const DB_PATH = process.env.DATABASE_URL ?? path.join(process.cwd(), 'data', 'app.db');
+
+// Module-level singleton — Next.js HMR can re-evaluate modules; guard against
+// opening multiple connections in development.
+const globalForDb = global as unknown as { db: Database.Database };
+
+export const db = globalForDb.db ?? new Database(DB_PATH);
+
+if (process.env.NODE_ENV !== 'production') globalForDb.db = db;
+
+// Always on — SQLite defers FK checks by default.
+db.pragma('foreign_keys = ON');
+// WAL mode: readers don't block writers; required for concurrent Server Actions.
+db.pragma('journal_mode = WAL');
+```
+
+**Why the global singleton pattern:** Next.js hot-reloads modules in development,
+which would open a new file handle on every save without this guard.
+
+### Migration files
+
+- Location: `lib/db/migrations/`
+- Naming: `NNNN_snake_case_description.sql` (e.g., `0001_create_users.sql`)
+- **Never modify a migration file after it has been merged to main.** Create a new one.
+- Every migration must be idempotent: use `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`.
+- Include both `-- migrate:up` and `-- migrate:down` sections.
+
+```sql
+-- migrate:up
+CREATE TABLE IF NOT EXISTS users (
+  id          TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  email       TEXT NOT NULL UNIQUE,
+  name        TEXT,
+  plan        TEXT NOT NULL DEFAULT 'free' CHECK (plan IN ('free', 'pro', 'enterprise')),
+  stripe_customer_id TEXT UNIQUE,
+  created_at  INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at  INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_stripe_customer_id ON users(stripe_customer_id);
+
+-- migrate:down
+DROP TABLE IF EXISTS users;
+```
+
+**Why `INTEGER` for timestamps, not `DATETIME`:** SQLite stores DATETIME as text,
+which makes range queries, ordering, and arithmetic awkward. `unixepoch()` is an
+integer; convert to `Date` in the query layer.
+
+**Why `lower(hex(randomblob(16)))` for IDs:** Produces a 32-char hex UUID-equivalent
+without requiring an extension. Avoids auto-increment IDs leaking row counts to clients.
+
+### Query functions (`lib/db/queries/`)
+
+One file per domain (e.g., `users.ts`, `subscriptions.ts`). All DB access goes here.
+Return typed objects — never return raw SQLite row objects to calling code.
+
+```typescript
+// lib/db/queries/users.ts
+import { db } from '../client';
+import { z } from 'zod';
+
+const UserSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  name: z.string().nullable(),
+  plan: z.enum(['free', 'pro', 'enterprise']),
+  stripe_customer_id: z.string().nullable(),
+  created_at: z.number().transform(ts => new Date(ts * 1000)),
+  updated_at: z.number().transform(ts => new Date(ts * 1000)),
+});
+export type User = z.infer<typeof UserSchema>;
+
+export function getUserByEmail(email: string): User | null {
+  const row = db.prepare('SELECT * FROM users WHERE email = ?').get(email);
+  if (!row) return null;
+  return UserSchema.parse(row);
+}
+
+export function createUser(data: { email: string; name?: string }): User {
+  const stmt = db.prepare(
+    'INSERT INTO users (email, name) VALUES (?, ?) RETURNING *'
+  );
+  const row = stmt.get(data.email, data.name ?? null);
+  return UserSchema.parse(row);
+}
+```
+
+**Why validate on read:** SQLite doesn't enforce column types. A Zod parse on read
+surfaces schema drift immediately instead of crashing in a React component.
+
+---
+
+## Authentication Rules
+
+Auth is handled entirely by `better-auth`. Do not implement custom JWT logic.
+
+```typescript
+// lib/auth/config.ts
+import { betterAuth } from 'better-auth';
+import { db } from '../db/client';
+
+export const auth = betterAuth({
+  database: { db, type: 'sqlite' },
+  emailAndPassword: { enabled: true },
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID!,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+    },
+  },
+});
+```
+
+- **Always call `auth.api.getSession()` in Server Components** to get the current user.
+  Never read the session from client-side cookies directly.
+- **Auth guard goes in the dashboard layout** (`app/(dashboard)/layout.tsx`), not in
+  individual pages. Redirect to `/login` if no session.
+- **Never expose `stripe_customer_id` or `password_hash` in Server Component props**
+  passed to Client Components.
+
+---
+
+## Stripe & Billing Rules
+
+- **Always verify the webhook signature** before reading `event.data`.
+  Unverified webhooks are a privilege-escalation vector.
+- **Plan upgrades come from webhooks only.** When a checkout succeeds, the client
+  redirects to a success page, but the DB plan update happens in the webhook handler
+  (`customer.subscription.updated`), not on success page load.
+- **Never trust `?session_id` on the success page** to grant access. It's informational only.
+
+```typescript
+// app/api/webhooks/stripe/route.ts
+import Stripe from 'stripe';
+import { headers } from 'next/headers';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const sig = (await headers()).get('stripe-signature')!;
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+  } catch {
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  if (event.type === 'customer.subscription.updated') {
+    // update plan in DB here
+  }
+
+  return new Response('ok');
+}
+```
+
+---
+
+## Component Patterns
+
+### Server Components (default)
+
+Use Server Components for anything that reads from the DB or needs the session.
+Do not add `'use client'` unless the component needs browser APIs or event handlers.
+
+```typescript
+// app/(dashboard)/settings/page.tsx
+import { auth } from '@/lib/auth/config';
+import { getUserByEmail } from '@/lib/db/queries/users';
+import { headers } from 'next/headers';
+
+export default async function SettingsPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect('/login');
+
+  const user = getUserByEmail(session.user.email);
+  return <SettingsForm user={user} />;
+}
+```
+
+### Server Actions (mutations)
+
+All form submissions use Server Actions. No separate API routes for form handling.
+
+```typescript
+// lib/actions/profile.ts
+'use server';
+import { auth } from '@/lib/auth/config';
+import { updateUser } from '@/lib/db/queries/users';
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+
+const UpdateProfileSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
+export async function updateProfile(formData: FormData) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) throw new Error('Unauthorized');
+
+  const { name } = UpdateProfileSchema.parse({
+    name: formData.get('name'),
+  });
+
+  updateUser(session.user.id, { name });
+  revalidatePath('/dashboard/settings');
+}
+```
+
+- **Always re-authenticate in Server Actions.** Never trust a user ID passed from
+  the client in form data — always derive the user ID from the server-side session.
+- **Validate with Zod before any DB write.**
+
+---
+
+## What We Don't Do (and Why)
+
+| Pattern | Why we avoid it |
+|---|---|
+| `useEffect` for data fetching | Server Components fetch data — no loading spinners, no waterfalls |
+| API routes for form submissions | Server Actions are colocated, type-safe, and don't need `fetch()` |
+| Client-side plan/entitlement checks | Trivially bypassable; always check on the server |
+| ORM (Prisma, Drizzle) | Adds a migration layer we don't need; raw SQL is explicit and auditable |
+| `any` in TypeScript | Defeats the point of strict mode; use `unknown` + narrowing |
+| Auto-increment integer PKs | Leaks row counts; use `randomblob(16)` hex IDs |
+| `DATETIME` columns in SQLite | Use `INTEGER` (unix epoch); range queries and ordering are correct |
+| `DELETE FROM table` without WHERE | Never. Use `WHERE id = ?`. The query layer enforces this. |
+| Storing JWTs in localStorage | XSS-exposed; `better-auth` uses `HttpOnly` cookies |
+| Trust Stripe checkout redirect for plan upgrade | Webhooks are authoritative; redirects are informational |
+| `process.env` in Client Components | Leaks secrets; only `NEXT_PUBLIC_` vars go to the client |
+| Modifying merged migrations | Create a new migration instead; existing data may depend on the original |
+
+---
+
+## Environment Variables
+
+```bash
+# .env.local (never commit)
+DATABASE_URL=./data/app.db          # Omit for default path
+
+BETTER_AUTH_SECRET=                 # 32+ random bytes: openssl rand -base64 32
+BETTER_AUTH_URL=http://localhost:3000
+
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+```
+
+**Rules:**
+- `NEXT_PUBLIC_` prefix: only for values that must be readable in the browser.
+- Never add `STRIPE_SECRET_KEY` or `BETTER_AUTH_SECRET` with a `NEXT_PUBLIC_` prefix.
+- `.env.local` is gitignored. Use `.env.example` (committed, no real values) as the reference.
+
+---
+
+## Testing
+
+### Unit tests (Vitest)
+
+Test query functions against an in-memory SQLite database:
+
+```typescript
+// lib/db/queries/users.test.ts
+import Database from 'better-sqlite3';
+import { vi, beforeEach, it, expect } from 'vitest';
+
+vi.mock('../client', () => ({ db: new Database(':memory:') }));
+
+beforeEach(() => {
+  // run migrations against in-memory DB
+});
+
+it('returns null for unknown email', () => {
+  expect(getUserByEmail('nobody@example.com')).toBeNull();
+});
+```
+
+### E2E tests (Playwright)
+
+Cover the three critical paths: sign-up, upgrade to paid plan, and login after
+password reset. Mock Stripe webhooks using `stripe trigger` in beforeAll.
+
+---
+
+## Naming Conventions
+
+- **Files**: `kebab-case.ts` / `kebab-case.tsx`
+- **Components**: `PascalCase`
+- **Functions / variables**: `camelCase`
+- **DB columns**: `snake_case`
+- **Environment variables**: `SCREAMING_SNAKE_CASE`; app-specific vars prefixed with nothing (not `APP_`)
+- **Migration files**: `NNNN_description.sql` where NNNN is zero-padded (0001, 0002, …)
+- **Server Actions**: exported async functions in `lib/actions/*.ts`, named by operation (`updateProfile`, `cancelSubscription`)
+
+---
+
+## Git Conventions
+
+- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`
+- One migration per PR when possible — easier to roll back
+- Do not commit `data/` (SQLite file) — it is gitignored
+- Do not commit `.env.local` — use `.env.example`


### PR DESCRIPTION
## Summary

A Python CLI (`claude-review`) and GitHub Action that reviews any GitHub PR via the Anthropic API and posts structured Markdown feedback — including per-line inline comments anchored to diff positions.

## Acceptance criteria

- [x] Works via CLI: `claude-review --pr https://github.com/owner/repo/pull/123`
- [x] Works via GitHub Action (`.github/workflows/claude-review.yml`)
- [x] Structured Markdown output: Summary, Identified Risks, Improvement Suggestions, Confidence Score
- [x] Tested on 2 real PRs (see `examples/`)
- [x] README with setup and usage

## What is included

- `bounty-4-pr-review-agent/claude-review` — Python 3 CLI, stdlib only (no pip install)
- `bounty-4-pr-review-agent/.github/workflows/claude-review.yml` — GitHub Action
- `bounty-4-pr-review-agent/README.md` — setup, options, output format
- `bounty-4-pr-review-agent/examples/` — two real PR review outputs

## How it works

Two-pass review: (1) narrative summary call producing structured Markdown with risks, suggestions, and confidence score; (2) inline comment call producing NDJSON mapped to diff hunk positions.

Inline comments use the GitHub Reviews API so all per-line notes appear as a single review event, anchored to the exact changed lines — the same UX as a human code reviewer.

Zero dependencies — Python 3 stdlib only. Works on macOS, Linux, and any CI runner without a pip install step.

Closes #4
