### PR TITLE
feat: add destructive command guard hook

### DIFF
--- a/DESTRUCTIVE_COMMAND_HOOK_README.md
+++ b/DESTRUCTIVE_COMMAND_HOOK_README.md
@@ -1,0 +1,40 @@
+# Claude Code destructive command guard
+
+A `pre-tool-use` hook for Claude Code that blocks risky Bash commands before they run.
+
+## What it blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force` / `git push -f`
+- `TRUNCATE`
+- `DELETE FROM ...` statements that do not include a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` with timestamp, attempted command, and project path.
+
+## Install in 2 commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block_destructive_bash.py ~/.claude/hooks/block_destructive_bash.py
+python3 -c "import json,pathlib; p=pathlib.Path.home()/'.claude/settings.json'; p.parent.mkdir(parents=True,exist_ok=True); data=json.loads(p.read_text()) if p.exists() else {}; data.setdefault('hooks',{}).setdefault('PreToolUse',[]).append({'matcher':'Bash','hooks':[{'type':'command','command':str(pathlib.Path.home()/'.claude/hooks/block_destructive_bash.py')}]}); p.write_text(json.dumps(data,indent=2)+'\n')"
+```
+
+## Local test
+
+Blocked command:
+
+```bash
+printf '%s
+' '{"tool_name":"Bash","tool_input":{"command":"rm -rf build","cwd":"/tmp/project"}}' | hooks/block_destructive_bash.py
+```
+
+Allowed command:
+
+```bash
+printf '%s
+' '{"tool_name":"Bash","tool_input":{"command":"python3 -m pytest","cwd":"/tmp/project"}}' | hooks/block_destructive_bash.py
+```
+
+## Notes
+
+The hook is intentionally conservative: it only exits non-zero for configured destructive patterns and returns success for normal Bash commands, non-Bash tools, or malformed/empty input. SQL matching is case-insensitive and treats `DELETE FROM users;` as destructive unless a `WHERE` clause appears before the statement terminator.

--- a/HOOK_TEST_OUTPUT.md
+++ b/HOOK_TEST_OUTPUT.md
@@ -1,0 +1,18 @@
+# Destructive command hook test output
+
+The hook was tested locally with Claude Code-style JSON payloads.
+
+## Blocked examples
+
+- `rm -rf build` exits `2`, prints a clear block message, and writes `rm -rf` to `~/.claude/hooks/blocked.log`.
+- `DROP TABLE users;` exits `2` and logs `DROP TABLE`.
+- `git push --force origin main` exits `2` and logs `git push --force`.
+- `TRUNCATE audit_log;` exits `2` and logs `TRUNCATE`.
+- `DELETE FROM users;` exits `2` and logs `DELETE FROM without WHERE`.
+
+## Allowed examples
+
+- `python3 -m pytest` exits `0`.
+- `git status --short` exits `0`.
+- `DELETE FROM users WHERE id = 1;` exits `0`.
+- Non-Bash tool payloads exit `0`.

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Claude Code pre-tool-use hook that blocks destructive bash commands."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+BLOCK_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    ("rm -rf", re.compile(r"(^|[;&|`$()\s])rm\s+(?:-[A-Za-z]*r[A-Za-z]*f|-\w*f\w*r)\b", re.IGNORECASE), "Recursive forced deletion can remove large parts of the filesystem."),
+    ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE), "Dropping database tables is destructive and must be reviewed manually."),
+    ("git push --force", re.compile(r"\bgit\s+push\b[^\n;|&]*\s--force(?:\s|=|$)|\bgit\s+push\b[^\n;|&]*\s-f(?:\s|$)", re.IGNORECASE), "Force-pushing can rewrite shared Git history."),
+    ("TRUNCATE", re.compile(r"\bTRUNCATE\b", re.IGNORECASE), "TRUNCATE removes table data without per-row safeguards."),
+    ("DELETE FROM without WHERE", re.compile(r"\bDELETE\s+FROM\s+[\w.\"`]+(?:(?!\bWHERE\b)[^;])*($|;)", re.IGNORECASE | re.DOTALL), "DELETE FROM without a WHERE clause can delete every row."),
+]
+
+def _load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {"tool_name": "Bash", "tool_input": {"command": raw}}
+
+def _extract_command(payload: dict[str, Any]) -> str:
+    tool_name = str(payload.get("tool_name") or payload.get("tool") or "")
+    tool_input = payload.get("tool_input") or payload.get("input") or {}
+    if not isinstance(tool_input, dict):
+        return ""
+    command = tool_input.get("command") or tool_input.get("cmd") or ""
+    if tool_name and tool_name.lower() not in {"bash", "shell"}:
+        return ""
+    return command if isinstance(command, str) else ""
+
+def _project_path(payload: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "workspace", "root"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    tool_input = payload.get("tool_input") or {}
+    if isinstance(tool_input, dict):
+        value = tool_input.get("cwd") or tool_input.get("workdir")
+        if isinstance(value, str) and value:
+            return value
+    return os.getcwd()
+
+def _log_block(command: str, project_path: str, matches: list[tuple[str, str]]) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    ts = _dt.datetime.now(_dt.timezone.utc).astimezone().isoformat(timespec="seconds")
+    reasons = ", ".join(name for name, _ in matches)
+    safe_command = command.replace("\n", "\\n")
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{ts}\tproject={project_path}\treasons={reasons}\tcommand={safe_command}\n")
+
+def main() -> int:
+    payload = _load_payload()
+    command = _extract_command(payload)
+    if not command:
+        return 0
+    matches = [(name, message) for name, pattern, message in BLOCK_PATTERNS if pattern.search(command)]
+    if not matches:
+        return 0
+    project_path = _project_path(payload)
+    _log_block(command, project_path, matches)
+    print("Claude Code pre-tool-use hook blocked a destructive Bash command.", file=sys.stderr)
+    for name, message in matches:
+        print(f"- {name}: {message}", file=sys.stderr)
+    print("Review the command manually before running it outside Claude Code.", file=sys.stderr)
+    return 2
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the #3 Claude Code pre-tool-use hook bounty.

Includes:
- Python hook at `hooks/block_destructive_bash.py`
- Blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without `WHERE`
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
- Two-command install README and local test output

Validation run locally: `python3 -m py_compile`, blocked-pattern examples exit 2, normal Bash/DELETE with WHERE examples exit 0.