### PR TITLE
feat(bounty#3): pre-tool-use hook blocking destructive bash commands

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,60 @@
+# Destructive Command Guard — Claude Code PreToolUse Hook
+
+A lightweight bash hook that blocks dangerous commands before Claude Code executes them.
+
+## Blocked Patterns
+
+| Pattern | Why |
+|---|---|
+| `rm -rf` | Recursive force-delete |
+| `DROP TABLE` | SQL table destruction |
+| `git push --force` | Overwrites remote history |
+| `TRUNCATE` | SQL table wipe |
+| `DELETE FROM` (no `WHERE`) | Deletes all rows |
+
+## Install
+
+```bash
+cp block-destructive.sh ~/.claude/hooks/ && chmod +x ~/.claude/hooks/block-destructive.sh
+```
+
+Then add the hook to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-destructive.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+That's it. Blocked attempts are logged to `~/.claude/hooks/blocked.log`.
+
+## Log Format
+
+```
+[2026-04-05T13:00:00+00:00] BLOCKED | reason: Blocked: 'rm -rf' is a destructive filesystem command | command: rm -rf / | project: /home/user/myproject
+```
+
+## How It Works
+
+The hook receives JSON on stdin from Claude Code's `PreToolUse` event. It checks the `tool_input.command` field against the blocked patterns. If a match is found, it returns a JSON `permissionDecision: "deny"` response and logs the attempt. Normal commands pass through with `exit 0`.
+
+## Requirements
+
+- `jq` (pre-installed on most systems, required by Claude Code)
+- `bash`
+
+## License
+
+MIT

--- a/hooks/block-destructive.sh
+++ b/hooks/block-destructive.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook — blocks destructive bash commands
+# Install: cp block-destructive.sh ~/.claude/hooks/ && chmod +x ~/.claude/hooks/block-destructive.sh
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only inspect Bash tool calls
+[[ "$TOOL" == "Bash" ]] || exit 0
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -n "$CMD" ]] || exit 0
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
+LOG="$HOME/.claude/hooks/blocked.log"
+
+block() {
+  local reason="$1"
+  mkdir -p "$(dirname "$LOG")"
+  echo "[$(date -Iseconds)] BLOCKED | reason: $reason | command: $CMD | project: $CWD" >> "$LOG"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# --- Pattern checks (case-insensitive) ---
+CMD_UPPER=$(echo "$CMD" | tr '[:lower:]' '[:upper:]')
+
+echo "$CMD" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f|rm\s+-[a-zA-Z]*f[a-zA-Z]*r' \
+  && block "Blocked: 'rm -rf' is a destructive filesystem command"
+
+echo "$CMD_UPPER" | grep -qE '\bDROP\s+TABLE\b' \
+  && block "Blocked: 'DROP TABLE' is a destructive SQL operation"
+
+echo "$CMD" | grep -qiE 'git\s+push\s+.*--force\b|git\s+push\s+-f\b' \
+  && block "Blocked: 'git push --force' can destroy remote history"
+
+echo "$CMD_UPPER" | grep -qE '\bTRUNCATE\b' \
+  && block "Blocked: 'TRUNCATE' is a destructive SQL operation"
+
+# DELETE FROM without WHERE
+if echo "$CMD_UPPER" | grep -qE '\bDELETE\s+FROM\b'; then
+  echo "$CMD_UPPER" | grep -qE '\bDELETE\s+FROM\b.*\bWHERE\b' || \
+    block "Blocked: 'DELETE FROM' without a WHERE clause deletes all rows"
+fi
+
+# All clear
+exit 0


### PR DESCRIPTION
## Closes #3

### What
Bash PreToolUse hook that blocks destructive commands before Claude Code executes them.

### Blocked patterns
- `rm -rf` — recursive force-delete
- `DROP TABLE` — SQL table destruction
- `git push --force` / `git push -f` — overwrites remote history
- `TRUNCATE` — SQL table wipe
- `DELETE FROM` without `WHERE` — deletes all rows

### How it works
- Receives JSON on stdin from Claude Code's PreToolUse event
- Checks `tool_input.command` against blocked patterns
- Returns `permissionDecision: "deny"` JSON on match
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
- Normal commands pass through with `exit 0`

### Install (2 commands)
```bash
cp block-destructive.sh ~/.claude/hooks/ && chmod +x ~/.claude/hooks/block-destructive.sh
```
Then add the hook config to `~/.claude/settings.json` (see README).

### Requirements
- `bash`, `jq`