### PR TITLE
Feat: Add script to auto-generate CHANGELOG from git history (Fixes #1)

### DIFF
--- a/README-CHANGELOG-BOUNTY.md
+++ b/README-CHANGELOG-BOUNTY.md
@@ -1,0 +1,25 @@
+# Automated Changelog Generator (Issue #1)
+
+This solution provides a robust Bash script and a Claude Code `SKILL.md` to automatically generate a structured `CHANGELOG.md` from a project's git history, fulfilling the requirements for Bounty #1.
+
+## Features
+- **Dependency Checks:** Ensures `claude` and `git` are installed before running.
+- **Tag Detection:** Automatically finds the last git tag and fetches commits since that tag. If no tags exist, it fetches recent commits.
+- **Safe Interpolation:** Commit messages are passed safely via a temporary file, avoiding arbitrary bash variable expansion (e.g., if a commit message contains `$PATH`).
+- **Token Limits:** Limits the fetch to the last 500 commits to prevent overwhelming the LLM context window.
+
+## Usage
+
+### Option 1: Direct Bash Script
+Simply execute the script in your git repository:
+```bash
+bash ./generate-changelog.sh
+```
+It will analyze the commits and output a cleanly formatted `CHANGELOG_NEW.md` using the Anthropic Claude CLI.
+
+### Option 2: Claude Code Skill
+If you are using Claude Code, the provided `SKILL.md` acts as a custom skill definition. Place it in your project's `.claude/skills/` directory (or wherever you manage skills) so Claude knows how to invoke the changelog generation.
+
+## Requirements
+- `git`
+- [Anthropic Claude CLI](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) (`npm install -g @anthropic-ai/claude-cli`)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,13 @@
+# Skill: Generate Structured Changelog
+# Description: Automatically generates a structured CHANGELOG.md from git history using Claude Code.
+
+# PREREQUISITES
+# 1. `git` installed in the repository
+# 2. `claude` (Anthropic Claude Code CLI) installed and authenticated
+
+# USAGE
+# To use this skill, the user or agent must run:
+# bash ./generate-changelog.sh
+
+# The script finds the last git tag, grabs all commit messages since then,
+# and asks Claude to format them into Added/Fixed/Changed/Removed categories, saving the result to CHANGELOG_NEW.md.

--- a/generate-changelog.sh
+++ b/generate-changelog.sh
@@ -1,23 +1,41 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
-# Find the last tag
+# 1. Dependency check
+if ! command -v claude &> /dev/null; then
+    echo "Error: 'claude' CLI is not installed or not in PATH."
+    exit 1
+fi
+
+if ! command -v git &> /dev/null; then
+    echo "Error: 'git' is not installed."
+    exit 1
+fi
+
+# 2. Get commits safely
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
 if [ -z "$LAST_TAG" ]; then
-    echo "No previous tags found. Fetching all commits..."
-    COMMITS=$(git log --pretty=format:"- %s")
+    echo "No previous tags found. Fetching all commits (up to 500)..."
+    COMMITS=$(git log --pretty=format:"- %s" -n 500)
 else
-    echo "Fetching commits since tag: $LAST_TAG"
-    COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s")
+    echo "Fetching commits since tag: $LAST_TAG..."
+    COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s" -n 500)
 fi
 
 if [ -z "$COMMITS" ]; then
-    echo "No new commits found."
+    echo "No new commits found since last tag. Exiting."
     exit 0
 fi
 
-cat << PROMPT_EOF > changelog_prompt.txt
+# 3. Create a secure temp file
+PROMPT_FILE=$(mktemp)
+
+# Clean up trap
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
+# 4. Write prompt literally (no interpolation)
+cat << 'PROMPT_EOF' > "$PROMPT_FILE"
 You are a strict release notes generator. Group the following commit messages exactly into these categories:
 ### Added
 ### Fixed
@@ -27,10 +45,12 @@ You are a strict release notes generator. Group the following commit messages ex
 Do not include empty categories. Format as valid Markdown.
 
 Commits:
-$COMMITS
 PROMPT_EOF
 
+# Append commits safely without expanding any $VARIABLES inside commit messages
+echo "$COMMITS" >> "$PROMPT_FILE"
+
 echo "Sending commits to Claude..."
-cat changelog_prompt.txt | claude -p "Generate CHANGELOG.md" > CHANGELOG_NEW.md
-rm changelog_prompt.txt
+cat "$PROMPT_FILE" | claude -p "Generate CHANGELOG.md" > CHANGELOG_NEW.md
+
 echo "Successfully generated CHANGELOG_NEW.md"

--- a/generate-changelog.sh
+++ b/generate-changelog.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+# Find the last tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [ -z "$LAST_TAG" ]; then
+    echo "No previous tags found. Fetching all commits..."
+    COMMITS=$(git log --pretty=format:"- %s")
+else
+    echo "Fetching commits since tag: $LAST_TAG"
+    COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s")
+fi
+
+if [ -z "$COMMITS" ]; then
+    echo "No new commits found."
+    exit 0
+fi
+
+cat << PROMPT_EOF > changelog_prompt.txt
+You are a strict release notes generator. Group the following commit messages exactly into these categories:
+### Added
+### Fixed
+### Changed
+### Removed
+
+Do not include empty categories. Format as valid Markdown.
+
+Commits:
+$COMMITS
+PROMPT_EOF
+
+echo "Sending commits to Claude..."
+cat changelog_prompt.txt | claude -p "Generate CHANGELOG.md" > CHANGELOG_NEW.md
+rm changelog_prompt.txt
+echo "Successfully generated CHANGELOG_NEW.md"


### PR DESCRIPTION

This PR introduces a bash script and an OpenClaw skill that automatically fetch commits since the last tag and pipe them into the Claude CLI to generate a structured `CHANGELOG.md` (Added/Fixed/Changed/Removed), as outlined in Issue #1.

**Bounty claimed:** $50 USD
Fixes #1