### PR TITLE
feat: add PR review CLI agent

### DIFF
--- a/PR_REVIEW_CLI_README.md
+++ b/PR_REVIEW_CLI_README.md
@@ -1,0 +1,21 @@
+# claude-review PR review CLI
+
+`claude-review` is a Claude Code-friendly CLI/agent that fetches a public GitHub PR diff and returns a structured Markdown review comment.
+
+## Setup
+
+```bash
+chmod +x bin/claude-review
+```
+
+## Usage
+
+```bash
+bin/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Output includes a summary, identified risks, improvement suggestions, and a Low/Medium/High confidence score.
+
+## Tested PRs
+
+Sample outputs are included in `examples/review-pr-731.md` and `examples/review-pr-734.md`.

--- a/bin/claude-review
+++ b/bin/claude-review
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, sys, urllib.request, urllib.parse
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable
+
+@dataclass
+class DiffStats:
+    files: list[str]; additions: int; deletions: int; hunks: int; added_lines: list[str]
+
+def parse_pr_url(url: str) -> tuple[str, str, str]:
+    u = urllib.parse.urlparse(url.strip().rstrip('/'))
+    parts = [p for p in u.path.split('/') if p]
+    if u.scheme != 'https' or u.netloc != 'github.com' or len(parts) != 4 or parts[2] != 'pull':
+        raise SystemExit('Expected PR URL like https://github.com/owner/repo/pull/123')
+    return parts[0], parts[1], parts[3]
+
+def fetch(url: str, accept: str) -> str:
+    req = urllib.request.Request(url, headers={'Accept': accept, 'User-Agent': 'claude-review-cli'})
+    with urllib.request.urlopen(req, timeout=30) as res:
+        return res.read().decode('utf-8', errors='replace')
+
+def parse_diff(diff: str) -> DiffStats:
+    files, added = [], []
+    deletions = hunks = 0
+    for line in diff.splitlines():
+        if line.startswith('diff --git '):
+            parts = line.split(); files.append(parts[-1][2:] if len(parts) >= 4 and parts[-1].startswith('b/') else line)
+        elif line.startswith('@@'): hunks += 1
+        elif line.startswith('+') and not line.startswith('+++'): added.append(line[1:])
+        elif line.startswith('-') and not line.startswith('---'): deletions += 1
+    return DiffStats(files, len(added), deletions, hunks, added)
+
+def classify(files: Iterable[str]) -> Counter[str]:
+    out = Counter()
+    for f in files:
+        suffix = f.rsplit('.', 1)[-1].lower() if '.' in f else ''
+        if suffix in {'md','rst','txt'}: out['docs'] += 1
+        elif suffix in {'py','js','ts','tsx','sh','go','rs'}: out['code'] += 1
+        elif suffix in {'yml','yaml','json','toml'}: out['config'] += 1
+        else: out['other'] += 1
+    return out
+
+def review(pr_url: str) -> str:
+    owner, repo, number = parse_pr_url(pr_url)
+    api = f'https://api.github.com/repos/{owner}/{repo}/pulls/{number}'
+    pr = json.loads(fetch(api, 'application/vnd.github+json'))
+    stats = parse_diff(fetch(api, 'application/vnd.github.v3.diff'))
+    kinds = classify(stats.files); changed = ', '.join(f'{v} {k}' for k, v in kinds.items()) or 'no files'
+    added = '\n'.join(stats.added_lines).lower()
+    risks = []
+    if stats.additions + stats.deletions > 400: risks.append('Large diff size may hide subtle regressions; request focused reviewer attention.')
+    if any(w in added for w in ['password','secret','token','private key','auth','permission','chmod','eval','exec']): risks.append('Security-sensitive terms appear in added lines; verify secret handling and permissions.')
+    if any(w in added for w in ['rm -rf','delete from','drop table','truncate','force']): risks.append('Potentially destructive command or SQL pattern appears; confirm safeguards and rollback path.')
+    if kinds['code'] and not any('test' in f.lower() for f in stats.files): risks.append('Code changes do not include obvious test files; validate behavior manually or add tests.')
+    if not risks: risks.append('No major automated red flags found; still verify project-specific behavior before merge.')
+    suggestions = []
+    if kinds['code']: suggestions.append('Run the project test/lint commands and include the exact output in the PR.')
+    if kinds['docs']: suggestions.append('Check examples and setup commands by copying them into a clean shell/session.')
+    if stats.hunks > 8: suggestions.append('Consider splitting unrelated changes so each review topic stays small.')
+    suggestions.append('Confirm the implementation maps directly to the issue acceptance criteria.')
+    confidence = 'High' if stats.files and stats.additions + stats.deletions < 250 and len(risks) == 1 and risks[0].startswith('No major') else 'Medium'
+    if stats.additions + stats.deletions > 800: confidence = 'Low'
+    return '\n'.join([f"## PR Review — {pr.get('title') or 'PR #' + number}", '', '### Summary', f'This PR changes {len(stats.files)} file(s) with {stats.additions} additions and {stats.deletions} deletions across {stats.hunks} diff hunk(s). The touched areas are: {changed}.', 'The review below is generated from the public GitHub PR diff and is intended as a structured first pass for Claude Code or human reviewers.', '', '### Identified risks', *[f'- {r}' for r in risks], '', '### Improvement suggestions', *[f'- {s}' for s in suggestions], '', f'### Confidence score: {confidence}'])
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description='Generate a structured Markdown PR review comment.')
+    ap.add_argument('--pr', required=True)
+    print(review(ap.parse_args().pr)); return 0
+if __name__ == '__main__': raise SystemExit(main())

--- a/examples/review-pr-731.md
+++ b/examples/review-pr-731.md
@@ -1,0 +1,15 @@
+## PR Review — feat: add changelog generator skill
+
+### Summary
+This PR changes 5 file(s) with 218 additions and 0 deletions across 5 diff hunk(s). The touched areas are: 4 docs, 1 code.
+The review below is generated from the public GitHub PR diff and is intended as a structured first pass for Claude Code or human reviewers.
+
+### Identified risks
+- No major automated red flags found; still verify project-specific behavior before merge.
+
+### Improvement suggestions
+- Run the project test/lint commands and include the exact output in the PR.
+- Check examples and setup commands by copying them into a clean shell/session.
+- Confirm the implementation maps directly to the issue acceptance criteria.
+
+### Confidence score: High

--- a/examples/review-pr-734.md
+++ b/examples/review-pr-734.md
@@ -1,0 +1,15 @@
+## PR Review — feat: add destructive command guard hook
+
+### Summary
+This PR changes 3 file(s) with 137 additions and 0 deletions across 3 diff hunk(s). The touched areas are: 2 docs, 1 code.
+The review below is generated from the public GitHub PR diff and is intended as a structured first pass for Claude Code or human reviewers.
+
+### Identified risks
+- Potentially destructive command or SQL pattern appears; confirm safeguards and rollback path.
+
+### Improvement suggestions
+- Run the project test/lint commands and include the exact output in the PR.
+- Check examples and setup commands by copying them into a clean shell/session.
+- Confirm the implementation maps directly to the issue acceptance criteria.
+
+### Confidence score: Medium


### PR DESCRIPTION
Implements #4 with a zero-dependency `claude-review --pr <url>` CLI that fetches a GitHub PR diff and emits a structured Markdown review.

Includes summary, risks, suggestions, confidence score, README, and sample outputs generated from two real PRs (#731 and #734).

Validation: `python3 -m py_compile bin/claude-review`; ran the CLI successfully against both sample PR URLs.