### PR TITLE
feat(bounty#1): generate-changelog — auto-categorized CHANGELOG from git history

### DIFF
--- a/submissions/changelog-skill/README.md
+++ b/submissions/changelog-skill/README.md
@@ -1,0 +1,63 @@
+# generate-changelog
+
+Auto-generate a structured `CHANGELOG.md` from your git history in seconds.
+
+## Setup (3 steps)
+
+1. Copy `changelog.sh` to your project root
+2. Make it executable: `chmod +x changelog.sh`
+3. Run it: `bash changelog.sh`
+
+## Usage
+
+```bash
+# Auto-detect last tag, write to CHANGELOG.md
+bash changelog.sh
+
+# Since a specific tag
+bash changelog.sh v1.2.0
+
+# Custom output file
+bash changelog.sh v1.2.0 RELEASES.md
+```
+
+## What it does
+
+- Fetches all commits since the last git tag (or all commits if no tags exist)
+- Auto-categorizes into **Added / Fixed / Changed / Removed / Other**
+- Uses conventional commit prefixes when present (`feat:`, `fix:`, `chore:` etc.)
+- Prepends new section to existing `CHANGELOG.md` — history is never lost
+- Works on any git repo, zero dependencies
+
+## Categorization Rules
+
+| Prefix | Section |
+|---|---|
+| `feat`, `add`, `new`, `implement`, `create` | ✨ Added |
+| `fix`, `bug`, `patch`, `resolve`, `hotfix` | 🐛 Fixed |
+| `remove`, `delete`, `drop`, `deprecate`, `revert` | 🗑️ Removed |
+| `update`, `change`, `refactor`, `improve`, `bump`, `chore`, `perf`, `docs`, `ci` | 🔄 Changed |
+| Everything else | 📝 Other |
+
+## Sample Output
+
+```markdown
+# Changelog
+
+## [Unreleased] — since `v1.2.0` (2026-04-02)
+
+### ✨ Added
+- New image upscaling endpoint with 4x super-resolution
+- Discord bot with sales automation and memory
+
+### 🐛 Fixed
+- Pinterest board selector failing on mobile viewport
+- YouTube auth token refresh loop on expired sessions
+
+### 🔄 Changed
+- Upgraded Playwright to 1.52 for Chrome 145 compatibility
+- Refactored brand_cron to bypass godmode for all platforms
+
+### 🗑️ Removed
+- Legacy cookie-injection method for Instagram posting
+```

--- a/submissions/changelog-skill/changelog.sh
+++ b/submissions/changelog-skill/changelog.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# generate-changelog: auto-generate CHANGELOG.md from git history
+# Usage: bash changelog.sh [since-tag] [output-file]
+# If no tag provided, uses the last git tag. If no tags exist, uses all commits.
+
+set -euo pipefail
+
+SINCE_TAG="${1:-}"
+OUTPUT="${2:-CHANGELOG.md}"
+DATE=$(date +%Y-%m-%d)
+
+# Detect since tag
+if [ -z "$SINCE_TAG" ]; then
+  SINCE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+fi
+
+if [ -n "$SINCE_TAG" ]; then
+  RANGE="${SINCE_TAG}..HEAD"
+  HEADER="## [Unreleased] — since \`${SINCE_TAG}\` (${DATE})"
+else
+  RANGE="HEAD"
+  HEADER="## [Unreleased] — ${DATE}"
+fi
+
+echo "📋 Generating changelog ${SINCE_TAG:+from $SINCE_TAG }to HEAD..."
+
+# Fetch all commit messages in range
+COMMITS=$(git log "$RANGE" --pretty=format:"%s" --no-merges 2>/dev/null || git log --pretty=format:"%s" --no-merges)
+
+if [ -z "$COMMITS" ]; then
+  echo "⚠️  No commits found."
+  exit 0
+fi
+
+# Categorize commits
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+while IFS= read -r msg; do
+  lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+  # Strip conventional commit prefixes for display
+  clean=$(echo "$msg" | sed -E 's/^(feat|fix|chore|refactor|docs|style|test|perf|ci|build|revert)(\([^)]*\))?!?:\s*//')
+
+  if echo "$lower" | grep -qE '^(feat|add|new|implement|create|introduce|support)'; then
+    ADDED="${ADDED}- ${clean}\n"
+  elif echo "$lower" | grep -qE '^(fix|bug|patch|correct|resolve|close|hotfix)'; then
+    FIXED="${FIXED}- ${clean}\n"
+  elif echo "$lower" | grep -qE '^(remove|delete|drop|deprecate|revert)'; then
+    REMOVED="${REMOVED}- ${clean}\n"
+  elif echo "$lower" | grep -qE '^(update|change|refactor|improve|bump|upgrade|migrate|rename|move|replace|chore|perf|style|docs|ci|build|test)'; then
+    CHANGED="${CHANGED}- ${clean}\n"
+  else
+    OTHER="${OTHER}- ${clean}\n"
+  fi
+done <<< "$COMMITS"
+
+# Build changelog content
+{
+  # Prepend to existing CHANGELOG if it exists
+  echo "# Changelog"
+  echo ""
+  echo "$HEADER"
+  echo ""
+
+  if [ -n "$ADDED" ]; then
+    echo "### ✨ Added"
+    printf "%b" "$ADDED"
+    echo ""
+  fi
+
+  if [ -n "$FIXED" ]; then
+    echo "### 🐛 Fixed"
+    printf "%b" "$FIXED"
+    echo ""
+  fi
+
+  if [ -n "$CHANGED" ]; then
+    echo "### 🔄 Changed"
+    printf "%b" "$CHANGED"
+    echo ""
+  fi
+
+  if [ -n "$REMOVED" ]; then
+    echo "### 🗑️ Removed"
+    printf "%b" "$REMOVED"
+    echo ""
+  fi
+
+  if [ -n "$OTHER" ]; then
+    echo "### 📝 Other"
+    printf "%b" "$OTHER"
+    echo ""
+  fi
+
+  # Append previous changelog content (skip existing "# Changelog" header)
+  if [ -f "$OUTPUT" ]; then
+    tail -n +2 "$OUTPUT"
+  fi
+
+} > "${OUTPUT}.tmp"
+
+mv "${OUTPUT}.tmp" "$OUTPUT"
+echo "✅ Changelog written to $OUTPUT"


### PR DESCRIPTION
Closes #1

## Solution
A zero-dependency bash script that generates a structured `CHANGELOG.md` from git history.

## How it works
- Auto-detects last git tag via `git describe`
- Categorizes commits by prefix: `feat` → Added, `fix` → Fixed, `chore/refactor/update` → Changed, `remove` → Removed
- Prepends new section to existing CHANGELOG — history is never lost
- Works on any git repo with zero dependencies

## Usage
```bash
bash changelog.sh              # auto-detect last tag
bash changelog.sh v1.2.0       # since specific tag
bash changelog.sh v1.2.0 RELEASES.md  # custom output
```

## Sample Output
```markdown
# Changelog

## [Unreleased] — since `v1.2.0` (2026-04-02)

### ✨ Added
- New image upscaling endpoint with 4x super-resolution

### 🐛 Fixed  
- Pinterest board selector failing on mobile viewport

### 🔄 Changed
- Upgraded Playwright to 1.52 for Chrome 145 compatibility

### 🗑️ Removed
- Legacy cookie-injection method for Instagram posting
```

Tested on this repo and a private project with 200+ commits. Works with and without existing tags.