### PR TITLE
feat: Add pre-tool-use hook to block destructive bash commands

### DIFF
--- a/hooks/block-destructive-commands/README.md
+++ b/hooks/block-destructive-commands/README.md
@@ -1,0 +1,53 @@
+# Claude Code Pre-tool-use Hook: Block Destructive Commands
+
+A safety hook that intercepts and blocks dangerous bash commands before execution in Claude Code.
+
+## Installation (2 commands)
+
+```bash
+# 1. Clone/download the hook
+mkdir -p ~/.claude/hooks && curl -sL https://raw.githubusercontent.com/YOUR_FORK/claude-safety-hooks/main/pre-tool-use.sh -o ~/.claude/hooks/pre-tool-use.sh
+
+# 2. Make it executable
+chmod +x ~/.claude/hooks/pre-tool-use.sh
+```
+
+That's it! The hook will automatically block dangerous commands in Claude Code.
+
+## What It Blocks
+
+- `rm -rf` - Recursive force delete
+- `DROP TABLE` - SQL table deletion
+- `TRUNCATE` - SQL table clearing  
+- `DELETE FROM` without WHERE - Unchecked SQL deletions
+- `git push --force` - Force push to git
+
+## Blocked Commands Log
+
+All blocked attempts are logged to `~/.claude/hooks/blocked.log` with:
+- Timestamp
+- Attempted command
+- Project path
+
+View the log:
+```bash
+cat ~/.claude/hooks/blocked.log
+```
+
+## How It Works
+
+The hook intercepts bash tool calls before execution and checks for dangerous patterns. If found, it returns an error message explaining why the command was blocked.
+
+## Testing
+
+Try asking Claude to run a dangerous command - it should be blocked with an explanation.
+
+## Uninstall
+
+```bash
+rm ~/.claude/hooks/pre-tool-use.sh
+```
+
+## License
+
+MIT

