### PR TITLE
Add destructive Bash command pre-tool-use hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,31 @@
+# Destructive Command PreToolUse Hook
+
+This Claude Code `pre-tool-use` hook blocks Bash commands that can destroy files, database contents, or git history.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/pre-tool-use.py ~/.claude/hooks/pre-tool-use.py && chmod +x ~/.claude/hooks/pre-tool-use.py
+```
+
+```bash
+printf '%s\n' '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"~/.claude/hooks/pre-tool-use.py"}]}]}}' > ~/.claude/settings.json
+```
+
+## Blocked Commands
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON with a timestamp, attempted command, project path, and matched pattern.
+
+Normal Bash commands return a `PreToolUse` `permissionDecision` of `allow` and continue without log noise. Blocked commands return `permissionDecision: "deny"` with a clear reason.
+
+## Test
+
+```bash
+bash hooks/test-pre-tool-use.sh
+```

--- a/hooks/pre-tool-use.py
+++ b/hooks/pre-tool-use.py
@@ -17,7 +17,11 @@ LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
 BLOCKERS: list[tuple[str, re.Pattern[str], str]] = [
     (
         "rm -rf",
-        re.compile(r"(^|[;&|]\s*)rm\s+-[^\n;|&]*r[^\n;|&]*f\b"),
+        re.compile(
+            r"(^|[;&|]\s*)(?:sudo\s+)?rm\s+"
+            r"(?=[^\n;|&]*(?:-[^\n;|&]*r|--recursive\b))"
+            r"(?=[^\n;|&]*(?:-[^\n;|&]*f|--force\b))[^\n;|&]*"
+        ),
         "recursive force delete can remove large parts of the filesystem",
     ),
     (

--- a/hooks/pre-tool-use.py
+++ b/hooks/pre-tool-use.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+BLOCKERS: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "rm -rf",
+        re.compile(r"(^|[;&|]\s*)rm\s+-[^\n;|&]*r[^\n;|&]*f\b"),
+        "recursive force delete can remove large parts of the filesystem",
+    ),
+    (
+        "DROP TABLE",
+        re.compile(r"\bdrop\s+table\b", re.I),
+        "DROP TABLE destroys schema and data",
+    ),
+    (
+        "TRUNCATE",
+        re.compile(r"\btruncate\b", re.I),
+        "TRUNCATE deletes table data without row-level review",
+    ),
+    (
+        "git push --force",
+        re.compile(r"\bgit\s+push\b[^\n;|&]*(--force|-f\b|--force-with-lease)"),
+        "force-pushing can overwrite remote history",
+    ),
+    (
+        "DELETE FROM without WHERE",
+        re.compile(r"\bdelete\s+from\b(?:(?!\bwhere\b).)*($|;)", re.I | re.S),
+        "DELETE FROM without WHERE can wipe an entire table",
+    ),
+]
+
+
+def emit_decision(permission: str, reason: str | None = None) -> None:
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": permission,
+        }
+    }
+    if reason:
+        output["hookSpecificOutput"]["permissionDecisionReason"] = reason
+    print(json.dumps(output))
+
+
+def extract_command(payload: dict[str, object]) -> str:
+    tool_input = payload.get("tool_input") or payload.get("input") or payload.get("arguments") or {}
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command") or tool_input.get("cmd") or ""
+        return str(command)
+    return ""
+
+
+def project_path(payload: dict[str, object]) -> str:
+    for key in ("cwd", "project_path", "workspace"):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return os.getcwd()
+
+
+def find_block(command: str) -> tuple[str, str] | None:
+    for name, pattern, reason in BLOCKERS:
+        if pattern.search(command):
+            return name, reason
+    return None
+
+
+def log_block(command: str, path: str, pattern: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "command": command,
+        "project_path": path,
+        "pattern": pattern,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        emit_decision("deny", f"Invalid hook payload: {exc}")
+        return 0
+
+    command = extract_command(payload)
+    if not command:
+        emit_decision("allow")
+        return 0
+
+    blocked = find_block(command)
+    if blocked is None:
+        emit_decision("allow")
+        return 0
+
+    pattern, reason = blocked
+    path = project_path(payload)
+    log_block(command, path, pattern)
+    emit_decision(
+        "deny",
+        f"Blocked destructive Bash command ({pattern}): {reason}. "
+        f"The attempt was logged to {LOG_PATH}.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/test-pre-tool-use.sh
+++ b/hooks/test-pre-tool-use.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pre-tool-use.py"
+
+assert_decision() {
+  local command="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(
+    printf '%s' "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$command\"},\"cwd\":\"/tmp/project\"}" \
+      | python3 "$hook" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["hookSpecificOutput"]["permissionDecision"])'
+  )"
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "expected '$command' to return '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+python3 -m py_compile "$hook"
+
+assert_decision "rm -rf build" "deny"
+assert_decision "DROP TABLE users" "deny"
+assert_decision "git push --force origin main" "deny"
+assert_decision "TRUNCATE users" "deny"
+assert_decision "DELETE FROM users" "deny"
+assert_decision "DELETE FROM users WHERE id = 1" "allow"
+assert_decision "git status" "allow"
+
+echo "pre-tool-use hook tests passed"

--- a/hooks/test-pre-tool-use.sh
+++ b/hooks/test-pre-tool-use.sh
@@ -23,6 +23,9 @@ assert_decision() {
 python3 -m py_compile "$hook"
 
 assert_decision "rm -rf build" "deny"
+assert_decision "rm -fr build" "deny"
+assert_decision "sudo rm --recursive --force build" "deny"
+assert_decision "rm -r build" "allow"
 assert_decision "DROP TABLE users" "deny"
 assert_decision "git push --force origin main" "deny"
 assert_decision "TRUNCATE users" "deny"


### PR DESCRIPTION
## Summary

/opire claim #3

Adds a Claude Code PreToolUse hook under `hooks/` that blocks destructive Bash commands before execution.

It blocks `rm -rf`, `DROP TABLE`, `git push --force` / `-f` / `--force-with-lease`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause. Blocked attempts are logged to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and matched pattern.

The hook uses Claude Code's current `PreToolUse` output shape: `hookSpecificOutput.permissionDecision` with `allow` or `deny`.

## Validation

Tested locally with:

```bash
bash hooks/test-pre-tool-use.sh
```

The test script runs `python3 -m py_compile hooks/pre-tool-use.py` and checks these decisions:

- `rm -rf build` -> `deny`
- `DROP TABLE users` -> `deny`
- `git push --force origin main` -> `deny`
- `TRUNCATE users` -> `deny`
- `DELETE FROM users` -> `deny`
- `DELETE FROM users WHERE id = 1` -> `allow`
- `git status` -> `allow`

Result: `pre-tool-use hook tests passed`.

Closes #3.