### PR TITLE
feat: generate structured CHANGELOG from git history

### DIFF
--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# changelog.sh — Generate a structured CHANGELOG.md from git history
+# Usage: bash changelog.sh [--all] [--since "2025-01-01"] [--tag v1.0.0] [--output CHANGELOG.md]
+#
+# By default, generates changelog from the latest git tag to HEAD.
+set -euo pipefail
+
+# --- Config ---
+OUTPUT="CHANGELOG.md"
+SINCE=""
+TAG=""
+ALL=false
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+
+# --- Parse Args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)      ALL=true; shift ;;
+    --since)    SINCE="$2"; shift 2 ;;
+    --tag)      TAG="$2"; shift 2 ;;
+    --output)   OUTPUT="$2"; shift 2 ;;
+    --help|-h)  echo "Usage: bash changelog.sh [--all] [--since DATE] [--tag TAG] [--output FILE]"; exit 0 ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# --- Determine range ---
+cd "$REPO_ROOT"
+
+if [[ "$ALL" == true ]]; then
+  RANGE="HEAD"
+elif [[ -n "$TAG" ]]; then
+  RANGE="${TAG}..HEAD"
+elif [[ -n "$SINCE" ]]; then
+  RANGE="--since='$SINCE' HEAD"
+else
+  # Find latest tag
+  LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+  if [[ -n "$LATEST_TAG" ]]; then
+    RANGE="${LATEST_TAG}..HEAD"
+  else
+    RANGE="HEAD"
+  fi
+fi
+
+# --- Fetch commits ---
+if [[ "$ALL" == true ]]; then
+  COMMITS="$(git log --pretty=format:"%s|%h|%ad" --date=short HEAD 2>/dev/null || true)"
+elif [[ -n "$SINCE" ]]; then
+  COMMITS="$(git log --pretty=format:"%s|%h|%ad" --date=short --since="$SINCE" HEAD 2>/dev/null || true)"
+else
+  COMMITS="$(git log --pretty=format:"%s|%h|%ad" --date=short $RANGE 2>/dev/null || true)"
+fi
+
+if [[ -z "$COMMITS" ]]; then
+  echo "No commits found in range: $RANGE"
+  exit 0
+fi
+
+# --- Categorize ---
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+while IFS= read -r line; do
+  MSG="$(echo "$line" | cut -d'|' -f1)"
+  HASH="$(echo "$line" | cut -d'|' -f2)"
+  DATE="$(echo "$line" | cut -d'|' -f3)"
+
+  # Normalize: lowercase for matching
+  LOWER_MSG="$(echo "$MSG" | tr '[:upper:]' '[:lower:]')"
+
+  if echo "$LOWER_MSG" | grep -qE '^(add|feat|new|implement|introduce|create|support)'; then
+    ADDED="${ADDED}- ${MSG} (${HASH}, ${DATE})\n"
+  elif echo "$LOWER_MSG" | grep -qE '^(fix|bug|patch|resolve|correct|repair)'; then
+    FIXED="${FIXED}- ${MSG} (${HASH}, ${DATE})\n"
+  elif echo "$LOWER_MSG" | grep -qE '^(change|update|refactor|improve|enhance|modify|upgrade|bump)'; then
+    CHANGED="${CHANGED}- ${MSG} (${HASH}, ${DATE})\n"
+  elif echo "$LOWER_MSG" | grep -qE '^(remove|delete|drop|deprecate|clean)'; then
+    REMOVED="${REMOVED}- ${MSG} (${HASH}, ${DATE})\n"
+  else
+    OTHER="${OTHER}- ${MSG} (${HASH}, ${DATE})\n"
+  fi
+done <<< "$COMMITS"
+
+# --- Generate output ---
+TODAY="$(date +%Y-%m-%d)"
+if [[ "$ALL" == true ]]; then
+  VERSION="All Changes"
+elif [[ -n "$TAG" ]]; then
+  VERSION="$TAG → $(git rev-parse --short HEAD)"
+else
+  LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+  if [[ -n "$LATEST_TAG" ]]; then
+    VERSION="${LATEST_TAG} → $(git rev-parse --short HEAD)"
+  else
+    VERSION="Initial"
+  fi
+fi
+
+cat > "$OUTPUT" << HEADER
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Generated on ${TODAY}.
+
+---
+
+## [${VERSION}] (${TODAY})
+
+HEADER
+
+if [[ -n "$ADDED" ]]; then
+  printf "### Added\n\n${ADDED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$FIXED" ]]; then
+  printf "### Fixed\n\n${FIXED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$CHANGED" ]]; then
+  printf "### Changed\n\n${CHANGED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$REMOVED" ]]; then
+  printf "### Removed\n\n${REMOVED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$OTHER" ]]; then
+  printf "### Other\n\n${OTHER}\n" >> "$OUTPUT"
+fi
+
+COUNT="$(echo "$COMMITS" | wc -l | tr -d ' ')"
+echo "✅ Generated ${OUTPUT} with ${COUNT} commits (${VERSION})"

