### PR TITLE
feat: generate-changelog with Added/Fixed/Changed/Removed (closes #1)

### DIFF
--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -1,0 +1,119 @@
+# Git Changelog Generator 📝
+
+Generate structured `CHANGELOG.md` files from Git conventional commits, auto-categorized into **Added / Fixed / Changed / Removed**.
+
+## Features
+
+- **Conventional Commits** — Parses `feat:`, `fix:`, `docs:`, etc.
+- **4 categories** — Added, Fixed, Changed, Removed
+- **Dual implementation** — Bash script (lightweight) + Python script (full-featured)
+- **Flexible ranges** — Full history, between tags, or unreleased only
+- **Zero dependencies** — Only requires `git`
+
+## Setup (3 steps)
+
+```bash
+# 1. Copy the script to your project
+cp generate-changelog.sh your-project/scripts/
+
+# 2. Make it executable
+chmod +x your-project/scripts/generate-changelog.sh
+
+# 3. Run it
+cd your-project && ./scripts/generate-changelog.sh
+```
+
+Or use the Python version:
+
+```bash
+cp generate-changelog.py your-project/scripts/
+python3 your-project/scripts/generate-changelog.py
+```
+
+## Usage
+
+### Bash
+
+```bash
+# Full changelog
+./generate-changelog.sh
+
+# Since a specific tag
+./generate-changelog.sh --since v1.0.0
+
+# Unreleased changes only
+./generate-changelog.sh --unreleased
+
+# Write to file
+./generate-changelog.sh -o CHANGELOG.md
+```
+
+### Python
+
+```bash
+python3 generate-changelog.py
+python3 generate-changelog.py --since v1.0.0
+python3 generate-changelog.py --unreleased
+python3 generate-changelog.py -o CHANGELOG.md
+```
+
+## Category Mapping
+
+Conventional commit types are mapped to changelog categories:
+
+| Commit Type | Category |
+|-------------|----------|
+| `feat` | **Added** |
+| `fix` | **Fixed** |
+| `remove` | **Removed** |
+| `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert` | **Changed** |
+| (non-conventional) | **Changed** |
+
+## Example Output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] - 2026-05-01
+
+### Added
+
+- **auth:** add OAuth2 support (`d4e5f6a`)
+- **dashboard:** add real-time charts (`b7c8d9e`)
+
+### Fixed
+
+- **db:** fix connection pool leak (`f0a1b2c`)
+
+### Changed
+
+- upgrade dependencies (`a1b2c3d`)
+```
+
+## Commit Message Format
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[optional scope]: <description>
+```
+
+Examples:
+```
+feat(auth): add OAuth2 support
+fix(db): fix connection pool leak
+docs: update README
+remove: drop deprecated API endpoint
+```
+
+## Requirements
+
+- **Bash version:** 3.2+ (compatible with macOS default bash)
+- **Python version:** Python 3.9+
+- **Git:** Any modern version
+
+## License
+
+MIT

--- a/changelog-generator/generate-changelog.py
+++ b/changelog-generator/generate-changelog.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+generate-changelog.py — Generate CHANGELOG.md from Git History
+
+Parses conventional commits and generates a structured changelog
+categorized into: Added / Fixed / Changed / Removed
+
+Usage:
+  python3 generate-changelog.py                    # Full changelog
+  python3 generate-changelog.py --since v1.0.0     # From tag to HEAD
+  python3 generate-changelog.py --unreleased       # Since last tag
+  python3 generate-changelog.py -o CHANGELOG.md    # Write to file
+
+Requires: git, Python 3.9+
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from typing import Optional
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+
+COMMIT_PATTERN = re.compile(
+    r"^(?P<type>[a-zA-Z]+)"
+    r"(?:\((?P<scope>[^)]+)\))?"
+    r"(?P<breaking>!)?"
+    r":\s*(?P<description>.+)$"
+)
+
+# ─── Git Helpers ──────────────────────────────────────────────────────────────
+
+def run_git(args: list[str]) -> str:
+    """Run a git command and return stdout."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 128:
+            print("Error: Not a git repository", file=sys.stderr)
+            sys.exit(1)
+        return ""
+    except FileNotFoundError:
+        print("Error: git not found", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_latest_tag() -> Optional[str]:
+    """Get the most recent tag."""
+    try:
+        return run_git(["describe", "--tags", "--abbrev=0"])
+    except Exception:
+        return None
+
+
+def get_commits(ref_range: Optional[str] = None) -> list[dict]:
+    """Get commits with hash and subject."""
+    fmt = "%H|%s"
+    if ref_range:
+        log = run_git(["log", ref_range, f"--pretty=format:{fmt}", "--no-merges"])
+    else:
+        log = run_git(["log", f"--pretty=format:{fmt}", "--no-merges"])
+
+    if not log:
+        return []
+
+    commits = []
+    for line in log.split("\n"):
+        if not line.strip():
+            continue
+        parts = line.split("|", 1)
+        if len(parts) >= 2:
+            commits.append({"hash": parts[0], "subject": parts[1]})
+    return commits
+
+
+# ─── Commit Parsing ───────────────────────────────────────────────────────────
+
+def classify_commit_type(commit_type: str) -> str:
+    """Map conventional commit type to changelog category."""
+    mapping = {
+        "feat": "Added",
+        "fix": "Fixed",
+        "remove": "Removed",
+    }
+    return mapping.get(commit_type.lower(), "Changed")
+
+
+def parse_commit(subject: str) -> Optional[dict]:
+    """Parse a conventional commit message."""
+    match = COMMIT_PATTERN.match(subject)
+    if not match:
+        return None
+    return {
+        "type": match.group("type").lower(),
+        "scope": match.group("scope") or "",
+        "description": match.group("description"),
+    }
+
+
+def format_entry(scope: str, description: str, commit_hash: str) -> str:
+    """Format a changelog entry."""
+    short_hash = commit_hash[:7]
+    if scope:
+        return f"- **{scope}:** {description} (`{short_hash}`)"
+    return f"- {description} (`{short_hash}`)"
+
+
+# ─── Changelog Generation ─────────────────────────────────────────────────────
+
+def generate_changelog(commits: list[dict]) -> str:
+    """Generate the changelog content."""
+    sections: dict[str, list[str]] = defaultdict(list)
+    other_entries: list[str] = []
+
+    for commit in commits:
+        subject = commit["subject"]
+
+        if subject.startswith("Merge "):
+            continue
+
+        parsed = parse_commit(subject)
+        if not parsed:
+            other_entries.append(format_entry("", subject, commit["hash"]))
+            continue
+
+        category = classify_commit_type(parsed["type"])
+        entry = format_entry(parsed["scope"], parsed["description"], commit["hash"])
+        sections[category].append(entry)
+
+    # Build output
+    lines: list[str] = []
+    lines.append("# Changelog")
+    lines.append("")
+    lines.append("All notable changes to this project will be documented in this file.")
+    lines.append("")
+
+    from datetime import datetime
+    date = datetime.now().strftime("%Y-%m-%d")
+    lines.append(f"## [Unreleased] - {date}")
+    lines.append("")
+
+    for category in ["Added", "Fixed", "Changed", "Removed"]:
+        if sections.get(category):
+            lines.append(f"### {category}")
+            lines.append("")
+            lines.extend(sections[category])
+            lines.append("")
+
+    if other_entries:
+        lines.append("### Changed")
+        lines.append("")
+        lines.extend(other_entries)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate CHANGELOG.md from git conventional commits."
+    )
+    parser.add_argument("range", nargs="?", help="Git range (e.g., v1.0.0..v2.0.0)")
+    parser.add_argument("--since", help="Generate from this tag to HEAD")
+    parser.add_argument("--unreleased", action="store_true", help="Only since last tag")
+    parser.add_argument("--output", "-o", help="Output file (default: stdout)")
+
+    args = parser.parse_args()
+
+    ref_range = args.range
+    if args.since:
+        ref_range = f"{args.since}..HEAD"
+    elif args.unreleased:
+        latest = get_latest_tag()
+        if latest:
+            ref_range = f"{latest}..HEAD"
+
+    commits = get_commits(ref_range)
+    if not commits:
+        print("No commits found in range.", file=sys.stderr)
+        sys.exit(0)
+
+    changelog = generate_changelog(commits)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(changelog + "\n")
+        print(f"✅ Changelog written to {args.output}", file=sys.stderr)
+    else:
+        print(changelog)
+
+
+if __name__ == "__main__":
+    main()

--- a/changelog-generator/generate-changelog.sh
+++ b/changelog-generator/generate-changelog.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# generate-changelog.sh — Generate CHANGELOG.md from Git History
+#
+# Parses conventional commits and generates a structured changelog
+# categorized into: Added / Fixed / Changed / Removed
+#
+# Usage:
+#   ./generate-changelog.sh                    # Full changelog
+#   ./generate-changelog.sh --since v1.0.0     # From tag to HEAD
+#   ./generate-changelog.sh --unreleased       # Since last tag only
+#   ./generate-changelog.sh -o CHANGELOG.md    # Write to file
+#
+# Requires: git (Bash 3.2+)
+#
+set -euo pipefail
+
+# ─── Argument Parsing ─────────────────────────────────────────────────────────
+
+RANGE=""
+OUTPUT_FILE=""
+UNRELEASED_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output|-o)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        --since)
+            RANGE="$2..HEAD"
+            shift 2
+            ;;
+        --unreleased)
+            UNRELEASED_ONLY=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS] [RANGE]"
+            echo ""
+            echo "Generate CHANGELOG.md from git conventional commits."
+            echo ""
+            echo "Options:"
+            echo "  --output, -o FILE   Write output to FILE instead of stdout"
+            echo "  --since TAG         Generate from TAG to HEAD"
+            echo "  --unreleased        Only include commits since last tag"
+            echo "  --help, -h          Show this help"
+            echo ""
+            echo "Categories: Added, Fixed, Changed, Removed"
+            exit 0
+            ;;
+        *)
+            RANGE="$1"
+            shift
+            ;;
+    esac
+done
+
+# ─── Helper Functions ─────────────────────────────────────────────────────────
+
+check_git() {
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        echo "Error: Not a git repository" >&2
+        exit 1
+    fi
+}
+
+get_latest_tag() {
+    git describe --tags --abbrev=0 2>/dev/null || echo ""
+}
+
+# Map conventional commit type to changelog category
+classify_commit() {
+    local type="$1"
+    case "$type" in
+        feat)     echo "Added" ;;
+        fix)      echo "Fixed" ;;
+        remove)   echo "Removed" ;;
+        *)        echo "Changed" ;;
+    esac
+}
+
+# Parse conventional commit subject
+# Sets: PARSE_TYPE, PARSE_SCOPE, PARSE_DESC
+parse_subject() {
+    local subject="$1"
+    PARSE_TYPE=""
+    PARSE_SCOPE=""
+    PARSE_DESC="$subject"
+
+    # Try to match type(scope): description or type!: description
+    local remaining="$subject"
+
+    # Extract type (word before first : or ()
+    local type_part="${remaining%%:*}"
+    # Remove everything after ( if present
+    PARSE_TYPE="${type_part%%(*}"
+    # Remove trailing ! if present
+    PARSE_TYPE="${PARSE_TYPE%%!}"
+
+    # Extract scope if present
+    if [[ "$remaining" == *"("*")"* ]]; then
+        PARSE_SCOPE="${remaining#*(}"
+        PARSE_SCOPE="${PARSE_SCOPE%%)*}"
+    fi
+
+    # Extract description (after ": ")
+    if [[ "$remaining" == *": "* ]]; then
+        PARSE_DESC="${remaining#*: }"
+    fi
+}
+
+# ─── Main Logic ───────────────────────────────────────────────────────────────
+
+check_git
+
+# Determine range
+if [[ -z "$RANGE" && "$UNRELEASED_ONLY" == true ]]; then
+    LATEST_TAG=$(get_latest_tag)
+    if [[ -n "$LATEST_TAG" ]]; then
+        RANGE="${LATEST_TAG}..HEAD"
+    fi
+fi
+
+# Get commits
+if [[ -n "$RANGE" ]]; then
+    GIT_LOG=$(git log "$RANGE" --pretty=format:"%H|%s" --no-merges 2>/dev/null || true)
+else
+    GIT_LOG=$(git log --pretty=format:"%H|%s" --no-merges 2>/dev/null || true)
+fi
+
+if [[ -z "$GIT_LOG" ]]; then
+    echo "No commits found." >&2
+    exit 0
+fi
+
+# Collect entries by category (using temp files for Bash 3 compatibility)
+ADDED_FILE=$(mktemp)
+FIXED_FILE=$(mktemp)
+CHANGED_FILE=$(mktemp)
+REMOVED_FILE=$(mktemp)
+trap "rm -f $ADDED_FILE $FIXED_FILE $CHANGED_FILE $REMOVED_FILE" EXIT
+
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    HASH=$(echo "$line" | cut -d'|' -f1)
+    SUBJECT=$(echo "$line" | cut -d'|' -f2-)
+    SHORT="${HASH:0:7}"
+
+    # Skip merge commits
+    case "$SUBJECT" in
+        "Merge "*) continue ;;
+    esac
+
+    # Parse conventional commit
+    parse_subject "$SUBJECT"
+    TYPE="$PARSE_TYPE"
+    SCOPE="$PARSE_SCOPE"
+    DESC="$PARSE_DESC"
+
+    # Format entry
+    if [[ -n "$SCOPE" ]]; then
+        ENTRY="- **${SCOPE}:** ${DESC} (\`${SHORT}\`)"
+    else
+        ENTRY="- ${DESC} (\`${SHORT}\`)"
+    fi
+
+    # Classify and write to appropriate file
+    TYPE_LOWER=$(echo "$TYPE" | tr '[:upper:]' '[:lower:]')
+    CATEGORY=$(classify_commit "$TYPE_LOWER")
+
+    case "$CATEGORY" in
+        Added)   echo "$ENTRY" >> "$ADDED_FILE" ;;
+        Fixed)   echo "$ENTRY" >> "$FIXED_FILE" ;;
+        Removed) echo "$ENTRY" >> "$REMOVED_FILE" ;;
+        Changed) echo "$ENTRY" >> "$CHANGED_FILE" ;;
+    esac
+
+done <<< "$GIT_LOG"
+
+# ─── Generate Output ──────────────────────────────────────────────────────────
+
+DATE=$(date +%Y-%m-%d)
+OUTPUT=""
+
+OUTPUT+="# Changelog"$'\n'
+OUTPUT+=""$'\n'
+OUTPUT+="All notable changes to this project will be documented in this file."$'\n'
+OUTPUT+=""$'\n'
+OUTPUT+="## [Unreleased] - ${DATE}"$'\n'
+OUTPUT+=""$'\n'
+
+# Add each category that has entries
+for PAIR in "Added:${ADDED_FILE}" "Fixed:${FIXED_FILE}" "Changed:${CHANGED_FILE}" "Removed:${REMOVED_FILE}"; do
+    CATEGORY="${PAIR%%:*}"
+    FILE="${PAIR#*:}"
+    if [[ -s "$FILE" ]]; then
+        OUTPUT+="### ${CATEGORY}"$'\n'
+        OUTPUT+=""$'\n'
+        while IFS= read -r entry; do
+            OUTPUT+="${entry}"$'\n'
+        done < "$FILE"
+        OUTPUT+=""$'\n'
+    fi
+done
+
+# Historical releases from tags (if not unreleased-only)
+if [[ "$UNRELEASED_ONLY" != true ]]; then
+    PREV_TAG=""
+    while IFS= read -r TAG; do
+        [[ -z "$TAG" ]] && continue
+        TAG_DATE=$(git log -1 --format="%ai" "$TAG" 2>/dev/null | cut -d' ' -f1)
+        OUTPUT+="## [${TAG}] - ${TAG_DATE}"$'\n'
+        OUTPUT+=""$'\n'
+        if [[ -n "$PREV_TAG" ]]; then
+            OUTPUT+="See [git log](compare/${PREV_TAG}...${TAG}) for changes."$'\n'
+        else
+            OUTPUT+="See [git log](compare/${TAG}...HEAD) for changes."$'\n'
+        fi
+        OUTPUT+=""$'\n'
+        PREV_TAG="$TAG"
+    done <<< "$(git tag --sort=-v:refname 2>/dev/null || true)"
+fi
+
+# Output
+if [[ -n "$OUTPUT_FILE" ]]; then
+    echo "$OUTPUT" > "$OUTPUT_FILE"
+    echo "✅ Changelog written to ${OUTPUT_FILE}" >&2
+else
+    echo "$OUTPUT"
+fi


### PR DESCRIPTION
## Summary

Generate structured `CHANGELOG.md` from Git conventional commits, auto-categorized into **Added / Fixed / Changed / Removed**.

### Features

- **Dual implementation** — Bash script (3.2+ compatible) + Python script (3.9+)
- **4 categories** — Added, Fixed, Changed, Removed
- **Conventional Commits** — Parses `feat:`, `fix:`, `docs:`, etc.
- **Flexible ranges** — Full history, `--since TAG`, `--unreleased`
- **Zero dependencies** — Only requires `git`

### Category Mapping

| Commit Type | Category |
|-------------|----------|
| `feat` | Added |
| `fix` | Fixed |
| `remove` | Removed |
| Everything else | Changed |

### Sample Output (tested on real repo)

```markdown
# Changelog

All notable changes to this project will be documented in this file.

## [Unreleased] - 2026-05-01

### Added

- initial README with bounty board (`1aeae2a`)

### Changed

- Initial commit (`a80a580`)
```

### Setup (3 steps)

```bash
cp generate-changelog.sh your-project/scripts/
chmod +x your-project/scripts/generate-changelog.sh
./your-project/scripts/generate-changelog.sh -o CHANGELOG.md
```

### Acceptance Criteria

- [x] Works via `bash generate-changelog.sh`
- [x] Fetches commits since last git tag (`--unreleased` flag)
- [x] Auto-categorizes into: Added / Fixed / Changed / Removed
- [x] Outputs a properly formatted CHANGELOG.md
- [x] Tested on a real GitHub repo (sample output above)
- [x] README with setup instructions in 3 steps

Closes #1

---

*Wallet: 0xB7729D3927d507E4f1687B6f462F1eA3c654C8Fe*
