### PR TITLE
feat(bounty#1): generate-changelog — structured CHANGELOG from git history

### DIFF
--- a/TOOL-README.md
+++ b/TOOL-README.md
@@ -1,0 +1,27 @@
+# generate-changelog
+
+Generate a categorized `CHANGELOG.md` from your git history. Commits are auto-sorted into **Added / Fixed / Changed / Removed** based on conventional commit prefixes.
+
+## Setup
+
+1. Copy `changelog.sh` into your repo
+2. Run `bash changelog.sh`
+3. Check the generated `CHANGELOG.md`
+
+## How it works
+
+- Fetches commits since the last git tag (or all commits if no tags exist)
+- Categorizes by commit prefix: `feat:` → Added, `fix:` → Fixed, `chore:/refactor:` → Changed, `remove:/delete:` → Removed
+- Unrecognized prefixes go under Changed
+- Outputs a [Keep a Changelog](https://keepachangelog.com/) formatted file
+
+## Usage
+
+```bash
+bash changelog.sh              # writes CHANGELOG.md
+bash changelog.sh output.md   # writes to custom file
+```
+
+## Example
+
+See [sample-CHANGELOG.md](sample-CHANGELOG.md) for real output.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate a categorized CHANGELOG.md from git history since the last tag
+
+OUTFILE="${1:-CHANGELOG.md}"
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [ -n "$LAST_TAG" ]; then
+  RANGE="${LAST_TAG}..HEAD"
+  SINCE="since $LAST_TAG"
+else
+  RANGE=""
+  SINCE="(all commits)"
+fi
+
+# Collect commits: hash|subject
+COMMITS=$(git log $RANGE --pretty=format:"%h|%s" --no-merges)
+
+if [ -z "$COMMITS" ]; then
+  echo "No commits found $SINCE"
+  exit 0
+fi
+
+ADDED="" FIXED="" CHANGED="" REMOVED=""
+
+while IFS='|' read -r hash subject; do
+  entry="- ${subject} (\`${hash}\`)"
+  prefix=$(echo "$subject" | grep -oiE '^(feat|fix|chore|refactor|remove|delete)' || echo "")
+  case "${prefix,,}" in
+    feat)           ADDED+="${entry}"$'\n' ;;
+    fix)            FIXED+="${entry}"$'\n' ;;
+    remove|delete)  REMOVED+="${entry}"$'\n' ;;
+    chore|refactor) CHANGED+="${entry}"$'\n' ;;
+    *)              CHANGED+="${entry}"$'\n' ;;
+  esac
+done <<< "$COMMITS"
+
+DATE=$(date +%Y-%m-%d)
+
+write_section() {
+  local title="$1" body="$2"
+  if [ -n "$body" ]; then
+    echo "### ${title}"
+    echo ""
+    echo -n "$body"
+    echo ""
+  fi
+}
+
+{
+  echo "# Changelog — ${REPO_NAME}"
+  echo ""
+  echo "## [Unreleased] — ${DATE}"
+  echo ""
+  write_section "Added" "$ADDED"
+  write_section "Fixed" "$FIXED"
+  write_section "Changed" "$CHANGED"
+  write_section "Removed" "$REMOVED"
+  echo "---"
+  echo "*Generated $SINCE by [generate-changelog](https://github.com/claude-builders-bounty/claude-builders-bounty)*"
+} > "$OUTFILE"
+
+echo "✅ Wrote ${OUTFILE} (${SINCE})"

--- a/sample-CHANGELOG.md
+++ b/sample-CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog — fake-repo
+
+## [Unreleased] — 2026-04-05
+
+### Added
+
+- feat: add role-based access control (`5bebc5c`)
+- feat: add CSV export (`a40b0f1`)
+- feat: implement webhook notifications (`f031d15`)
+- feat: add dark mode support (`34f26ed`)
+- feat: add user authentication (`ca78170`)
+- feat: initial project setup (`199e020`)
+
+### Fixed
+
+- fix: sanitize user input on profile update (`5a4bd74`)
+- fix: handle empty dataset in reports (`6cf9954`)
+- fix: prevent duplicate email sends (`0f52f7c`)
+- fix: correct timezone handling in scheduler (`8c992fe`)
+- fix: resolve login redirect loop (`fbaabad`)
+
+### Changed
+
+- refactor: extract shared validation logic (`0d7e36b`)
+- chore: migrate CI to GitHub Actions (`8843b61`)
+- refactor: simplify database queries (`f3edc06`)
+- chore: update dependencies (`313374c`)
+
+### Removed
+
+- delete: remove deprecated admin panel (`4a3c72d`)
+- remove: drop legacy API endpoints (`c62c06b`)
+
+---
+*Generated (all commits) by [generate-changelog](https://github.com/claude-builders-bounty/claude-builders-bounty)*


### PR DESCRIPTION
Closes #1

## What it does
`bash changelog.sh` generates a categorized `CHANGELOG.md` from git history.

- Fetches commits since the last git tag (or all if no tags)
- Auto-categorizes: **Added** (feat), **Fixed** (fix), **Changed** (chore/refactor), **Removed** (remove/delete)
- Outputs [Keep a Changelog](https://keepachangelog.com/) formatted markdown

## Files
- `changelog.sh` — the tool
- `TOOL-README.md` — 3-step setup
- `sample-CHANGELOG.md` — real output from a test repo

## Usage
```bash
bash changelog.sh
```