### PR TITLE
[Issue #3] Pre-tool-use hook: blocks destructive bash commands

### DIFF
--- a/submissions/safe-bash-hook/README.md
+++ b/submissions/safe-bash-hook/README.md
@@ -1,0 +1,45 @@
+# Claude Code Safe Bash Hook
+
+Pre-tool-use hook that intercepts and blocks destructive bash commands before Claude executes them.
+
+## Install (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks
+cp safe_bash_hook.py ~/.claude/hooks/
+```
+
+Then add to `~/.claude/settings.json`:
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "python3 ~/.claude/hooks/safe_bash_hook.py" }]
+      }
+    ]
+  }
+}
+```
+
+## What It Blocks
+
+| Pattern | Reason |
+|---|---|
+| `rm -rf` | Irreversible recursive file deletion |
+| `DROP TABLE` | Permanently deletes a database table |
+| `git push --force` | Overwrites remote git history |
+| `TRUNCATE` | Removes all rows from a table |
+| `DELETE FROM` without WHERE | Deletes all rows in a table |
+
+## Logging
+
+Every blocked attempt is logged to `~/.claude/hooks/blocked.log`:
+```
+[2026-04-02T09:00:00] BLOCKED | project=/home/user/myapp | reason=rm -rf is destructive | cmd=rm -rf /tmp/test
+```
+
+## Normal Commands
+
+All non-destructive bash commands pass through unaffected.

--- a/submissions/safe-bash-hook/safe_bash_hook.py
+++ b/submissions/safe-bash-hook/safe_bash_hook.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook — blocks destructive bash commands.
+Place at: ~/.claude/hooks/safe_bash_hook.py
+"""
+import json
+import sys
+import re
+import os
+from datetime import datetime
+from pathlib import Path
+
+LOG_FILE = Path.home() / ".claude/hooks/blocked.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+BLOCKED_PATTERNS = [
+    (r'\brm\s+-[^\s]*r[^\s]*\s+-[^\s]*f|rm\s+-[^\s]*f[^\s]*\s+-[^\s]*r|\brm\s+-rf\b|\brm\s+-fr\b', "rm -rf is destructive and irreversible"),
+    (r'\bDROP\s+TABLE\b', "DROP TABLE permanently deletes a database table"),
+    (r'\bgit\s+push\s+--force\b|\bgit\s+push\s+-f\b', "git push --force can overwrite remote history"),
+    (r'\bTRUNCATE\b', "TRUNCATE permanently removes all rows from a table"),
+    (r'\bDELETE\s+FROM\s+\w+\s*(?:;|$)', "DELETE without WHERE clause removes all rows"),
+]
+
+def check_command(command: str) -> tuple[bool, str]:
+    """Returns (is_blocked, reason)."""
+    for pattern, reason in BLOCKED_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return True, reason
+    return False, ""
+
+def log_blocked(command: str, reason: str, project_path: str):
+    with open(LOG_FILE, "a") as f:
+        f.write(f"[{datetime.now().isoformat()}] BLOCKED | project={project_path} | reason={reason} | cmd={command}\n")
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = hook_input.get("tool_name", "")
+    tool_input = hook_input.get("tool_input", {})
+
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = tool_input.get("command", "")
+    project_path = hook_input.get("cwd", os.getcwd())
+
+    blocked, reason = check_command(command)
+
+    if blocked:
+        log_blocked(command, reason, project_path)
+        print(json.dumps({
+            "decision": "block",
+            "reason": f"🚫 Blocked: {reason}. Command: `{command[:100]}`. Check ~/.claude/hooks/blocked.log for full log."
+        }))
+        sys.exit(0)
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3

## What's included
- `safe_bash_hook.py` — Python hook following Claude Code hooks format
- Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, project path
- Returns structured JSON with clear explanation to Claude
- Normal bash commands pass through unaffected
- README with install in 2 commands

## Install
```bash
mkdir -p ~/.claude/hooks
cp submissions/safe-bash-hook/safe_bash_hook.py ~/.claude/hooks/
```