### PR TITLE
Add git changelog generator skill

### DIFF
--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$script_dir/generate-changelog/changelog.sh" "$@"

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,32 @@
+# Git Changelog Generator
+
+Generate a structured `CHANGELOG.md` from commits since the latest git tag.
+
+## Setup
+
+1. Copy `changelog.sh` and `generate-changelog/` into any git repository.
+2. Run `bash changelog.sh`.
+3. Review and commit the generated `CHANGELOG.md`.
+
+## Categories
+
+The script maps commit subjects into:
+
+- `Added`: `feat:`, `feature:`, `add:`, `new:`
+- `Fixed`: `fix:`, `bug:`, `bugfix:`, `repair:`, `hotfix:`
+- `Changed`: `change:`, `refactor:`, `perf:`, `docs:`, `test:`, `build:`, `ci:`, `chore:`, and uncategorized commits
+- `Removed`: `remove:`, `delete:`, `drop:`
+
+## Output
+
+By default the command writes `CHANGELOG.md` in the repository root. Pass a file path to write somewhere else:
+
+```bash
+bash changelog.sh /tmp/CHANGELOG.md
+```
+
+## Test
+
+```bash
+bash generate-changelog/test.sh
+```

--- a/generate-changelog/SAMPLE_CHANGELOG.md
+++ b/generate-changelog/SAMPLE_CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Generated from git history for all history on 2026-05-08.
+
+### Added
+
+- initial README with bounty board ([1aeae2a](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/1aeae2adc82d33f971fd7731644348dcdd24b5a6))
+
+### Changed
+
+- Initial commit ([a80a580](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/a80a580e34190a6bb8649a1b75a9fec8312bea5c))

--- a/generate-changelog/SKILL.md
+++ b/generate-changelog/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from the current git repository history.
+---
+
+# Generate Changelog
+
+Use this skill when a project needs a quick `CHANGELOG.md` generated from git commits since the latest tag.
+
+## Command
+
+```bash
+bash changelog.sh
+```
+
+The script:
+
+- Detects the latest git tag with `git describe --tags --abbrev=0`.
+- Falls back to all repository history when no tag exists.
+- Categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a Markdown `CHANGELOG.md` at the repository root.
+
+## Notes
+
+- Conventional commits produce the cleanest categories.
+- Non-conventional commits are kept under `Changed` so no work is silently dropped.
+- GitHub commit links are included when `remote.origin.url` points to GitHub.

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  since_label="since ${latest_tag}"
+else
+  range=""
+  since_label="for all history"
+fi
+
+remote_url="$(git config --get remote.origin.url || true)"
+commit_base=""
+if [[ "$remote_url" =~ ^git@github.com:(.+)\.git$ ]]; then
+  commit_base="https://github.com/${BASH_REMATCH[1]}/commit"
+elif [[ "$remote_url" =~ ^https://github.com/(.+)\.git$ ]]; then
+  commit_base="https://github.com/${BASH_REMATCH[1]}/commit"
+elif [[ "$remote_url" =~ ^https://github.com/(.+)$ ]]; then
+  commit_base="https://github.com/${BASH_REMATCH[1]}/commit"
+fi
+
+declare -a added=()
+declare -a fixed=()
+declare -a changed=()
+declare -a removed=()
+
+format_entry() {
+  local hash="$1"
+  local subject="$2"
+  local short="${hash:0:7}"
+
+  subject="$(printf '%s' "$subject" | sed -E 's/^[a-zA-Z]+(\([^)]+\))?!?:[[:space:]]*//')"
+  subject="$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+
+  if [[ -n "$commit_base" ]]; then
+    printf -- "- %s ([%s](%s/%s))" "$subject" "$short" "$commit_base" "$hash"
+  else
+    printf -- "- %s (%s)" "$subject" "$short"
+  fi
+}
+
+categorize() {
+  local subject="$1"
+  local lower
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$lower" in
+    feat:*|feat\(*|feature:*|add:*|added:*|new:*) echo "added" ;;
+    fix:*|fix\(*|bug:*|bugfix:*|repair:*|hotfix:*) echo "fixed" ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*) echo "removed" ;;
+    change:*|changed:*|refactor:*|refactor\(*|perf:*|docs:*|doc:*|style:*|test:*|build:*|ci:*|chore:*) echo "changed" ;;
+    *) echo "changed" ;;
+  esac
+}
+
+while IFS=$'\x1f' read -r hash subject; do
+  [[ -z "${hash:-}" ]] && continue
+  entry="$(format_entry "$hash" "$subject")"
+  case "$(categorize "$subject")" in
+    added) added+=("$entry") ;;
+    fixed) fixed+=("$entry") ;;
+    removed) removed+=("$entry") ;;
+    changed) changed+=("$entry") ;;
+  esac
+done < <(git log --reverse --format=$'%H%x1f%s' ${range:+"$range"})
+
+write_section() {
+  local title="$1"
+  shift
+  local entries=("$@")
+
+  if [[ "${#entries[@]}" -eq 0 ]]; then
+    return
+  fi
+
+  {
+    printf '\n### %s\n\n' "$title"
+    printf '%s\n' "${entries[@]}"
+  } >> "$output_file"
+}
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated from git history %s on %s.\n' "$since_label" "$(date +%Y-%m-%d)"
+} > "$output_file"
+
+if [[ "${#added[@]}" -eq 0 && "${#fixed[@]}" -eq 0 && "${#changed[@]}" -eq 0 && "${#removed[@]}" -eq 0 ]]; then
+  printf '\nNo commits found for this range.\n' >> "$output_file"
+else
+  write_section "Added" "${added[@]}"
+  write_section "Fixed" "${fixed[@]}"
+  write_section "Changed" "${changed[@]}"
+  write_section "Removed" "${removed[@]}"
+fi
+
+echo "Wrote ${output_file}"

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -54,12 +54,13 @@ categorize() {
   local subject="$1"
   local lower
   lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  lower="$(printf '%s' "$lower" | sed -E 's/^([a-z]+)(\([^)]+\))?!:/\1:/')"
 
   case "$lower" in
-    feat:*|feat\(*|feature:*|add:*|added:*|new:*) echo "added" ;;
-    fix:*|fix\(*|bug:*|bugfix:*|repair:*|hotfix:*) echo "fixed" ;;
+    feat:*|feature:*|add:*|added:*|new:*) echo "added" ;;
+    fix:*|bug:*|bugfix:*|repair:*|hotfix:*) echo "fixed" ;;
     remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*) echo "removed" ;;
