### PR TITLE
Add destructive Bash PreToolUse guard for bounty #3

### DIFF
--- a/submissions/bounty-3/destructive-bash-guard/README.md
+++ b/submissions/bounty-3/destructive-bash-guard/README.md
@@ -1,0 +1,78 @@
+# Destructive Bash Guard for Claude Code
+
+This submission implements bounty #3: a Claude Code `PreToolUse` hook that blocks destructive Bash commands before they execute.
+
+## Install
+
+From this directory:
+
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+The installer copies `destructive_bash_guard.py` to `~/.claude/hooks/` and registers this user-level hook in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/destructive_bash_guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## What It Blocks
+
+The hook blocks the required destructive patterns:
+
+| Pattern | Example |
+| --- | --- |
+| `rm -rf` | `rm -rf build`, `sudo rm -fr /tmp/cache` |
+| `DROP TABLE` | `sqlite3 app.db 'DROP TABLE users'` |
+| `git push --force` | `git push origin main --force`, `git push -f origin main` |
+| `TRUNCATE` | `psql -c 'TRUNCATE audit_log'` |
+| `DELETE FROM` without `WHERE` | `sqlite3 app.db 'DELETE FROM sessions;'` |
+
+It allows normal commands, including safe deletes without `-f`, normal `git push`, and SQL deletes with a `WHERE` clause.
+
+## Claude Code Hook Behavior
+
+The script follows the current Claude Code hook format:
+
+- Reads hook input JSON from stdin.
+- Only inspects `PreToolUse` events for the `Bash` tool.
+- Allows unrelated tools and safe Bash commands without output.
+- On a blocked command, writes a JSON response with:
+  - `hookSpecificOutput.hookEventName = "PreToolUse"`
+  - `hookSpecificOutput.permissionDecision = "deny"`
+  - `hookSpecificOutput.permissionDecisionReason` explaining the block.
+
+This avoids the deprecated `decision: "block"` PreToolUse format.
+
+## Logging
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines:
+
+```json
+{"timestamp":"2026-05-10T12:00:00+00:00","project_path":"/repo","reason":"rm with recursive and force flags can delete large directory trees","command":"rm -rf dist"}
+```
+
+Each entry includes the required timestamp, attempted command, and project path.
+
+## Test
+
+```bash
+python3 -m unittest test_destructive_bash_guard.py
+```
+
+The tests verify all required block patterns, safe commands, the current Claude Code denial schema, and log creation. They do not execute any destructive command.

--- a/submissions/bounty-3/destructive-bash-guard/destructive_bash_guard.py
+++ b/submissions/bounty-3/destructive-bash-guard/destructive_bash_guard.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+The hook reads Claude Code hook JSON from stdin. When a Bash command matches a
+blocked pattern, it logs the attempt and returns a PreToolUse denial using the
+current hookSpecificOutput.permissionDecision format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HOOK_COMMAND = "python3 ~/.claude/hooks/destructive_bash_guard.py"
+LOG_FILE = Path.home() / ".claude" / "hooks" / "blocked.log"
+SETTINGS_FILE = Path.home() / ".claude" / "settings.json"
+
+
+class BlockResult:
+    def __init__(self, blocked: bool, reason: str = "") -> None:
+        self.blocked = blocked
+        self.reason = reason
+
+
+def split_shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def has_rm_rf(tokens: list[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if token != "rm":
+            continue
+
+        flags = ""
+        for candidate in tokens[index + 1 :]:
+            if candidate == "--":
+                break
+            if not candidate.startswith("-") or candidate == "-":
+                continue
+            flags += candidate.lstrip("-").lower()
+
+        if "r" in flags and "f" in flags:
+            return True
+
+    return False
+
+
+def has_git_force_push(tokens: list[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if token != "git":
+            continue
+        try:
+            push_index = tokens.index("push", index + 1)
+        except ValueError:
+            continue
+        if any(arg in {"--force", "--force-with-lease", "-f"} for arg in tokens[push_index + 1 :]):
+            return True
+    return False
+
+
+def delete_without_where(command: str) -> bool:
+    for statement in re.split(r";|\n", command):
+        match = re.search(r"\bDELETE\s+FROM\b", statement, re.IGNORECASE)
+        if not match:
+            continue
+        tail = statement[match.end() :]
+        if not re.search(r"\bWHERE\b", tail, re.IGNORECASE):
+            return True
+    return False
+
+
+def classify_command(command: str) -> BlockResult:
+    tokens = split_shell_words(command)
+
+    if has_rm_rf(tokens):
+        return BlockResult(True, "rm with recursive and force flags can delete large directory trees")
+
+    if has_git_force_push(tokens):
+        return BlockResult(True, "git force-push can rewrite shared remote history")
+
+    if re.search(r"\bDROP\s+TABLE\b", command, re.IGNORECASE):
+        return BlockResult(True, "DROP TABLE can destroy database schema and data")
+
+    if re.search(r"\bTRUNCATE\b", command, re.IGNORECASE):
+        return BlockResult(True, "TRUNCATE removes all rows from a table")
+
+    if delete_without_where(command):
+        return BlockResult(True, "DELETE FROM without a WHERE clause can wipe an entire table")
+
+    return BlockResult(False)
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    return (
+        str(payload.get("cwd") or "")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+
+
+def append_log(command: str, reason: str, project: str) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_path": project,
+        "reason": reason,
+        "command": command,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=True) + "\n")
+
+
+def denial_payload(reason: str, command: str, project: str) -> dict[str, Any]:
+    return {
+        "suppressOutput": True,
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "Blocked destructive Bash command before execution.\n"
+                f"Reason: {reason}\n"
+                f"Project: {project}\n"
+                f"Command: {command}\n"
+                f"Log: {LOG_FILE}"
+            ),
+        },
+    }
+
+
+def run_hook() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") not in {None, "PreToolUse"}:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = str(tool_input.get("command") or "")
+    if not command:
+        return 0
+
+    result = classify_command(command)
+    if not result.blocked:
+        return 0
+
+    project = project_path(payload)
+    append_log(command, result.reason, project)
+    print(json.dumps(denial_payload(result.reason, command, project), ensure_ascii=True))
+    return 0
+
+
+def install_settings() -> int:
+    SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if SETTINGS_FILE.exists():
+        try:
+            settings = json.loads(SETTINGS_FILE.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            backup = SETTINGS_FILE.with_suffix(".json.bak")
+            SETTINGS_FILE.replace(backup)
+            settings = {}
+    else:
+        settings = {}
+
+    hooks = settings.setdefault("hooks", {})
+    pre_tool = hooks.setdefault("PreToolUse", [])
+
+    entry = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": HOOK_COMMAND}],
+    }
+
+    for existing in pre_tool:
+        if not isinstance(existing, dict):
+            continue
+        if existing.get("matcher") != "Bash":
+            continue
+        existing_hooks = existing.setdefault("hooks", [])
+        if any(hook.get("command") == HOOK_COMMAND for hook in existing_hooks if isinstance(hook, dict)):
+            break
+        existing_hooks.append(entry["hooks"][0])
+        break
+    else:
+        pre_tool.append(entry)
+
+    SETTINGS_FILE.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"Registered destructive Bash guard in {SETTINGS_FILE}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--install-settings", action="store_true")
+    args = parser.parse_args()
+
+    if args.install_settings:
+        return install_settings()
+
+    return run_hook()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/submissions/bounty-3/destructive-bash-guard/install.sh
+++ b/submissions/bounty-3/destructive-bash-guard/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_DIR="${HOME}/.claude/hooks"
+TARGET="${HOOK_DIR}/destructive_bash_guard.py"
+
+mkdir -p "${HOOK_DIR}"
+cp "${SCRIPT_DIR}/destructive_bash_guard.py" "${TARGET}"
+chmod +x "${TARGET}"
+python3 "${TARGET}" --install-settings
+
+echo "Installed destructive Bash guard at ${TARGET}"

