### PR TITLE
feat: Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/hooks/pre-tool-use-guard/README.md
+++ b/hooks/pre-tool-use-guard/README.md
@@ -1,0 +1,132 @@
+# 🛡️ Pre-tool-use Guard — Block Destructive Bash Commands
+
+A Claude Code **pre-tool-use hook** that intercepts and blocks dangerous bash commands before they execute. Prevents accidental data loss from `rm -rf`, SQL destruction, force pushes, and more.
+
+## Blocked Patterns
+
+| Pattern | Example | Why |
+|---------|---------|-----|
+| `rm -rf` | `rm -rf /`, `rm -rf ./build` | Recursive force delete |
+| `DROP TABLE` | `DROP TABLE users;` | SQL table deletion |
+| `git push --force` | `git push --force origin main` | Force push overwrites history |
+| `TRUNCATE` | `TRUNCATE TABLE orders;` | SQL mass data wipe |
+| `DELETE FROM` (no `WHERE`) | `DELETE FROM users;` | Unbounded SQL delete |
+
+Safe commands pass through without interference. For example, `rm file.txt`, `git push origin main`, and `DELETE FROM users WHERE id = 5` are all allowed.
+
+## Installation
+
+```bash
+git clone https://github.com/YPC0813/claude-builders-bounty.git && bash claude-builders-bounty/hooks/pre-tool-use-guard/install.sh
+```
+
+That's it — **one command**. The installer:
+
+1. Copies `guard.py` to `~/.claude/hooks/`
+2. Registers the hook in `~/.claude/settings.json`
+
+### Requirements
+
+- Python 3.10+
+- [`jq`](https://jqlang.github.io/jq/) (for the installer to merge settings)
+
+### Manual Installation
+
+If you prefer to install manually:
+
+```bash
+# 1. Copy the hook script
+mkdir -p ~/.claude/hooks
+cp guard.py ~/.claude/hooks/guard.py
+chmod +x ~/.claude/hooks/guard.py
+
+# 2. Add to ~/.claude/settings.json
+```
+
+Add this to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## How It Works
+
+```
+Claude decides to run a Bash command
+        │
+        ▼
+  ┌─────────────┐
+  │ PreToolUse   │  Claude Code fires the hook event
+  │ event fires  │
+  └──────┬───────┘
+         │
+         ▼
+  ┌─────────────┐
+  │ guard.py     │  Reads JSON from stdin, extracts the command
+  │ inspects cmd │
+  └──────┬───────┘
+         │
+    ┌────┴────┐
+    │         │
+ blocked    safe
+    │         │
+    ▼         ▼
+  deny      exit 0
+  + log     (allow)
+```
+
+1. Claude Code fires a `PreToolUse` event for every Bash tool call
+2. `guard.py` reads the JSON input from stdin
+3. The command is checked against destructive patterns (regex-based)
+4. **Blocked**: Returns a `deny` decision with a clear explanation; logs to `~/.claude/hooks/blocked.log`
+5. **Safe**: Exits with code 0 (allow) — no output, no delay
+
+### Block Log
+
+Every blocked command is logged to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-04-21T03:00:00Z] BLOCKED
+  Pattern : rm -rf (recursive force delete)
+  Command : rm -rf /tmp/important-data
+  Project : /home/user/my-project
+────────────────────────────────────────────────────────
+```
+
+## Testing
+
+```bash
+python3 test_guard.py
+```
+
+Or with pytest:
+
+```bash
+python3 -m pytest test_guard.py -v
+```
+
+## Uninstall
+
+```bash
+rm ~/.claude/hooks/guard.py
+```
+
+Then remove the `PreToolUse` hook entry from `~/.claude/settings.json`.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE)

--- a/hooks/pre-tool-use-guard/guard.py
+++ b/hooks/pre-tool-use-guard/guard.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Claude Code Pre-tool-use Hook: Destructive Command Guard
+=========================================================
+
+A pre-tool-use hook that intercepts and blocks dangerous bash commands
+before Claude Code executes them. Protects against accidental data loss,
+database destruction, and force-pushes.
+
+Blocked patterns:
+  - rm -rf           (recursive force delete)
+  - DROP TABLE       (SQL table deletion)
+  - git push --force (force push to remote)
+  - TRUNCATE         (SQL table truncation)
+  - DELETE FROM      (SQL delete without WHERE clause)
+
+Usage:
+  This script reads JSON from stdin (Claude Code hook protocol),
+  inspects the command, and returns a deny decision if a destructive
+  pattern is detected. Safe commands pass through unmodified.
+
+See: https://docs.anthropic.com/en/docs/claude-code/hooks
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+# Each rule: (compiled regex, human-readable description)
+DESTRUCTIVE_PATTERNS = [
+    (
+        re.compile(r"\brm\s+.*-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*\b|\brm\s+.*-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*\b", re.IGNORECASE),
+        "rm -rf (recursive force delete)",
+    ),
+    (
+        re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE),
+        "DROP TABLE (SQL table deletion)",
+    ),
+    (
+        re.compile(r"\bgit\s+push\s+.*--force\b|\bgit\s+push\s+.*-f\b", re.IGNORECASE),
+        "git push --force (force push to remote)",
+    ),
+    (
+        re.compile(r"\bTRUNCATE\b", re.IGNORECASE),
+        "TRUNCATE (SQL table truncation)",
+    ),
+]
+
+# Special pattern: DELETE FROM without WHERE
+DELETE_WITHOUT_WHERE = re.compile(
+    r"\bDELETE\s+FROM\s+\S+\s*;?\s*$", re.IGNORECASE | re.MULTILINE
+)
+
+
+# ── Core Logic ─────────────────────────────────────────────────────────
+
+
+def check_command(command: str) -> tuple[bool, str]:
+    """
+    Check if a command matches any destructive pattern.
+
+    Returns:
+        (is_blocked, reason) — True + reason if blocked, False + "" if safe.
+    """
+    for pattern, description in DESTRUCTIVE_PATTERNS:
+        if pattern.search(command):
+            return True, description
+
+    # DELETE FROM without WHERE clause
+    if re.search(r"\bDELETE\s+FROM\b", command, re.IGNORECASE):
+        # Allow if WHERE is present after DELETE FROM <table>
+        if not re.search(r"\bDELETE\s+FROM\s+\S+\s+WHERE\b", command, re.IGNORECASE):
+            return True, "DELETE FROM without WHERE clause (unsafe mass delete)"
+
+    return False, ""
+
+
+def log_blocked(command: str, reason: str, project_dir: str) -> None:
+    """Append a blocked-command entry to the log file."""
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    entry = (
+        f"[{timestamp}] BLOCKED\n"
+        f"  Pattern : {reason}\n"
+        f"  Command : {command}\n"
+        f"  Project : {project_dir}\n"
+        f"{'─' * 60}\n"
+    )
+
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(entry)
+
+
+def deny(reason: str, command: str) -> None:
+    """Output a deny decision in Claude Code hook JSON format and exit."""
+    message = (
+        f"🚫 BLOCKED by pre-tool-use guard\n"
+        f"   Reason: {reason}\n"
+        f"   Command: {command}\n"
+        f"   This command was blocked to prevent accidental data loss.\n"
+        f"   If you need to run this command, ask the user for explicit confirmation."
+    )
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": message,
+        }
+    }
+    json.dump(output, sys.stdout)
+    sys.exit(0)
+
+
+def main() -> None:
+    """Entry point: read hook input from stdin, check, decide."""
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        # Can't parse input → don't block, let it pass
+        sys.exit(0)
+
+    # Extract the command from tool_input
+    tool_input = hook_input.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if not command:
+        # No command to inspect → allow
+        sys.exit(0)
+
+    # Get project directory from the hook input
+    project_dir = hook_input.get("cwd", os.getcwd())
+
+    # Check against destructive patterns
+    is_blocked, reason = check_command(command)
+
+    if is_blocked:
+        log_blocked(command, reason, project_dir)
+        deny(reason, command)
+    else:
+        # Safe command → exit 0 (allow)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/pre-tool-use-guard/install.sh
+++ b/hooks/pre-tool-use-guard/install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# install.sh — Install the Pre-tool-use Destructive Command Guard
+#
+# Usage:
+#   curl -sSL <raw-url>/install.sh | bash
+#   — or —
+#   git clone ... && cd hooks/pre-tool-use-guard && bash install.sh
+#
+set -euo pipefail
+
+HOOK_DIR="$HOME/.claude/hooks"
+SCRIPT_NAME="guard.py"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+# Resolve the directory this script lives in
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_FILE="$SCRIPT_DIR/$SCRIPT_NAME"
+
+echo "🔧 Installing Claude Code pre-tool-use guard..."
+
+# 1. Copy the hook script
+mkdir -p "$HOOK_DIR"
+cp "$SOURCE_FILE" "$HOOK_DIR/$SCRIPT_NAME"
+chmod +x "$HOOK_DIR/$SCRIPT_NAME"
+echo "   ✅ Copied $SCRIPT_NAME → $HOOK_DIR/"
+
+# 2. Merge hook config into ~/.claude/settings.json
+NEW_HOOK='{
+  "matcher": "Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "python3 ~/.claude/hooks/guard.py"
+    }
+  ]
+}'
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+    # No settings file yet — create one
+    echo "{}" > "$SETTINGS_FILE"
+fi
+
+# Check if jq is available
+if ! command -v jq &>/dev/null; then
+    echo "   ⚠️  jq not found. Please install jq and re-run, or add the hook config manually."
+    echo ""
+    echo "   Add this to $SETTINGS_FILE under \"hooks.PreToolUse\":"
+    echo "   $NEW_HOOK"
+    exit 1
+fi
+
+# Read existing settings
+EXISTING=$(cat "$SETTINGS_FILE")
+
+# Check if PreToolUse hooks already exist
+if echo "$EXISTING" | jq -e '.hooks.PreToolUse' &>/dev/null; then
+    # Check if our hook is already installed
+    if echo "$EXISTING" | jq -e '.hooks.PreToolUse[] | select(.hooks[]?.command == "python3 ~/.claude/hooks/guard.py")' &>/dev/null; then
+        echo "   ℹ️  Hook already registered in settings.json — skipping"
+    else
+        # Append to existing PreToolUse array
+        UPDATED=$(echo "$EXISTING" | jq --argjson hook "$NEW_HOOK" '.hooks.PreToolUse += [$hook]')
+        echo "$UPDATED" > "$SETTINGS_FILE"
+        echo "   ✅ Appended hook to existing PreToolUse config"
+    fi
+else
+    # Create hooks.PreToolUse array
+    UPDATED=$(echo "$EXISTING" | jq --argjson hook "$NEW_HOOK" '.hooks.PreToolUse = [$hook]')
+    echo "$UPDATED" > "$SETTINGS_FILE"
+    echo "   ✅ Added PreToolUse hook to settings.json"
+fi
+
+echo ""
+echo "🎉 Installation complete!"
+echo "   Hook script: $HOOK_DIR/$SCRIPT_NAME"
+echo "   Settings:    $SETTINGS_FILE"
+echo "   Block log:   $HOOK_DIR/blocked.log"
+echo ""
+echo "   The guard will automatically block destructive commands"
+echo "   (rm -rf, DROP TABLE, git push --force, TRUNCATE, DELETE FROM without WHERE)"
+echo "   in all your Claude Code sessions."

--- a/hooks/pre-tool-use-guard/test_guard.py
+++ b/hooks/pre-tool-use-guard/test_guard.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Tests for the pre-tool-use destructive command guard.
+
+Run:  python3 -m pytest test_guard.py -v
+  or: python3 test_guard.py
+"""
+
+import json
+import subprocess
+import sys
+import os
+
+GUARD_SCRIPT = os.path.join(os.path.dirname(__file__), "guard.py")
+
+
+def run_hook(command: str) -> tuple[int, dict | None]:
+    """
+    Simulate a Claude Code PreToolUse hook call.
+
+    Returns (exit_code, parsed_json_output_or_None).
+    """
+    hook_input = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/tmp/test-project",
+    }
+
+    result = subprocess.run(
+        [sys.executable, GUARD_SCRIPT],
+        input=json.dumps(hook_input),
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    output = None
+    if result.stdout.strip():
+        try:
+            output = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+
+    return result.returncode, output
+
+
+def is_blocked(output: dict | None) -> bool:
+    """Check if the hook output indicates a deny decision."""
+    if output is None:
+        return False
+    decision = (
+        output.get("hookSpecificOutput", {}).get("permissionDecision", "")
+    )
+    return decision == "deny"
+
+
+# ── Tests: should be BLOCKED ──────────────────────────────────────────
+
+
+def test_rm_rf():
+    code, out = run_hook("rm -rf /")
+    assert code == 0
+    assert is_blocked(out), "rm -rf / should be blocked"
+
+
+def test_rm_rf_directory():
+    code, out = run_hook("rm -rf ./build")
+    assert code == 0
+    assert is_blocked(out), "rm -rf ./build should be blocked"
+
+
+def test_rm_fr():
+    """rm -fr is the same as rm -rf, just different flag order."""
+    code, out = run_hook("rm -fr /tmp/data")
+    assert code == 0
+    assert is_blocked(out), "rm -fr should be blocked"
+
+
+def test_drop_table():
+    code, out = run_hook("psql -c 'DROP TABLE users;'")
+    assert code == 0
+    assert is_blocked(out), "DROP TABLE should be blocked"
+
+
+def test_drop_table_case_insensitive():
+    code, out = run_hook("mysql -e 'drop table accounts'")
+    assert code == 0
+    assert is_blocked(out), "drop table (lowercase) should be blocked"
+
+
+def test_git_push_force():
+    code, out = run_hook("git push --force origin main")
+    assert code == 0
+    assert is_blocked(out), "git push --force should be blocked"
+
+
+def test_git_push_force_short():
+    code, out = run_hook("git push -f origin main")
+    assert code == 0
+    assert is_blocked(out), "git push -f should be blocked"
+
+
+def test_truncate():
+    code, out = run_hook("psql -c 'TRUNCATE users;'")
+    assert code == 0
+    assert is_blocked(out), "TRUNCATE should be blocked"
+
+
+def test_truncate_table():
+    code, out = run_hook("mysql -e 'TRUNCATE TABLE orders;'")
+    assert code == 0
+    assert is_blocked(out), "TRUNCATE TABLE should be blocked"
+
+
+def test_delete_from_no_where():
+    code, out = run_hook("psql -c 'DELETE FROM users;'")
+    assert code == 0
+    assert is_blocked(out), "DELETE FROM without WHERE should be blocked"
+
+
+def test_delete_from_no_where_no_semicolon():
+    code, out = run_hook("mysql -e 'DELETE FROM orders'")
+    assert code == 0
+    assert is_blocked(out), "DELETE FROM without WHERE (no semicolon) should be blocked"
+
+
+# ── Tests: should be ALLOWED ──────────────────────────────────────────
+
+
+def test_safe_rm():
+    code, out = run_hook("rm file.txt")
+    assert code == 0
+    assert not is_blocked(out), "rm file.txt should be allowed"
+
+
+def test_safe_rm_r():
+    """rm -r (without -f) is still risky but not matched by rm -rf pattern."""
+    code, out = run_hook("rm -r ./old")
+    assert code == 0
+    assert not is_blocked(out), "rm -r (without -f) should be allowed"
+
+
+def test_safe_git_push():
+    code, out = run_hook("git push origin main")
+    assert code == 0
+    assert not is_blocked(out), "git push (no --force) should be allowed"
+
+
+def test_safe_ls():
+    code, out = run_hook("ls -la")
+    assert code == 0
+    assert not is_blocked(out), "ls -la should be allowed"
+
+
+def test_safe_npm():
+    code, out = run_hook("npm install express")
+    assert code == 0
+    assert not is_blocked(out), "npm install should be allowed"
+
+
+def test_safe_delete_with_where():
+    code, out = run_hook("psql -c 'DELETE FROM users WHERE id = 5;'")
+    assert code == 0
+    assert not is_blocked(out), "DELETE FROM with WHERE should be allowed"
+
+
+def test_safe_python():
+    code, out = run_hook("python3 app.py")
+    assert code == 0
+    assert not is_blocked(out), "python3 should be allowed"
+
+
+def test_safe_cat():
+    code, out = run_hook("cat /etc/hosts")
+    assert code == 0
+    assert not is_blocked(out), "cat should be allowed"
+
+
+def test_empty_command():
+    code, out = run_hook("")
+    assert code == 0
+    assert not is_blocked(out), "empty command should be allowed"
+
+
+# ── Run tests directly ────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    test_functions = [
+        v for k, v in sorted(globals().items()) if k.startswith("test_")
+    ]
+    passed = 0
+    failed = 0
+    for fn in test_functions:
+        try:
+            fn()
+            print(f"  ✅ {fn.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  ❌ {fn.__name__}: {e}")
+            failed += 1
+
+    print(f"\n{'─' * 40}")
+    print(f"  {passed} passed, {failed} failed, {passed + failed} total")
+    if failed > 0:
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Implements a Python-based Claude Code `PreToolUse` hook that intercepts and blocks dangerous bash commands before Claude Code executes them.

Closes #3

## Blocked Patterns

| Pattern | Example | Description |
|---------|---------|-------------|
| `rm -rf` | `rm -rf /`, `rm -rf ./build` | Recursive force delete |
| `DROP TABLE` | `DROP TABLE users;` | SQL table deletion |
| `git push --force` | `git push --force origin main`, `git push -f` | Force push overwrites history |
| `TRUNCATE` | `TRUNCATE TABLE orders;` | SQL mass data wipe |
| `DELETE FROM` (no `WHERE`) | `DELETE FROM users;` | Unbounded SQL delete |

## Features

- ✅ Follows Claude Code hooks format — configured via `~/.claude/settings.json`
- ✅ Blocks all 5 required destructive patterns
- ✅ Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
- ✅ Displays clear deny message to Claude explaining why the command was blocked
- ✅ Zero interference with safe commands (`exit 0` passthrough)
- ✅ One-command installer (`install.sh`)
- ✅ 20 unit tests covering all patterns and edge cases (all passing)

## Installation

```bash
git clone https://github.com/YPC0813/claude-builders-bounty.git && bash claude-builders-bounty/hooks/pre-tool-use-guard/install.sh
```

## Files

- `hooks/pre-tool-use-guard/guard.py` — The hook script (Python 3.10+)
- `hooks/pre-tool-use-guard/install.sh` — One-command installer
- `hooks/pre-tool-use-guard/test_guard.py` — 20 unit tests
- `hooks/pre-tool-use-guard/README.md` — Documentation

## Testing

```
$ python3 -m pytest test_guard.py -v
20 passed in 0.36s
```

All 20 tests pass — 11 tests verify blocked patterns, 9 tests verify safe commands pass through.