### PR TITLE
Add changelog generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ You're in the right place.
 **To post a bounty**
 1. Open a GitHub issue with a clear description and acceptance criteria
 2. Comment `/opire create $XXX` in the issue to set the reward
-3. Share the link — contributors will find it
+3. Share the link �?contributors will find it
 
 **To claim a bounty**
 1. Browse the open issues below
 2. Comment `/opire try` in the issue you want to work on
-3. Submit a PR — payment is automatic on merge ✅
-
+3. Submit a PR �?payment is automatic on merge �?
 ---
 
 ## Active Bounties
@@ -30,16 +29,25 @@ You're in the right place.
 | [#2](../../issues/2) | TEMPLATE: CLAUDE.md for a Next.js + SQLite project | $75 | 🟢 Open |
 | [#3](../../issues/3) | HOOK: Block destructive bash commands in Claude Code | $100 | 🟢 Open |
 | [#4](../../issues/4) | AGENT: PR reviewer with structured Markdown output | $150 | 🟢 Open |
-| [#5](../../issues/5) | WORKFLOW: n8n + Claude API — automated weekly dev summary | $200 | 🟢 Open |
+| [#5](../../issues/5) | WORKFLOW: n8n + Claude API �?automated weekly dev summary | $200 | 🟢 Open |
 
 ---
 
+## Generate A Changelog
+
+1. Copy `changelog.sh` into any git repository and run `bash changelog.sh`.
+2. The script reads commits since the latest git tag, or all commits if no tag exists.
+3. It writes `CHANGELOG.md` with `Added`, `Fixed`, `Changed`, and `Removed` sections.
+
+See `examples/sample-changelog.md` for sample output.
+
+---
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling
 - Every issue must have clear acceptance criteria before a bounty is activated
 - Payment is handled by [Opire](https://opire.dev) (Stripe)
-- Quality over speed — a solid PR beats a fast one
+- Quality over speed �?a solid PR beats a fast one
 
 ---
 

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh must be run inside a git repository." >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  heading="Unreleased changes since ${latest_tag}"
+else
+  range="HEAD"
+  heading="Project changelog"
+fi
+
+declare -a added fixed changed removed
+
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+  lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$lower_subject" in
+    feat:*|feat\(*|add:*|added:*|create:*|new:*)
+      added+=("$subject")
+      ;;
+    fix:*|fix\(*|bugfix:*|hotfix:*|repair:*)
+      fixed+=("$subject")
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*)
+      removed+=("$subject")
+      ;;
+    *)
+      changed+=("$subject")
+      ;;
+  esac
+done < <(git log --no-merges --pretty=format:%s "$range")
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  printf '### %s\n\n' "$title"
+  if (( ${#items[@]} == 0 )); then
+    printf -- '- No changes.\n\n'
+    return
+  fi
+
+  for item in "${items[@]}"; do
+    printf -- '- %s\n' "$item"
+  done
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## %s\n\n' "$heading"
+  write_section "Added" "${added[@]}"
+  write_section "Fixed" "${fixed[@]}"
+  write_section "Changed" "${changed[@]}"
+  write_section "Removed" "${removed[@]}"
+} > "$output_file"
+
+echo "Wrote ${output_file}"

--- a/examples/sample-changelog.md
+++ b/examples/sample-changelog.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## Unreleased changes since v1.2.0
+
+### Added
+
+- feat: add GitHub OAuth login
+- add: create onboarding checklist
+
+### Fixed
+
+- fix: handle empty repository names
+- bugfix: prevent duplicate changelog entries
+
+### Changed
+
+- docs: clarify setup instructions
+- refactor: simplify changelog renderer
+
+### Removed
+
+- remove: delete deprecated webhook path


### PR DESCRIPTION
## Summary

- Add `changelog.sh`, a Bash changelog generator that reads git history since the latest tag.
- Categorize commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
- Add a sample changelog output and 3-step README setup instructions.

## Validation

- Reviewed script logic locally.
- Included `examples/sample-changelog.md` as the requested sample output.

Note: the API-prepared source archive does not include `.git`, so the script should be run inside a real git repository to generate `CHANGELOG.md`.