--- a/hooks/block-destructive-commands/pre-tool-use.sh
+++ b/hooks/block-destructive-commands/pre-tool-use.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Claude Code Pre-tool-use Hook: Block Destructive Commands
+# Blocks dangerous bash commands before execution
+# Logs to ~/.claude/hooks/blocked.log
+
+set -euo pipefail
+
+HOOKS_DIR="$HOME/.claude/hooks"
+LOG_FILE="$HOOKS_DIR/blocked.log"
+PROJECT_PATH="${PWD}"
+
+# Ensure log directory exists
+mkdir -p "$HOOKS_DIR"
+
+# Read stdin for tool input
+INPUT=$(cat)
+
+# Extract tool name and command
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+
+# Only check Bash tool calls
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    # Pass through non-bash tools
+    echo "$INPUT"
+    exit 0
+fi
+
+# Extract the command
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+# Dangerous patterns to block
+DANGEROUS_PATTERNS=(
+    'rm\s+-rf'
+    'rm\s+-fr'
+    'rm\s+-[a-z]*r[a-z]*f'
+    'DROP\s+TABLE'
+    'TRUNCATE\s+TABLE'
+    'TRUNCATE\s+[a-zA-Z_]'
+    'DELETE\s+FROM'
+    'git\s+push\s+--force'
+    'git\s+push\s+-f\s+origin'
+)
+
+# Check command against dangerous patterns
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qiE "$pattern"; then
+        # Log the blocked attempt
+        TIMESTAMP=$(date -Iseconds)
+        echo "[$TIMESTAMP] BLOCKED: $COMMAND | Project: $PROJECT_PATH" >> "$LOG_FILE"
+        
+        # Return error to Claude
+        cat <<EOF
+{"hook_specific_output": {"error_message": "⛔ BLOCKED: This command matches a dangerous pattern and was blocked for safety.
+
+Blocked pattern: $pattern
+Command attempted: $COMMAND
+
+Why this was blocked:
+- \`rm -rf\` can delete entire filesystems
+- \`DROP TABLE\` and \`TRUNCATE\` destroy database data
+- \`DELETE FROM\` without WHERE deletes all rows
+- \`git push --force\` can overwrite remote history
+
+This attempt has been logged to ~/.claude/hooks/blocked.log
+
+If you really need to run this command, ask the user to run it directly in their terminal."}}
+EOF
+        exit 2
+    fi
+done
+
+# Check for DELETE FROM without WHERE clause
+if echo "$COMMAND" | grep -qiE 'DELETE\s+FROM'; then
+    if ! echo "$COMMAND" | grep -qiE 'WHERE'; then
+        # Log the blocked attempt
+        TIMESTAMP=$(date -Iseconds)
+        echo "[$TIMESTAMP] BLOCKED: $COMMAND (DELETE without WHERE) | Project: $PROJECT_PATH" >> "$LOG_FILE"
+        
+        cat <<EOF
+{"hook_specific_output": {"error_message": "⛔ BLOCKED: DELETE FROM without WHERE clause detected.
+
+Command attempted: $COMMAND
+
+Why this was blocked:
+- \`DELETE FROM table\` without a WHERE clause deletes ALL rows
+- This is almost never intentional and can cause major data loss
+
+This attempt has been logged to ~/.claude/hooks/blocked.log
+
+If you really need to delete all rows, use TRUNCATE (also blocked) or ask the user to run it directly."}}
+EOF
+        exit 2
+    fi
+fi
+
+# Command is safe, pass through
+echo "$INPUT"
+exit 0

--- a/hooks/block-destructive-commands/test-hook.sh
+++ b/hooks/block-destructive-commands/test-hook.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Simple test script for the block-destructive-commands hook
+
+HOOK_SCRIPT="./pre-tool-use.sh"
+
+echo "Testing block-destructive-commands hook..."
+echo ""
+
+# Test 1: Safe command should pass
+echo "Test 1: Safe command (ls -la)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "✅ PASS: Safe command allowed"
+else
+    echo "❌ FAIL: Safe command was blocked"
+fi
+echo ""
+
+# Test 2: rm -rf should be blocked
+echo "Test 2: Dangerous command (rm -rf /tmp/test)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/test"}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: rm -rf was blocked"
+else
+    echo "❌ FAIL: rm -rf was not blocked"
+fi
+echo ""
+
+# Test 3: DROP TABLE should be blocked
+echo "Test 3: Dangerous SQL (DROP TABLE users)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "psql -c \"DROP TABLE users;\""}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: DROP TABLE was blocked"
+else
+    echo "❌ FAIL: DROP TABLE was not blocked"
+fi
+echo ""
+
+# Test 4: git push --force should be blocked
+echo "Test 4: Dangerous git (git push --force origin main)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: git push --force was blocked"
+else
+    echo "❌ FAIL: git push --force was not blocked"
+fi
+echo ""
+
+# Test 5: DELETE FROM without WHERE should be blocked
+echo "Test 5: Dangerous SQL (DELETE FROM users)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "psql -c \"DELETE FROM users;\""}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: DELETE FROM without WHERE was blocked"
+else
+    echo "❌ FAIL: DELETE FROM without WHERE was not blocked"
+fi
+echo ""
+
+# Test 6: DELETE FROM with WHERE should pass
+echo "Test 6: Safe SQL (DELETE FROM users WHERE id = 1)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "psql -c \"DELETE FROM users WHERE id = 1;\""}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "✅ PASS: DELETE FROM with WHERE allowed"
+else
+    echo "❌ FAIL: DELETE FROM with WHERE was blocked"
+fi
+echo ""
+
+echo "All tests completed!"


### PR DESCRIPTION
## Summary
A safety hook that intercepts and blocks dangerous bash commands before execution in Claude Code.

## Features
- Blocks `rm -rf`, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without WHERE, `git push --force`
- Logs all blocked attempts to `~/.claude/hooks/blocked.log` with timestamp and project path
- 2-command installation process

## Installation
```bash
mkdir -p ~/.claude/hooks && curl -sL https://raw.githubusercontent.com/alexanderxfgl-bit/claude-builders-bounty/main/hooks/block-destructive-commands/pre-tool-use.sh -o ~/.claude/hooks/pre-tool-use.sh
chmod +x ~/.claude/hooks/pre-tool-use.sh
```

## Testing
Test script included: `./test-hook.sh`

## Files
- `pre-tool-use.sh` - Main hook script
- `README.md` - Documentation
- `test-hook.sh` - Test script

Closes #3