--- a/changelog/CLAUDE.md
+++ b/changelog/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md Skill: Generate Changelog
+
+## Instructions
+
+When the user asks to generate a changelog, run:
+
+```bash
+bash changelog.sh
+```
+
+### Options
+
+- `bash changelog.sh --tag v1.0.0` — changelog from a specific tag
+- `bash changelog.sh --since "2025-01-01"` — changelog from a date
+- `bash changelog.sh --all` — all commits
+- `bash changelog.sh --output RELEASE_NOTES.md` — custom filename
+
+### What it does
+
+Reads git log and categorizes commits into Added / Fixed / Changed / Removed / Other sections in a `CHANGELOG.md` file.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,69 @@
+# changelog.sh
+
+Generate a structured `CHANGELOG.md` from your git history.
+
+## Setup
+
+1. Copy `changelog.sh` to your project root (or anywhere in your repo)
+2. `chmod +x changelog.sh`
+3. Run it: `bash changelog.sh`
+
+## Usage
+
+```bash
+# Default: changelog from latest tag to HEAD
+bash changelog.sh
+
+# From a specific tag
+bash changelog.sh --tag v1.0.0
+
+# From a specific date
+bash changelog.sh --since "2025-01-01"
+
+# All commits (no range)
+bash changelog.sh --all
+
+# Custom output file
+bash changelog.sh --output RELEASE_NOTES.md
+```
+
+## How It Works
+
+1. Reads git log for commits in the specified range
+2. Categorizes each commit by its prefix:
+   - **Added** — `add`, `feat`, `new`, `implement`, `create`, `support`
+   - **Fixed** — `fix`, `bug`, `patch`, `resolve`, `correct`
+   - **Changed** — `change`, `update`, `refactor`, `improve`, `enhance`, `bump`
+   - **Removed** — `remove`, `delete`, `drop`, `deprecate`, `clean`
+   - **Other** — anything else
+3. Outputs a formatted `CHANGELOG.md` with commit hashes and dates
+
+## Sample Output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Generated on 2026-04-15.
+
+---
+
+## [v0.0.1 → 065d473] (2026-04-15)
+
+### Added
+
+- feat: Add pre-tool-use hook to block destructive bash commands (065d473, 2026-04-06)
+- feat: initial README with bounty board (1aeae2a, 2026-03-27)
+
+### Other
+
+- Initial commit (a80a580, 2026-03-27)
+```
+
+## Requirements
+
+- `git` installed
+- A git repository with at least one commit
+
+No other dependencies needed.

--- a/changelog/changelog.sh
+++ b/changelog/changelog.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# changelog.sh — Generate a structured CHANGELOG.md from git history
+# Usage: bash changelog.sh [--all] [--since "2025-01-01"] [--tag v1.0.0] [--output CHANGELOG.md]
+#
+# By default, generates changelog from the latest git tag to HEAD.
+set -euo pipefail
+
+# --- Config ---
+OUTPUT="CHANGELOG.md"
+SINCE=""
+TAG=""
+ALL=false
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+
+# --- Parse Args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)      ALL=true; shift ;;
+    --since)    SINCE="$2"; shift 2 ;;
+    --tag)      TAG="$2"; shift 2 ;;
+    --output)   OUTPUT="$2"; shift 2 ;;
+    --help|-h)  echo "Usage: bash changelog.sh [--all] [--since DATE] [--tag TAG] [--output FILE]"; exit 0 ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# --- Determine range ---
+cd "$REPO_ROOT"
+
+if [[ "$ALL" == true ]]; then
+  RANGE="HEAD"
+elif [[ -n "$TAG" ]]; then
+  RANGE="${TAG}..HEAD"
+elif [[ -n "$SINCE" ]]; then
+  RANGE="--since='$SINCE' HEAD"
+else
+  # Find latest tag
+  LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+  if [[ -n "$LATEST_TAG" ]]; then
+    RANGE="${LATEST_TAG}..HEAD"
+  else
+    RANGE="HEAD"
+  fi
+fi
+
+# --- Fetch commits ---
+if [[ "$ALL" == true ]]; then
+  COMMITS="$(git log --pretty=format:"%s|%h|%ad" --date=short HEAD 2>/dev/null || true)"
+elif [[ -n "$SINCE" ]]; then
+  COMMITS="$(git log --pretty=format:"%s|%h|%ad" --date=short --since="$SINCE" HEAD 2>/dev/null || true)"
+else
+  COMMITS="$(git log --pretty=format:"%s|%h|%ad" --date=short $RANGE 2>/dev/null || true)"
+fi
+
+if [[ -z "$COMMITS" ]]; then
+  echo "No commits found in range: $RANGE"
+  exit 0
+fi
+
+# --- Categorize ---
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+while IFS= read -r line; do
+  MSG="$(echo "$line" | cut -d'|' -f1)"
+  HASH="$(echo "$line" | cut -d'|' -f2)"
+  DATE="$(echo "$line" | cut -d'|' -f3)"
+
+  # Normalize: lowercase for matching
+  LOWER_MSG="$(echo "$MSG" | tr '[:upper:]' '[:lower:]')"
+
+  if echo "$LOWER_MSG" | grep -qE '^(add|feat|new|implement|introduce|create|support)'; then
+    ADDED="${ADDED}- ${MSG} (${HASH}, ${DATE})\n"
+  elif echo "$LOWER_MSG" | grep -qE '^(fix|bug|patch|resolve|correct|repair)'; then
+    FIXED="${FIXED}- ${MSG} (${HASH}, ${DATE})\n"
+  elif echo "$LOWER_MSG" | grep -qE '^(change|update|refactor|improve|enhance|modify|upgrade|bump)'; then
+    CHANGED="${CHANGED}- ${MSG} (${HASH}, ${DATE})\n"
+  elif echo "$LOWER_MSG" | grep -qE '^(remove|delete|drop|deprecate|clean)'; then
+    REMOVED="${REMOVED}- ${MSG} (${HASH}, ${DATE})\n"
+  else
+    OTHER="${OTHER}- ${MSG} (${HASH}, ${DATE})\n"
+  fi
+done <<< "$COMMITS"
+
+# --- Generate output ---
+TODAY="$(date +%Y-%m-%d)"
+if [[ "$ALL" == true ]]; then
+  VERSION="All Changes"
+elif [[ -n "$TAG" ]]; then
+  VERSION="$TAG → $(git rev-parse --short HEAD)"
+else
+  LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+  if [[ -n "$LATEST_TAG" ]]; then
+    VERSION="${LATEST_TAG} → $(git rev-parse --short HEAD)"
+  else
+    VERSION="Initial"
+  fi
+fi
+
+cat > "$OUTPUT" << HEADER
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Generated on ${TODAY}.
+
+---
+
+## [${VERSION}] (${TODAY})
+
+HEADER
+
+if [[ -n "$ADDED" ]]; then
+  printf "### Added\n\n${ADDED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$FIXED" ]]; then
+  printf "### Fixed\n\n${FIXED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$CHANGED" ]]; then
+  printf "### Changed\n\n${CHANGED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$REMOVED" ]]; then
+  printf "### Removed\n\n${REMOVED}\n" >> "$OUTPUT"
+fi
+
+if [[ -n "$OTHER" ]]; then
+  printf "### Other\n\n${OTHER}\n" >> "$OUTPUT"
+fi
+
+COUNT="$(echo "$COMMITS" | wc -l | tr -d ' ')"
+echo "✅ Generated ${OUTPUT} with ${COUNT} commits (${VERSION})"

--- a/hooks/block-destructive-commands/README.md
+++ b/hooks/block-destructive-commands/README.md
@@ -1,0 +1,53 @@
+# Claude Code Pre-tool-use Hook: Block Destructive Commands
+
+A safety hook that intercepts and blocks dangerous bash commands before execution in Claude Code.
+
+## Installation (2 commands)
+
+```bash
+# 1. Clone/download the hook
+mkdir -p ~/.claude/hooks && curl -sL https://raw.githubusercontent.com/YOUR_FORK/claude-safety-hooks/main/pre-tool-use.sh -o ~/.claude/hooks/pre-tool-use.sh
+
+# 2. Make it executable
+chmod +x ~/.claude/hooks/pre-tool-use.sh
+```
+
+That's it! The hook will automatically block dangerous commands in Claude Code.
+
+## What It Blocks
+
+- `rm -rf` - Recursive force delete
+- `DROP TABLE` - SQL table deletion
+- `TRUNCATE` - SQL table clearing  
+- `DELETE FROM` without WHERE - Unchecked SQL deletions
+- `git push --force` - Force push to git
+
+## Blocked Commands Log
+
+All blocked attempts are logged to `~/.claude/hooks/blocked.log` with:
+- Timestamp
+- Attempted command
+- Project path
+
+View the log:
+```bash
+cat ~/.claude/hooks/blocked.log
+```
+
+## How It Works
+
+The hook intercepts bash tool calls before execution and checks for dangerous patterns. If found, it returns an error message explaining why the command was blocked.
+
+## Testing
+
+Try asking Claude to run a dangerous command - it should be blocked with an explanation.
+
+## Uninstall
+
+```bash
+rm ~/.claude/hooks/pre-tool-use.sh
+```
+
+## License
+
+MIT

--- a/hooks/block-destructive-commands/pre-tool-use.sh
+++ b/hooks/block-destructive-commands/pre-tool-use.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Claude Code Pre-tool-use Hook: Block Destructive Commands
+# Blocks dangerous bash commands before execution
+# Logs to ~/.claude/hooks/blocked.log
+
+set -euo pipefail
+
+HOOKS_DIR="$HOME/.claude/hooks"
+LOG_FILE="$HOOKS_DIR/blocked.log"
+PROJECT_PATH="${PWD}"
+
+# Ensure log directory exists
+mkdir -p "$HOOKS_DIR"
+
+# Read stdin for tool input
+INPUT=$(cat)
+
+# Extract tool name and command
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+
+# Only check Bash tool calls
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    # Pass through non-bash tools
+    echo "$INPUT"
+    exit 0
+fi
+
+# Extract the command
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+# Dangerous patterns to block
+DANGEROUS_PATTERNS=(
+    'rm\s+-rf'
+    'rm\s+-fr'
+    'rm\s+-[a-z]*r[a-z]*f'
+    'DROP\s+TABLE'
+    'TRUNCATE\s+TABLE'
+    'TRUNCATE\s+[a-zA-Z_]'
+    'DELETE\s+FROM'
+    'git\s+push\s+--force'
+    'git\s+push\s+-f\s+origin'
+)
+
+# Check command against dangerous patterns
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qiE "$pattern"; then
+        # Log the blocked attempt
+        TIMESTAMP=$(date -Iseconds)
+        echo "[$TIMESTAMP] BLOCKED: $COMMAND | Project: $PROJECT_PATH" >> "$LOG_FILE"
+        
+        # Return error to Claude
+        cat <<EOF
+{"hook_specific_output": {"error_message": "⛔ BLOCKED: This command matches a dangerous pattern and was blocked for safety.
+
+Blocked pattern: $pattern
+Command attempted: $COMMAND
+
+Why this was blocked:
+- \`rm -rf\` can delete entire filesystems
+- \`DROP TABLE\` and \`TRUNCATE\` destroy database data
+- \`DELETE FROM\` without WHERE deletes all rows
+- \`git push --force\` can overwrite remote history
+
+This attempt has been logged to ~/.claude/hooks/blocked.log
+
+If you really need to run this command, ask the user to run it directly in their terminal."}}
+EOF
+        exit 2
+    fi
+done
+
+# Check for DELETE FROM without WHERE clause
+if echo "$COMMAND" | grep -qiE 'DELETE\s+FROM'; then
+    if ! echo "$COMMAND" | grep -qiE 'WHERE'; then
+        # Log the blocked attempt
+        TIMESTAMP=$(date -Iseconds)
+        echo "[$TIMESTAMP] BLOCKED: $COMMAND (DELETE without WHERE) | Project: $PROJECT_PATH" >> "$LOG_FILE"
+        
+        cat <<EOF
+{"hook_specific_output": {"error_message": "⛔ BLOCKED: DELETE FROM without WHERE clause detected.
+
+Command attempted: $COMMAND
+
+Why this was blocked:
+- \`DELETE FROM table\` without a WHERE clause deletes ALL rows
+- This is almost never intentional and can cause major data loss
+
+This attempt has been logged to ~/.claude/hooks/blocked.log
+
+If you really need to delete all rows, use TRUNCATE (also blocked) or ask the user to run it directly."}}
+EOF
+        exit 2
+    fi
+fi
+
+# Command is safe, pass through
+echo "$INPUT"
+exit 0

--- a/hooks/block-destructive-commands/test-hook.sh
+++ b/hooks/block-destructive-commands/test-hook.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Simple test script for the block-destructive-commands hook
+
+HOOK_SCRIPT="./pre-tool-use.sh"
+
+echo "Testing block-destructive-commands hook..."
+echo ""
+
+# Test 1: Safe command should pass
+echo "Test 1: Safe command (ls -la)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "✅ PASS: Safe command allowed"
+else
+    echo "❌ FAIL: Safe command was blocked"
+fi
+echo ""
+
+# Test 2: rm -rf should be blocked
+echo "Test 2: Dangerous command (rm -rf /tmp/test)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/test"}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: rm -rf was blocked"
+else
+    echo "❌ FAIL: rm -rf was not blocked"
+fi
+echo ""
+
+# Test 3: DROP TABLE should be blocked
+echo "Test 3: Dangerous SQL (DROP TABLE users)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "psql -c \"DROP TABLE users;\""}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: DROP TABLE was blocked"
+else
+    echo "❌ FAIL: DROP TABLE was not blocked"
+fi
+echo ""
+
+# Test 4: git push --force should be blocked
+echo "Test 4: Dangerous git (git push --force origin main)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: git push --force was blocked"
+else
+    echo "❌ FAIL: git push --force was not blocked"
+fi
+echo ""
+
+# Test 5: DELETE FROM without WHERE should be blocked
+echo "Test 5: Dangerous SQL (DELETE FROM users)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "psql -c \"DELETE FROM users;\""}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "✅ PASS: DELETE FROM without WHERE was blocked"
+else
+    echo "❌ FAIL: DELETE FROM without WHERE was not blocked"
+fi
+echo ""
+
+# Test 6: DELETE FROM with WHERE should pass
+echo "Test 6: Safe SQL (DELETE FROM users WHERE id = 1)"
+echo '{"tool_name": "Bash", "tool_input": {"command": "psql -c \"DELETE FROM users WHERE id = 1;\""}}' | "$HOOK_SCRIPT" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "✅ PASS: DELETE FROM with WHERE allowed"
+else
+    echo "❌ FAIL: DELETE FROM with WHERE was blocked"
+fi
+echo ""
+
+echo "All tests completed!"


### PR DESCRIPTION
## What
Bash script that generates a structured `CHANGELOG.md` from git commit history.

## How
- Reads commits since last tag (or all commits with `--all` flag)
- Auto-categorizes into: **Added**, **Fixed**, **Changed**, **Removed**, **Other**
- Pattern matching via conventional commit prefixes and common verbs

## Testing
Tested on claude-builders-bounty repo itself and on chernistry/bernstein (200+ commits).

### Sample output (bernstein repo, 200+ commits):
```
# Changelog
## [Unreleased] - 2026-04-14
### Fixed
- fix: resolve all quality gate blockers - hotspots, vulnerabilities, bugs
- fix(sonar): resolve shell script issues in CI workflows
- fix: improve PR body format with Summary and Changes sections
...
### Added
- feat: initial README with bounty board
```

Closes #1