### PR TITLE
[BOUNTY $100] HOOK: Pre-tool-use hook that blocks destructive commands

### DIFF
--- a/skills/pre-tool-use-hook/README.md
+++ b/skills/pre-tool-use-hook/README.md
@@ -1,0 +1,58 @@
+# Claude Code Pre-Tool-Use Hook
+
+A Python hook that blocks destructive bash commands before execution.
+
+## Installation
+
+```bash
+mkdir -p ~/.claude/hooks
+cp pre_tool_hook.py ~/.claude/hooks/pre-tool-use.py
+chmod +x ~/.claude/hooks/pre-tool-use.py
+```
+
+## Features
+
+✅ Blocks dangerous patterns:
+- `rm -rf` (recursive delete)
+- `DROP TABLE` (database)
+- `git push --force` (force push)
+- `TRUNCATE` (database)
+- `DELETE FROM` without WHERE clause
+- Fork bombs and device writes
+
+✅ Logs all blocked attempts to `~/.claude/hooks/blocked.log`
+
+✅ Shows clear warning message
+
+✅ Non-intrusive - doesn't affect normal commands
+
+## Usage
+
+Once installed, Claude Code will automatically check commands before execution.
+
+If a dangerous command is detected:
+```
+⚠️  BLOCKED: Destructive command detected!
+   Command: rm -rf /important/data
+   Project: /home/user/project
+   
+   This command matches a blocked pattern.
+   See blocked.log for details.
+```
+
+## View Blocked Commands
+
+```bash
+cat ~/.claude/hooks/blocked.log
+```
+
+## How It Works
+
+1. Claude Code calls the pre-tool-use hook before executing bash commands
+2. Hook checks command against blocked patterns
+3. If match found: logs attempt and blocks execution
+4. If safe: allows execution to proceed
+
+## Customization
+
+Edit `BLOCKED_PATTERNS` in `pre_tool_hook.py` to add/remove patterns.

--- a/skills/pre-tool-use-hook/pre_tool_hook.py
+++ b/skills/pre-tool-use-hook/pre_tool_hook.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Claude Code Pre-Tool-Use Hook
+Blocks destructive bash commands before execution
+
+Install: Copy to ~/.claude/hooks/pre-tool-use.py
+"""
+
+import os
+import sys
+import re
+from datetime import datetime
+from pathlib import Path
+
+# Configuration
+BLOCKED_PATTERNS = [
+    r'rm\s+-rf\s+',           # Delete recursively
+    r'DROP\s+TABLE',          # Drop database table
+    r'git\s+push\s+--force',  # Force push
+    r'TRUNCATE',              # Truncate table
+    r'DELETE\s+FROM\s+(?!\w+\s+WHERE)',  # Delete without WHERE
+    r'--all\s+--force',       # Git force all
+    r'rm\s+-\s*[rf]',        # rm -rf variations
+    r'>\s*/dev/sd',           # Direct device write
+    r':\(\)\{',               # Fork bomb
+]
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+def log_blocked(command: str, project_path: str):
+    """Log blocked command to file"""
+    Path(LOG_FILE).parent.mkdir(parents=True, exist_ok=True)
+    
+    timestamp = datetime.now().isoformat()
+    with open(LOG_FILE, "a") as f:
+        f.write(f"[{timestamp}] BLOCKED: {command}\n")
+        f.write(f"  Project: {project_path}\n\n")
+
+def is_dangerous(command: str) -> bool:
+    """Check if command matches any blocked pattern"""
+    for pattern in BLOCKED_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return True
+    return False
+
+def get_project_path() -> str:
+    """Get current project path"""
+    # Try to get from git repo
+    try:
+        result = os.popen("git rev-parse --show-toplevel 2>/dev/null").read().strip()
+        if result:
+            return result
+    except:
+        pass
+    
+    # Fallback to cwd
+    return os.getcwd()
+
+def main():
+    # Read input from Claude Code
+    input_data = sys.stdin.read()
+    
+    # Parse the command from input
+    # Claude Code sends JSON with tool_name and tool_input
+    
+    if not input_data:
+        sys.exit(0)  # No input, allow
+    
+    # Check if this is a bash command
+    if '"bash"' in input_data or '"shell"' in input_data:
+        # Extract command from input
+        import json
+        try:
+            data = json.loads(input_data)
+            command = data.get("command", "")
+            
+            if is_dangerous(command):
+                project = get_project_path()
+                log_blocked(command, project)
+                
+                # Block the command
+                print("\n⚠️  BLOCKED: Destructive command detected!")
+                print(f"   Command: {command[:80]}...")
+                print(f"   Project: {project}")
+                print(f"\n   This command matches a blocked pattern.")
+                print(f"   See blocked.log for details.")
+                
+                # Exit with error to block
+                sys.exit(1)
+        except json.JSONDecodeError:
+            pass
+    
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Pre-Tool-Use Hook for Claude Code

Closes #3

### Features
- Blocks dangerous bash commands before execution
- Patterns: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, etc.
- Logs all blocked attempts to `~/.claude/hooks/blocked.log`
- Clear warning message with project path
- 2-command installation

### Installation
```bash
mkdir -p ~/.claude/hooks
cp pre_tool_hook.py ~/.claude/hooks/pre-tool-use.py
```

### Files
- `skills/pre-tool-use-hook/pre_tool_hook.py` - Main hook
- `skills/pre-tool-use-hook/README.md` - Documentation

### Test
1. Install hook
2. Try `rm -rf /` → Blocked!
3. Check `~/.claude/hooks/blocked.log`