--- a/submissions/bounty-3/destructive-bash-guard/test_destructive_bash_guard.py
+++ b/submissions/bounty-3/destructive-bash-guard/test_destructive_bash_guard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import destructive_bash_guard as guard
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_blocks_required_patterns(self) -> None:
+        blocked = [
+            "rm -rf build",
+            "sudo rm -fr /tmp/cache",
+            "rm -Rf dist",
+            "sqlite3 app.db 'DROP TABLE users'",
+            "psql -c 'TRUNCATE audit_log'",
+            "git push origin main --force",
+            "git -C ../repo push origin main --force-with-lease",
+            "git push -f origin main",
+            "sqlite3 app.db 'DELETE FROM sessions;'",
+        ]
+
+        for command in blocked:
+            with self.subTest(command=command):
+                self.assertTrue(guard.classify_command(command).blocked)
+
+    def test_allows_safe_commands(self) -> None:
+        allowed = [
+            "ls -la",
+            "rm -r build",
+            "git push origin main",
+            "sqlite3 app.db 'DELETE FROM sessions WHERE expires_at < datetime()'",
+            "python3 manage.py migrate",
+        ]
+
+        for command in allowed:
+            with self.subTest(command=command):
+                self.assertFalse(guard.classify_command(command).blocked)
+
+
+class HookOutputTests(unittest.TestCase):
+    def test_denies_bash_command_with_current_hook_schema(self) -> None:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "cwd": "/repo",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf dist"},
+        }
+
+        with tempfile.TemporaryDirectory() as home:
+            script = Path(__file__).with_name("destructive_bash_guard.py")
+            result = subprocess.run(
+                [sys.executable, str(script)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                env={"HOME": home, "PATH": ""},
+                check=True,
+            )
+
+            output = json.loads(result.stdout)
+            specific = output["hookSpecificOutput"]
+            self.assertEqual(specific["hookEventName"], "PreToolUse")
+            self.assertEqual(specific["permissionDecision"], "deny")
+            self.assertIn("rm with recursive and force flags", specific["permissionDecisionReason"])
+
+            log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log_path.exists())
+            log_entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+            self.assertEqual(log_entry["command"], "rm -rf dist")
+            self.assertEqual(log_entry["project_path"], "/repo")
+
+    def test_allows_non_bash_without_output(self) -> None:
+        payload = {"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {}}
+        script = Path(__file__).with_name("destructive_bash_guard.py")
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements bounty #3 with a Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.

The submission includes:
- `destructive_bash_guard.py`, a stdin/stdout Claude Code hook that only handles `PreToolUse` events for the Bash tool
- `install.sh`, a two-command install path that copies the hook to `~/.claude/hooks/` and registers it in `~/.claude/settings.json`
- README documentation for install, blocked patterns, logging, and hook behavior
- unit tests for the required destructive patterns, safe commands, denial schema, and log creation

## Bounty requirements covered

- Blocks `rm -rf`
- Blocks `DROP TABLE`
- Blocks `git push --force`, `--force-with-lease`, and `-f`
- Blocks `TRUNCATE`
- Blocks `DELETE FROM` without `WHERE`
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, reason, and project path
- Returns a clear Claude Code denial message using the current `hookSpecificOutput.permissionDecision = "deny"` schema
- Allows normal Bash commands without output
- Installs in two shell commands from the submission directory

## Test

```bash
cd submissions/bounty-3/destructive-bash-guard
python3 -B -m unittest test_destructive_bash_guard.py
```

All tests pass locally.