-    change:*|changed:*|refactor:*|refactor\(*|perf:*|docs:*|doc:*|style:*|test:*|build:*|ci:*|chore:*) echo "changed" ;;
+    change:*|changed:*|refactor:*|perf:*|docs:*|doc:*|style:*|test:*|build:*|ci:*|chore:*) echo "changed" ;;
     *) echo "changed" ;;
   esac
 }

--- a/generate-changelog/test.sh
+++ b/generate-changelog/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cp "$repo_root/changelog.sh" "$tmp/changelog.sh"
+mkdir -p "$tmp/generate-changelog"
+cp "$repo_root/generate-changelog/changelog.sh" "$tmp/generate-changelog/changelog.sh"
+
+(
+  cd "$tmp"
+  git init -q
+  git config user.name "Changelog Test"
+  git config user.email "changelog-test@example.com"
+
+  echo "one" > file.txt
+  git add file.txt
+  git commit -qm "feat: initial feature"
+  git tag v0.1.0
+
+  echo "two" >> file.txt
+  git add file.txt
+  git commit -qm "fix: repair output"
+
+  echo "three" >> file.txt
+  git add file.txt
+  git commit -qm "remove: old path"
+
+  bash ./changelog.sh OUT.md >/dev/null
+
+  grep -q "Generated from git history since v0.1.0" OUT.md
+  grep -q "### Fixed" OUT.md
+  grep -q "repair output" OUT.md
+  grep -q "### Removed" OUT.md
+  grep -q "old path" OUT.md
+  if grep -q "initial feature" OUT.md; then
+    echo "test failed: included commit before latest tag" >&2
+    exit 1
+  fi
+)
+
+echo "generate-changelog tests passed"

--- a/generate-changelog/test.sh
+++ b/generate-changelog/test.sh
@@ -28,11 +28,28 @@ cp "$repo_root/generate-changelog/changelog.sh" "$tmp/generate-changelog/changel
   git add file.txt
   git commit -qm "remove: old path"
 
+  echo "four" >> file.txt
+  git add file.txt
+  git commit -qm "feat(api)!: scoped breaking feature"
+
+  echo "five" >> file.txt
+  git add file.txt
+  git commit -qm "fix(core): scoped bug fix"
+
+  echo "six" >> file.txt
+  git add file.txt
+  git commit -qm "docs(readme): scoped docs update"
+
   bash ./changelog.sh OUT.md >/dev/null
 
   grep -q "Generated from git history since v0.1.0" OUT.md
+  grep -q "### Added" OUT.md
+  grep -q "scoped breaking feature" OUT.md
   grep -q "### Fixed" OUT.md
   grep -q "repair output" OUT.md
+  grep -q "scoped bug fix" OUT.md
+  grep -q "### Changed" OUT.md
+  grep -q "scoped docs update" OUT.md
   grep -q "### Removed" OUT.md
   grep -q "old path" OUT.md
   if grep -q "initial feature" OUT.md; then


### PR DESCRIPTION
## Summary

/opire claim #1

Adds a focused git changelog generator:

- `changelog.sh` works from the repository root as the exact accepted command: `bash changelog.sh`.
- `generate-changelog/changelog.sh` generates `CHANGELOG.md` from commits since the latest git tag, or all history if no tags exist.
- `generate-changelog/SKILL.md` documents the Claude Code `/generate-changelog` style workflow.
- `generate-changelog/README.md` gives setup in 3 steps.
- `generate-changelog/SAMPLE_CHANGELOG.md` is sample output from this repository's real git history.
- `generate-changelog/test.sh` smoke-tests the root command against a temporary tagged git repo.

## Reproduction / validation

Tested in this repository with:

```bash
chmod +x changelog.sh generate-changelog/changelog.sh generate-changelog/test.sh
bash changelog.sh generate-changelog/SAMPLE_CHANGELOG.md
bash generate-changelog/test.sh
```

Result: `generate-changelog/test.sh` created a temporary repo with tag `v0.1.0`, verified only post-tag commits were included, verified `fix:` went under `Fixed`, verified `remove:` went under `Removed`, and failed if a pre-tag commit appeared.

## Notes

The script keeps non-conventional commits under `Changed` instead of dropping them, and links commits when `remote.origin.url` points to GitHub.

Closes #1.