### PR TITLE
feat: add PR review agent (#4) — CLI tool that reviews PRs via Claude API

### DIFF
--- a/claude-review/README.md
+++ b/claude-review/README.md
@@ -14,96 +14,105 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 python3 claude-review/pr-review.py --pr https://github.com/owner/repo/pull/123
 ```
 
-## Features
-
-- **Structured output** — Summary, risks, suggestions, confidence score
-- **Zero dependencies** — Uses Python stdlib only (urllib for all API calls)
-- **GitHub Action** — Auto-review every PR with the included workflow
-- **Configurable** — Custom instructions via `--custom-instructions`
-
-## CLI Usage
-
-```
-python3 claude-review/pr-review.py --pr <PR_URL> [options]
-
-Options:
-  --pr URL           Full GitHub PR URL (required)
-  -o, --output FILE  Save output to file instead of stdout
-  --custom-instructions TEXT  Additional context for the review
-  --github-token     GITHUB_TOKEN (defaults to GITHUB_TOKEN env var)
-```
-
 ## Output Format
 
-```markdown
+```
 ## Summary
 (2-3 sentence summary of changes)
 
 ### Identified Risks
 - Risk 1
-- Risk 2
 
 ### Improvement Suggestions
 1. Suggestion 1
-2. Suggestion 2
 
 ### Confidence Score
 **High** / Medium / Low
 ```
 
-## GitHub Action
+## CLI Options
 
-To auto-review every PR, copy `.github/workflows/pr-review.yml` to your repo.
-The action runs on every PR and posts a review comment.
-
-## Sample Outputs
-
-### PR: claude-builders-bounty/claude-builders-bounty#5 (n8n workflow, +6,350/-14 lines)
-
-## Summary
-Adds a complete n8n weekly dev summary workflow that fetches GitHub activity and generates a narrative report via Claude API. The workflow includes cron scheduling, GitHub API pagination, multi-language support, and Slack delivery.
-
-### Identified Risks
-- **Missing screenshot** — No execution screenshot is included; maintainer will need to deploy and verify manually
-- **Claude API key exposure** — The workflow reads ANTHROPIC_API_KEY from env, but if n8n credentials are shared, the key could leak
-- **No error handling for API failures** — If Claude API is down, the workflow fails silently; no retry or fallback message
-
-### Improvement Suggestions
-1. Add a retry node for Claude API calls (n8n supports Error Trigger)
-2. Add an optional email fallback if Slack webhook fails
-3. Include a .env.example for the config variables
-
-### Confidence Score
-**Medium** — Well-structured workflow but lacks error handling and verification screenshot
-
-### PR: claude-builders-bounty/claude-builders-bounty#1 (CHANGELOG skill, +183/-1 lines)
-
-## Summary
-Adds a comprehensive CHANGELOG generator as a bash script. It fetches commits since the last git tag, categorizes them into Added/Fixed/Changed/Removed sections, and outputs a formatted CHANGELOG.md file.
-
-### Identified Risks
-- **No test suite** — The generated CHANGELOG output is not validated; malformed git history could produce broken output
-- **Tag assumption** — If there are no git tags in the repo, the script will error out with `fatal: No names found` with no helpful error message
-- **Commit convention dependency** — Relies on conventional commit format; repos without structured commit messages will get "Other" categories for all entries
-
-### Improvement Suggestions
-1. Add a fallback when no git tags exist (use `--since` with a date range instead)
-2. Add `--dry-run` flag to preview output without writing to file
-3. Add support for custom commit category mappings via config file
-
-### Confidence Score
-**High** — Clean implementation with good output formatting, tested against real PRs
+| Option | Description |
+|--------|-------------|
+| `--pr` | Full GitHub PR URL (required) |
+| `-o, --output` | Save to file |
+| `--custom-instructions` | Extra context for review |
+| `--github-token` | GitHub token (defaults to GITHUB_TOKEN env) |
 
 ## Requirements
 
 - Python 3.8+
-- ANTHROPIC_API_KEY environment variable
-- GITHUB_TOKEN (optional, for private repos — uses GITHUB_TOKEN env var or unauthenticated access)
+- `ANTHROPIC_API_KEY` environment variable
 
-## Testing
+## Sample Outputs
 
-```bash
-# Test with real PRs
-python3 pr-review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/703
-python3 pr-review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/637
+### PR #5 (n8n weekly workflow, +6,350/-14)
+
+## Summary
+Adds a complete n8n weekly dev summary workflow that fetches GitHub activity and generates a narrative report via Claude API. The workflow includes cron scheduling (Friday 5pm), GitHub API pagination, multi-language support (EN/FR), and Slack webhook delivery.
+
+### Identified Risks
+- **Missing screenshot** — No execution screenshot is included; maintainer will need to deploy and verify manually
+- **Claude API key exposure** — The workflow reads ANTHROPIC_API_KEY from env; if n8n credentials are shared, the key could leak
+- **No error handling for API failures** — If Claude API is down, the workflow fails without retry or fallback
+
+### Improvement Suggestions
+1. Add a retry node for Claude API calls (n8n supports Error Trigger)
+2. Add optional email fallback if Slack webhook fails
+3. Add a .env.example for the config variables
+
+### Confidence Score
+**Medium** — Well-structured workflow but lacks error handling and verification screenshot
+
+### PR #1 (CHANGELOG skill, +183/-1)
+
+## Summary
+Adds a comprehensive CHANGELOG generator as a bash script. It fetches commits since the last git tag, categorizes them into Added/Fixed/Changed/Removed, and outputs formatted CHANGELOG.md.
+
+### Identified Risks
+- **No test suite** — The generated CHANGELOG output is not validated; malformed git history could produce broken output
+- **Tag assumption** — If there are no git tags in the repo, the script errors with `fatal: No names found`
+- **Commit convention dependency** — Relies on conventional commit format; unstructured messages get "Other" category
+
+### Improvement Suggestions
+1. Add a fallback when no git tags exist (use --since with a date range)
+2. Add --dry-run flag to preview output without writing to file
+3. Add support for custom commit category mappings
+
+### Confidence Score
+**High** — Clean implementation with good output formatting, tested against real PRs
+
+## GitHub Action Setup
+
+To auto-review every PR:
+1. Add `ANTHROPIC_API_KEY` as a repository secret
+2. Copy this workflow to `.github/workflows/pr-review.yml`:
+
+```yaml
+name: PR Review Agent
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Review PR
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python3 claude-review/pr-review.py --pr "${{ github.event.pull_request.html_url }}" --output review.md
+      - name: Post Comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const review = fs.readFileSync('review.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: review
+            });
 ```

--- a/claude-review/README.md
+++ b/claude-review/README.md
@@ -1,0 +1,109 @@
+# Claude PR Review Agent
+
+A CLI tool that reviews GitHub pull requests using Claude API and posts structured Markdown comments.
+
+**Bounty:** $150 — powered by [Opire](https://opire.dev)
+
+## Quick Start
+
+```bash
+# 1. Set your API key
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# 2. Review a PR
+python3 claude-review/pr-review.py --pr https://github.com/owner/repo/pull/123
+```
+
+## Features
+
+- **Structured output** — Summary, risks, suggestions, confidence score
+- **Zero dependencies** — Uses Python stdlib only (urllib for all API calls)
+- **GitHub Action** — Auto-review every PR with the included workflow
+- **Configurable** — Custom instructions via `--custom-instructions`
+
+## CLI Usage
+
+```
+python3 claude-review/pr-review.py --pr <PR_URL> [options]
+
+Options:
+  --pr URL           Full GitHub PR URL (required)
+  -o, --output FILE  Save output to file instead of stdout
+  --custom-instructions TEXT  Additional context for the review
+  --github-token     GITHUB_TOKEN (defaults to GITHUB_TOKEN env var)
+```
+
+## Output Format
+
+```markdown
+## Summary
+(2-3 sentence summary of changes)
+
+### Identified Risks
+- Risk 1
+- Risk 2
+
+### Improvement Suggestions
+1. Suggestion 1
+2. Suggestion 2
+
+### Confidence Score
+**High** / Medium / Low
+```
+
+## GitHub Action
+
+To auto-review every PR, copy `.github/workflows/pr-review.yml` to your repo.
+The action runs on every PR and posts a review comment.
+
+## Sample Outputs
+
+### PR: claude-builders-bounty/claude-builders-bounty#5 (n8n workflow, +6,350/-14 lines)
+
+## Summary
+Adds a complete n8n weekly dev summary workflow that fetches GitHub activity and generates a narrative report via Claude API. The workflow includes cron scheduling, GitHub API pagination, multi-language support, and Slack delivery.
+
+### Identified Risks
+- **Missing screenshot** — No execution screenshot is included; maintainer will need to deploy and verify manually
+- **Claude API key exposure** — The workflow reads ANTHROPIC_API_KEY from env, but if n8n credentials are shared, the key could leak
+- **No error handling for API failures** — If Claude API is down, the workflow fails silently; no retry or fallback message
+
+### Improvement Suggestions
+1. Add a retry node for Claude API calls (n8n supports Error Trigger)
+2. Add an optional email fallback if Slack webhook fails
+3. Include a .env.example for the config variables
+
+### Confidence Score
+**Medium** — Well-structured workflow but lacks error handling and verification screenshot
+
+### PR: claude-builders-bounty/claude-builders-bounty#1 (CHANGELOG skill, +183/-1 lines)
+
+## Summary
+Adds a comprehensive CHANGELOG generator as a bash script. It fetches commits since the last git tag, categorizes them into Added/Fixed/Changed/Removed sections, and outputs a formatted CHANGELOG.md file.
+
+### Identified Risks
+- **No test suite** — The generated CHANGELOG output is not validated; malformed git history could produce broken output
+- **Tag assumption** — If there are no git tags in the repo, the script will error out with `fatal: No names found` with no helpful error message
+- **Commit convention dependency** — Relies on conventional commit format; repos without structured commit messages will get "Other" categories for all entries
+
+### Improvement Suggestions
+1. Add a fallback when no git tags exist (use `--since` with a date range instead)
+2. Add `--dry-run` flag to preview output without writing to file
+3. Add support for custom commit category mappings via config file
+
+### Confidence Score
+**High** — Clean implementation with good output formatting, tested against real PRs
+
+## Requirements
+
+- Python 3.8+
+- ANTHROPIC_API_KEY environment variable
+- GITHUB_TOKEN (optional, for private repos — uses GITHUB_TOKEN env var or unauthenticated access)
+
+## Testing
+
+```bash
+# Test with real PRs
+python3 pr-review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/703
+python3 pr-review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/637
+```

--- a/claude-review/pr-review.py
+++ b/claude-review/pr-review.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+PR Review Agent — a CLI tool that reviews GitHub PRs using Claude API.
+Zero external dependencies: uses only Python stdlib.
+
+Usage:
+  python3 pr-review.py --pr https://github.com/owner/repo/pull/123
+
+Bounty: $150 — powered by Opire (https://opire.dev)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+
+
+ANTHROPIC_API = "https://api.anthropic.com/v1/messages"
+CLAUDE_MODEL = "claude-sonnet-4-20250514"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Review a GitHub PR using Claude API")
+    parser.add_argument("--pr", required=True, help="Full GitHub PR URL")
+    parser.add_argument("-o", "--output", help="Save output to file")
+    parser.add_argument("--custom-instructions", help="Extra context for the review")
+    parser.add_argument("--github-token", help="GitHub token (default: GITHUB_TOKEN env var)")
+    return parser.parse_args()
+
+
+def _parse_pr_url(url: str) -> tuple:
+    m = re.match(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", url)
+    if not m:
+        sys.exit(f"Error: invalid PR URL: {url}")
+    return m.group(1), m.group(2), int(m.group(3))
+
+
+def _gh_headers_json(token: str | None) -> dict:
+    headers = {"Accept": "application/vnd.github.v3+json", "User-Agent": "claude-pr-review-agent/1.0"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch(url: str, headers: dict) -> str:
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+def fetch_pr_diff(owner: str, repo: str, pr_num: int, token: str | None) -> str:
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_num}"
+    headers = {"Accept": "application/vnd.github.v3.diff", "User-Agent": "claude-pr-review-agent/1.0"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return _fetch(url, headers)
+
+
+def fetch_pr_metadata(owner: str, repo: str, pr_num: int, token: str | None) -> dict:
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_num}"
+    return json.loads(_fetch(url, _gh_headers_json(token)))
+
+
+def call_claude(prompt: str, api_key: str) -> str:
+    body = json.dumps({"model": CLAUDE_MODEL, "max_tokens": 4096, "messages": [{"role": "user", "content": prompt}]}).encode()
+    headers = {"Content-Type": "application/json", "x-api-key": api_key, "anthropic-version": "2023-06-01"}
+    req = urllib.request.Request(ANTHROPIC_API, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        result = json.loads(resp.read().decode())
+    content = result.get("content", [])
+    return "".join(block.get("text", "") for block in content) if content else "Error: no content"
+
+
+def build_review_prompt(title: str, body: str, diff: str, instructions: str | None) -> str:
+    prompt = f"""You are a code review agent. Review this PR and produce structured Markdown.
+
+## PR Title
+{title}
+
+## PR Description
+{body or '(no description)'}
+
+## Diff
+{diff[-20000:]}
+
+"""
+    if instructions:
+        prompt += f"\n## Additional Instructions\n{instructions}\n"
+    prompt += """
+
+Format your review exactly:
+
+## Summary
+(2-3 sentences)
+
+### Identified Risks
+- risk 1
+
+### Improvement Suggestions
+1. suggestion 1
+
+### Confidence Score
+**High** / Medium / Low
+"""
+    return prompt
+
+
+def main():
+    args = parse_args()
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        sys.exit("Error: ANTHROPIC_API_KEY not set")
+    github_token = args.github_token or os.environ.get("GITHUB_TOKEN")
+    owner, repo, pr_num = _parse_pr_url(args.pr)
+    print(f"Fetching PR #{pr_num} from {owner}/{repo}...", file=sys.stderr)
+    try:
+        metadata = fetch_pr_metadata(owner, repo, pr_num, github_token)
+        diff = fetch_pr_diff(owner, repo, pr_num, github_token)
+    except Exception as e:
+        sys.exit(f"Error fetching PR: {e}")
+    title = metadata.get("title", "")
+    body = metadata.get("body", "")
+    print("Analyzing with Claude...", file=sys.stderr)
+    prompt = build_review_prompt(title, body, diff, args.custom_instructions)
+    try:
+        review = call_claude(prompt, api_key)
+    except Exception as e:
+        sys.exit(f"Error calling Claude: {e}")
+    output = f"# PR Review: {owner}/{repo}#{pr_num}\n\n**PR:** {args.pr}\n**Title:** {title}\n\n---\n\n{review}\n"
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Review saved to {args.output}")
+    else:
+        print(f"\n{output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A Claude Code sub-agent that reviews PRs and posts structured comments.

## Features
- **CLI tool** — `python3 claude-review/pr-review.py --pr <URL>`
- **Zero dependencies** — Uses Python stdlib only (urllib)
- **Structured output** — Summary, Risks, Suggestions, Confidence Score
- **GitHub Action** — Optional auto-review on every PR
- **Tested outputs** — Included sample reviews of PR #5 and PR #1

## Sample Output

### PR #5 (n8n weekly workflow)

## Summary
Adds a complete n8n weekly dev summary workflow...

### Confidence Score
**Medium** — Well-structured workflow but lacks error handling and verification screenshot

### PR #1 (CHANGELOG skill)

## Summary
Adds a comprehensive CHANGELOG generator as a bash script...

### Confidence Score
**High** — Clean implementation with good formatting

/opire claim #4