### PR TITLE
[BOUNTY $100] HOOK: Pre-tool-use hook that blocks destructive bash commands (#3)

### DIFF
--- a/hooks/block-destructive-commands/README.md
+++ b/hooks/block-destructive-commands/README.md
@@ -1,0 +1,78 @@
+# Block Destructive Commands — Claude Code Hook
+
+A pre-tool-use hook for Claude Code that intercepts and blocks dangerous bash commands before execution.
+
+## Install (2 commands)
+
+```bash
+cp block-destructive-commands.sh ~/.claude/hooks/pre-tool-use.sh
+chmod +x ~/.claude/hooks/pre-tool-use.sh
+```
+
+## What It Blocks
+
+| Pattern | Example | Why |
+|---------|---------|-----|
+| `rm -rf` | `rm -rf /var/data` | Irreversible recursive force delete |
+| `DROP TABLE` | `DROP TABLE users` | Permanently deletes database tables |
+| `git push --force` | `git push --force origin main` | Overwrites remote history |
+| `git push --force-with-lease` | `git push --force-with-lease origin main` | Rewrites remote history even if it feels safer than `--force` |
+| `TRUNCATE` | `TRUNCATE TABLE logs` | Empties entire table |
+| `DELETE FROM` (no WHERE) | `DELETE FROM users` | Deletes ALL rows without filtering |
+
+## How It Works
+
+1. Claude Code sends tool-use events to the hook via stdin (JSON format)
+2. The hook parses the command from `Bash` tool calls
+3. If the command matches a dangerous pattern, it's **blocked** with exit code 2
+4. The block reason is displayed to Claude
+5. The attempt is logged to `~/.claude/hooks/blocked.log`
+6. Normal commands pass through unaffected (exit code 0)
+
+## Blocked Command Log
+
+Every blocked attempt is recorded in `~/.claude/hooks/blocked.log`:
+
+```
+[2026-04-15 12:34:56] BLOCKED | cmd: rm -rf /var/data | reason: recursive force delete | path: /home/user/project
+```
+
+## Allowed Commands
+
+The hook only blocks the specific dangerous patterns above. These are fine:
+
+```bash
+rm file.txt              # Single file delete (no -rf)
+git push origin main     # Normal push (no --force)
+DELETE FROM users WHERE id = 1  # DELETE with WHERE clause
+DROP TABLE IF EXISTS temp      # Wait — this IS blocked (intentional safety)
+```
+
+## Quick Validation
+
+Run these after installing the hook:
+
+```bash
+printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/demo","workdir":"/repo"}}' | ~/.claude/hooks/pre-tool-use.sh
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin main","workdir":"/repo"}}' | ~/.claude/hooks/pre-tool-use.sh
+```
+
+The first command should exit with status `2` and append to `blocked.log`. The second should exit `0`.
+
+## Uninstall
+
+```bash
+rm ~/.claude/hooks/pre-tool-use.sh
+```
+
+## Override
+
+If you need to run a blocked command, run it directly in your terminal (outside Claude Code). The hook only intercepts Claude's tool-use events.
+
+## Technical Details
+
+- **Format**: Claude Code hooks spec (`~/.claude/hooks/`)
+- **Input**: JSON on stdin with `tool_name` and `tool_input.command`
+- **Exit codes**: 0 = allow, 2 = block
+- **Dependencies**: bash, python3
+- **Platform**: macOS / Linux (no GNU `grep -P` required)

--- a/hooks/block-destructive-commands/block-destructive-commands.sh
+++ b/hooks/block-destructive-commands/block-destructive-commands.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# block-destructive-commands.sh
+# Claude Code pre-tool-use hook that blocks dangerous bash commands.
+# Install: cp block-destructive-commands.sh ~/.claude/hooks/pre-tool-use.sh && chmod +x ~/.claude/hooks/pre-tool-use.sh
+#
+# Bounty: claude-builders-bounty/claude-builders-bounty#3 ($100)
+
+set -euo pipefail
+
+HOOK_INPUT="$(cat)"
+
+CLAUDE_HOOK_INPUT="$HOOK_INPUT" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+
+def block(reason: str, command: str, project_path: str) -> None:
+    hook_dir = os.path.join(os.path.expanduser("~"), ".claude", "hooks")
+    os.makedirs(hook_dir, exist_ok=True)
+    log_file = os.path.join(hook_dir, "blocked.log")
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open(log_file, "a", encoding="utf-8") as handle:
+        handle.write(
+            f"[{timestamp}] BLOCKED | cmd: {command} | reason: {reason} | path: {project_path}\n"
+        )
+
+    print(f"BLOCKED: {reason}")
+    print(f"Command: {command}")
+    print("Run the command in a normal terminal if you intentionally want to bypass the hook.")
+    sys.exit(2)
+
+
+raw = os.environ.get("CLAUDE_HOOK_INPUT", "")
+if not raw.strip():
+    sys.exit(0)
+
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+tool_name = str(payload.get("tool_name") or payload.get("tool") or "").strip().lower()
+tool_input = payload.get("tool_input") or {}
+command = str(tool_input.get("command") or "").strip()
+project_path = (
+    str(tool_input.get("workdir") or tool_input.get("cwd") or "").strip()
+    or os.getcwd()
+)
+
+if tool_name != "bash" or not command:
+    sys.exit(0)
+
+normalized = " ".join(command.split())
+upper = normalized.upper()
+
+rm_force_recursive = [
+    re.compile(r"\brm\b[^;\n|&]*\s-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b"),
+    re.compile(r"\brm\b[^;\n|&]*\s-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*\b"),
+    re.compile(r"\brm\b[^;\n|&]*\s-[A-Za-z]*r[A-Za-z]*\s-[A-Za-z]*f[A-Za-z]*\b"),
+    re.compile(r"\brm\b[^;\n|&]*\s-[A-Za-z]*f[A-Za-z]*\s-[A-Za-z]*r[A-Za-z]*\b"),
+]
+
+if any(pattern.search(normalized) for pattern in rm_force_recursive):
+    block(
+        "rm -rf detected: recursive force deletion is irreversible and can destroy entire directories",
+        normalized,
+        project_path,
+    )
+
+if re.search(r"\bDROP\s+(TABLE|DATABASE|SCHEMA)\b", upper):
+    block(
+        "DROP TABLE/DATABASE detected: this permanently deletes database structures and all related data",
+        normalized,
+        project_path,
+    )
+
+if re.search(r"\bgit\s+push\b[^;\n|&]*\s(--force(?:-with-lease)?|-f)\b", normalized):
+    block(
+        "git push --force detected: this can overwrite remote history and destroy other contributors' commits",
+        normalized,
+        project_path,
+    )
+
+if re.search(r"\bTRUNCATE\s+(TABLE\s+)?[A-Z_][A-Z0-9_.$]*\b", upper):
+    block(
+        "TRUNCATE detected: this empties an entire table without row-level filtering",
+        normalized,
+        project_path,
+    )
+
+for statement in [segment.strip() for segment in re.split(r";|\n", upper) if segment.strip()]:
+    if "DELETE FROM" in statement and "WHERE" not in statement:
+        block(
+            "DELETE FROM without WHERE detected: this deletes every row in the target table",
+            normalized,
+            project_path,
+        )
+
+sys.exit(0)
+PY


### PR DESCRIPTION
## Summary
Adds a Claude Code pre-tool-use hook that blocks destructive bash commands before execution.

## What changed in this revision
- replaced GNU `grep -P` matching with a more portable `bash` + `python3` implementation
- blocks `rm -rf`, `DROP TABLE` / `DROP DATABASE`, `git push --force` and `--force-with-lease`, `TRUNCATE`, and `DELETE FROM` without `WHERE`
- keeps logging in `~/.claude/hooks/blocked.log`
- added quick validation steps to the README

## Acceptance Criteria ?
- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks the required destructive patterns
- [x] Logs every blocked attempt with timestamp, command, and project path
- [x] Displays a clear block message to Claude
- [x] Leaves normal commands untouched
- [x] Includes a 2-command install flow in the README

Closes #3