### PR TITLE
[BOUNTY $200] WORKFLOW: n8n + Claude Code - automated weekly dev summary (#5)

### DIFF
--- a/workflows/weekly-dev-summary/README.md
+++ b/workflows/weekly-dev-summary/README.md
@@ -1,0 +1,63 @@
+# Weekly Dev Summary: n8n + Claude
+
+An importable n8n workflow that pulls a week's worth of GitHub activity, turns it into a clean context block, asks Claude for a narrative summary, and delivers the result by email and/or Slack webhook.
+
+## Setup in 5 Steps
+
+1. Import `weekly-dev-summary.json` into n8n.
+2. Add a **GitHub Token** credential using HTTP Header Auth:
+   - header: `Authorization`
+   - value: `Bearer <your-github-token>`
+3. Add an **Anthropic API Key** credential using HTTP Header Auth:
+   - header: `x-api-key`
+   - value: `<your-anthropic-api-key>`
+4. Configure environment variables:
+   - `GITHUB_REPO=owner/repo`
+   - `LANGUAGE=EN` or `FR`
+   - `SLACK_WEBHOOK_URL=https://hooks.slack.com/...` (optional)
+   - `SMTP_FROM=dev@example.com` and `EMAIL_TO=team@example.com` (optional)
+5. Activate the workflow. It runs every Friday at 5 PM.
+
+## Workflow Shape
+
+```text
+Friday 5 PM
+  -> Fetch commits
+  -> Fetch closed issues
+  -> Fetch closed PRs
+  -> Build weekly context
+  -> Ask Claude for a narrative summary
+  -> Format Markdown
+  -> Send Email and/or Post to Slack
+```
+
+## What It Produces
+
+The generated summary stays under 400 words and includes:
+
+1. a short weekly overview,
+2. key highlights,
+3. notable merged changes, and
+4. notable closed issues.
+
+## Why This Version Is Safer
+
+- filters out pull requests from the issues feed,
+- filters PRs by `merged_at` inside the last week instead of relying on `updated_at`,
+- calls Anthropic directly via HTTP instead of pretending Anthropic is OpenAI-compatible, and
+- keeps delivery optional so email and Slack can be enabled independently.
+
+## Delivery Notes
+
+- Slack uses the `text` field out of the box.
+- To switch to Discord, duplicate the webhook node and send `content` instead of `text`.
+- If you only want one destination, disable or delete the other output node.
+
+## Validation Notes
+
+The workflow is designed to be tested against a real n8n instance by:
+
+1. manually executing the schedule trigger,
+2. checking that the GitHub nodes return the last 7 days of activity,
+3. confirming Claude returns a readable narrative, and
+4. verifying the message lands in Slack or email.

--- a/workflows/weekly-dev-summary/weekly-dev-summary.json
+++ b/workflows/weekly-dev-summary/weekly-dev-summary.json
@@ -1,0 +1,367 @@
+{
+  "name": "Weekly Dev Summary with Claude",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "days",
+              "weeksInterval": 1,
+              "days": [
+                "Friday"
+              ],
+              "triggerAtHour": 17,
+              "triggerAtMinute": 0
+            }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Every Friday 5PM",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{($env.GITHUB_API_URL || 'https://api.github.com') + '/repos/' + $env.GITHUB_REPO + '/commits?since=' + $now.minus({days:7}).toISO() + '&per_page=100'}}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "github-commits",
+      "name": "Fetch Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        220,
+        -120
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "GITHUB_CREDENTIALS_ID",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{($env.GITHUB_API_URL || 'https://api.github.com') + '/repos/' + $env.GITHUB_REPO + '/issues?state=closed&since=' + $now.minus({days:7}).toISO() + '&per_page=100'}}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "github-issues",
+      "name": "Fetch Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        220,
+        40
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "GITHUB_CREDENTIALS_ID",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{($env.GITHUB_API_URL || 'https://api.github.com') + '/repos/' + $env.GITHUB_REPO + '/pulls?state=closed&sort=updated&direction=desc&per_page=100'}}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "github-prs",
+      "name": "Fetch Closed PRs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        220,
+        200
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "GITHUB_CREDENTIALS_ID",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combinationMode": "multiplex"
+      },
+      "id": "merge-data",
+      "name": "Merge GitHub Data",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [
+        440,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const commits = $('Fetch Commits').first().json ?? [];\nconst issues = $('Fetch Closed Issues').first().json ?? [];\nconst prs = $('Fetch Closed PRs').first().json ?? [];\n\nconst oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;\nconst repo = $env.GITHUB_REPO || 'owner/repo';\nconst language = ($env.LANGUAGE || 'EN').toUpperCase();\n\nconst commitItems = Array.isArray(commits) ? commits.slice(0, 30) : [];\nconst issueItems = Array.isArray(issues)\n  ? issues.filter((item) => !item.pull_request).slice(0, 20)\n  : [];\nconst mergedPrItems = Array.isArray(prs)\n  ? prs.filter((item) => item.merged_at && Date.parse(item.merged_at) >= oneWeekAgo).slice(0, 20)\n  : [];\n\nconst commitLines = commitItems.map((item) => {\n  const title = item.commit?.message?.split('\\n')[0] || 'No commit message';\n  const author = item.commit?.author?.name || item.author?.login || 'unknown';\n  return `- ${title} (by ${author})`;\n});\n\nconst issueLines = issueItems.map((item) => `- #${item.number} ${item.title}`);\nconst prLines = mergedPrItems.map((item) => `- #${item.number} ${item.title}`);\n\nconst prompt = [\n  `Repository: ${repo}`,\n  `Language: ${language}`,\n  '',\n  `Commits this week (${commitLines.length}):`,\n  commitLines.length ? commitLines.join('\\n') : '- No notable commits captured',\n  '',\n  `Closed issues this week (${issueLines.length}):`,\n  issueLines.length ? issueLines.join('\\n') : '- No closed issues captured',\n  '',\n  `Merged pull requests this week (${prLines.length}):`,\n  prLines.length ? prLines.join('\\n') : '- No merged PRs captured',\n  '',\n  'Write a concise narrative weekly engineering summary under 400 words with these sections:',\n  '1. Overview',\n  '2. Key highlights',\n  '3. Notable changes',\n  'Keep it factual and avoid fluff.'\n].join('\\n');\n\nreturn [{\n  json: {\n    repo,\n    language,\n    weekEnding: new Date().toISOString().split('T')[0],\n    commitCount: commitLines.length,\n    issueCount: issueLines.length,\n    prCount: prLines.length,\n    prompt\n  }\n}];"
+      },
+      "id": "build-context",
+      "name": "Build Weekly Context",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        660,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{$env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages'}}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { \"model\": \"claude-sonnet-4-20250514\", \"max_tokens\": 1024, \"temperature\": 0.3, \"messages\": [ { \"role\": \"user\", \"content\": $json.prompt } ] } }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "anthropic-summary",
+      "name": "Generate Summary (Claude)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        900,
+        40
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "ANTHROPIC_CREDENTIALS_ID",
+          "name": "Anthropic API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $('Generate Summary (Claude)').first().json ?? {};\nconst context = $('Build Weekly Context').first().json;\n\nconst messageText = Array.isArray(response.content)\n  ? response.content.map((item) => item.text || '').join('\\n\\n').trim()\n  : response.text || response.output_text || JSON.stringify(response, null, 2);\n\nconst formatted = [\n  `# Weekly Dev Summary: ${context.repo}`,\n  `**Week ending:** ${context.weekEnding}`,\n  '',\n  messageText\n].join('\\n');\n\nreturn [{\n  json: {\n    repo: context.repo,\n    weekEnding: context.weekEnding,\n    formatted\n  }\n}];"
+      },
+      "id": "format-output",
+      "name": "Format Markdown Output",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1120,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "fromEmail": "={{$env.SMTP_FROM}}",
+        "toEmail": "={{$env.EMAIL_TO}}",
+        "subject": "=Weekly Dev Summary: {{$json.repo}} ({{$json.weekEnding}})",
+        "text": "={{$json.formatted}}",
+        "options": {}
+      },
+      "id": "send-email",
+      "name": "Send Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        1340,
+        -40
+      ],
+      "credentials": {
+        "smtp": {
+          "id": "SMTP_CREDENTIALS_ID",
+          "name": "SMTP Account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{$env.SLACK_WEBHOOK_URL}}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { \"text\": $json.formatted } }}",
+        "options": {}
+      },
+      "id": "slack-webhook",
+      "name": "Post to Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1340,
+        120
+      ]
+    }
+  ],
+  "connections": {
+    "Every Friday 5PM": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed Issues",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed PRs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits": {
+      "main": [
+        [
+          {
+            "node": "Merge GitHub Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed Issues": {
+      "main": [
+        [
+          {
+            "node": "Merge GitHub Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed PRs": {
+      "main": [
+        [
+          {
+            "node": "Merge GitHub Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge GitHub Data": {
+      "main": [
+        [
+          {
+            "node": "Build Weekly Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Weekly Context": {
+      "main": [
+        [
+          {
+            "node": "Generate Summary (Claude)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Summary (Claude)": {
+      "main": [
+        [
+          {
+            "node": "Format Markdown Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Markdown Output": {
+      "main": [
+        [
+          {
+            "node": "Send Email",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Post to Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {
+      "name": "weekly-summary"
+    },
+    {
+      "name": "claude"
+    },
+    {
+      "name": "github"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds an importable n8n workflow that generates a weekly narrative summary of GitHub activity with Claude and delivers it to email and/or Slack.

## What changed in this revision
- normalizes commits, issues, and merged PRs into a single weekly context block before summarization
- filters pull requests out of the issues feed and filters PRs by `merged_at` within the last 7 days
- calls Anthropic directly via HTTP instead of relying on an OpenAI-compatible shortcut
- documents how to switch the webhook output from Slack to Discord if needed

## Acceptance Criteria ?
- [x] Exportable n8n workflow JSON
- [x] Weekly cron trigger (Friday 5 PM)
- [x] Fetches commits, closed issues, and merged PRs from GitHub
- [x] Uses `claude-sonnet-4-20250514` for narrative summary generation
- [x] Delivers to email and/or Slack webhook, with Discord swap guidance in the README
- [x] Exposes configurable repo and language settings
- [x] Includes a concise setup README

Closes #5