### PR TITLE
feat: add changelog generator skill

### DIFF
--- a/CHANGELOG_GENERATOR_README.md
+++ b/CHANGELOG_GENERATOR_README.md
@@ -1,0 +1,11 @@
+# Generate Changelog Bounty
+
+Generate a structured `CHANGELOG.md` from git history in 3 steps:
+
+1. Copy `changelog.sh` into a git repository.
+2. Run `bash changelog.sh` from the repository root.
+3. Commit the generated `CHANGELOG.md`.
+
+The script automatically detects the latest git tag, reads commits since that tag, categorizes them into `Added`, `Fixed`, `Changed`, and `Removed`, then writes a formatted changelog.
+
+See `SAMPLE_OUTPUT.md` for an example generated from a real GitHub repository.

--- a/SAMPLE_OUTPUT.md
+++ b/SAMPLE_OUTPUT.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes are generated from git history.
+
+## [Unreleased] - 2026-05-02
+
+_Commits for all commits (no tags found)._
+
+### Added
+
+- initial README with bounty board (1aeae2a)
+
+### Fixed
+
+- None
+
+### Changed
+
+- Initial commit (a80a580)
+
+### Removed
+
+- None
+

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commits since the last tag.
+---
+
+# Generate Changelog
+
+Use this skill when a user asks to generate or refresh a `CHANGELOG.md` from a repository's git history.
+
+## Command
+
+Run this from the target repository root:
+
+```bash
+bash changelog.sh
+```
+
+Optional flags:
+
+```bash
+bash changelog.sh --repo /path/to/repo --output CHANGELOG.md
+```
+
+## Behavior
+
+The script:
+
+1. Detects the latest git tag with `git describe --tags --abbrev=0`.
+2. Fetches non-merge commits from `LAST_TAG..HEAD`.
+3. Categorizes commits into:
+   - `Added`
+   - `Fixed`
+   - `Changed`
+   - `Removed`
+4. Writes a formatted `CHANGELOG.md`.
+
+## Categorization rules
+
+- `feat:` / `feature:` / add/create/implement/support → `Added`
+- `fix:` / bug/patch/resolve/correct → `Fixed`
+- remove/delete/drop/deprecate → `Removed`
+- docs/chore/refactor/ci/build/test/perf/style/update/improve → `Changed`
+
+If no tag exists, the script uses all commits in the repository.

--- a/TAGGED_TEST_OUTPUT.md
+++ b/TAGGED_TEST_OUTPUT.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes are generated from git history.
+
+## [Unreleased] - 2026-05-02
+
+_Commits since v0.1.0._
+
+### Added
+
+- add export command (f5c0fac)
+
+### Fixed
+
+- correct sorting bug (5b2a198)
+
+### Changed
+
+- update setup instructions (7963d94)
+
+### Removed
+
+- remove legacy flag (6809d94)

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate a structured CHANGELOG.md from git commits since the last tag.
+# Usage: bash changelog.sh [--output CHANGELOG.md] [--repo .]
+
+OUTPUT="CHANGELOG.md"
+REPO="."
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output|-o)
+      OUTPUT="${2:?missing output path}"
+      shift 2
+      ;;
+    --repo|-r)
+      REPO="${2:?missing repo path}"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: bash changelog.sh [--output CHANGELOG.md] [--repo .]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "$REPO"
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "Error: not inside a git repository" >&2
+  exit 1
+}
+
+LAST_TAG=""
+if LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+  RANGE="${LAST_TAG}..HEAD"
+  SINCE="since ${LAST_TAG}"
+else
+  RANGE="HEAD"
+  SINCE="for all commits (no tags found)"
+fi
+
+VERSION="Unreleased"
+TODAY=$(date +%Y-%m-%d)
+
+COMMITS=$(git log "$RANGE" --no-merges --pretty=format:'%h%x09%s' 2>/dev/null || true)
+
+categorize() {
+  local subject="$1"
+  local lower
+  lower=$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')
+
+  if [[ "$lower" =~ ^(feat|feature)(\(.+\))?!?: ]] || [[ "$lower" =~ add|create|implement|introduce|support ]]; then
+    echo "Added"
+  elif [[ "$lower" =~ ^(fix|bugfix|hotfix)(\(.+\))?!?: ]] || [[ "$lower" =~ fix|bug|patch|resolve|correct ]]; then
+    echo "Fixed"
+  elif [[ "$lower" =~ ^(remove|removed|delete|deleted)(\(.+\))?!?: ]] || [[ "$lower" =~ remove|delete|drop|deprecate ]]; then
+    echo "Removed"
+  elif [[ "$lower" =~ ^(change|changed|refactor|perf|style|docs|test|ci|build|chore)(\(.+\))?!?: ]] || [[ "$lower" =~ update|change|refactor|improve|rename|bump ]]; then
+    echo "Changed"
+  else
+    echo "Changed"
+  fi
+}
+
+sanitize_subject() {
+  local subject="$1"
+  # Strip common Conventional Commit prefixes while keeping the human-readable title.
+  printf '%s' "$subject" | sed -E 's/^[a-zA-Z]+(\([^)]*\))?!?:[[:space:]]*//'
+}
+
+declare -a ADDED=() FIXED=() CHANGED=() REMOVED=()
+
+if [[ -n "${COMMITS}" ]]; then
+  while IFS=$'\t' read -r hash subject; do
+    [[ -z "${hash:-}" || -z "${subject:-}" ]] && continue
+    clean=$(sanitize_subject "$subject")
+    entry="- ${clean} (${hash})"
+    case "$(categorize "$subject")" in
+      Added) ADDED+=("$entry") ;;
+      Fixed) FIXED+=("$entry") ;;
+      Removed) REMOVED+=("$entry") ;;
+      *) CHANGED+=("$entry") ;;
+    esac
+  done <<< "$COMMITS"
+fi
+
+write_section() {
+  local title="$1"
+  shift
+  local -a items=("$@")
+  printf '### %s\n\n' "$title"
+  if [[ ${#items[@]} -eq 0 ]]; then
+    printf -- '- None\n\n'
+  else
+    printf '%s\n' "${items[@]}"
+    printf '\n'
+  fi
+}
+
+{
+  printf '# Changelog\n\n'
+  printf 'All notable changes are generated from git history.\n\n'
+  printf '## [%s] - %s\n\n' "$VERSION" "$TODAY"
+  printf '_Commits %s._\n\n' "$SINCE"
+  write_section "Added" "${ADDED[@]}"
+  write_section "Fixed" "${FIXED[@]}"
+  write_section "Changed" "${CHANGED[@]}"
+  write_section "Removed" "${REMOVED[@]}"
+} > "$OUTPUT"
+
+printf 'Generated %s from commits %s\n' "$OUTPUT" "$SINCE"


### PR DESCRIPTION
## Summary
- Adds `changelog.sh`, a reusable changelog generator that groups commits since the latest tag into Added/Fixed/Changed/Removed sections.
- Adds a `generate-changelog` skill descriptor and usage README.
- Includes sample output files for validation and review.

## Validation
- Ran `bash -n changelog.sh`.
- Generated sample output from the repository history.
- Validated behavior in a temporary git repository with tagged commits.

Closes #1