### PR TITLE
Add destructive command hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,47 @@
+# Destructive Command Blocker Hook
+
+This Claude Code `PreToolUse` hook blocks high-risk Bash commands before they run and records every blocked attempt in `~/.claude/hooks/blocked.log`.
+
+## What It Blocks
+
+- `rm -rf` and equivalent combined recursive-force `rm` flags
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- SQL statements containing `DROP TABLE`
+- SQL statements containing `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+
+Normal Bash commands are allowed through unchanged.
+
+## Install In 2 Commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp destructive_command_blocker.py ~/.claude/hooks/destructive_command_blocker.py && chmod +x ~/.claude/hooks/destructive_command_blocker.py
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+settings_path = Path.home() / ".claude" / "settings.json"
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+settings = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+entry = {
+    "matcher": "Bash",
+    "hooks": [{
+        "type": "command",
+        "command": str(Path.home() / ".claude" / "hooks" / "destructive_command_blocker.py")
+    }]
+}
+pre_tool_use = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+if entry not in pre_tool_use:
+    pre_tool_use.append(entry)
+settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+PY
+```
+
+## Test Manually
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"/tmp/demo","tool_input":{"command":"rm -rf build"}}' | ~/.claude/hooks/destructive_command_blocker.py
+echo $?
+```
+
+The first command should print a clear block reason and the exit code should be `2`, which tells Claude Code to stop the Bash tool call.

--- a/hooks/destructive_command_blocker.py
+++ b/hooks/destructive_command_blocker.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+
+
+COMMAND_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||;|\|)\s*")
+DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\btruncate(?:\s+table)?\b", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bwhere\b", re.IGNORECASE)
+
+
+def blocked_log_path() -> Path:
+    hooks_home = os.environ.get("CLAUDE_HOOKS_HOME")
+    if hooks_home:
+        return Path(hooks_home).expanduser() / "hooks" / "blocked.log"
+    return Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def tokenize(segment: str) -> list[str]:
+    try:
+        return shlex.split(segment, posix=True)
+    except ValueError:
+        return segment.split()
+
+
+def skip_command_prefixes(tokens: list[str]) -> list[str]:
+    """Skip common wrappers so `sudo rm -rf` and `env X=1 git push --force` block."""
+    remaining = tokens[:]
+    while remaining:
+        head = remaining[0]
+        if head == "sudo":
+            remaining = remaining[1:]
+            continue
+        if head == "env":
+            remaining = remaining[1:]
+            while remaining and "=" in remaining[0] and not remaining[0].startswith("-"):
+                remaining = remaining[1:]
+            continue
+        if re.match(r"^\w+=.+", head):
+            remaining = remaining[1:]
+            continue
+        break
+    return remaining
+
+
+def rm_rf_reason(tokens: list[str]) -> str | None:
+    tokens = skip_command_prefixes(tokens)
+    if not tokens or tokens[0] != "rm":
+        return None
+
+    flags = [token for token in tokens[1:] if token.startswith("-")]
+    short_flag_chars = "".join(flag.lstrip("-") for flag in flags if not flag.startswith("--"))
+    has_recursive = "r" in short_flag_chars or "R" in short_flag_chars
+    has_force = "f" in short_flag_chars
+    has_recursive = has_recursive or any(flag in {"--recursive", "--dir"} for flag in flags)
+    has_force = has_force or "--force" in flags
+    has_recursive_force = has_recursive and has_force
+    if has_recursive_force:
+        return "rm -rf is destructive and can recursively delete project or system files."
+    return None
+
+
+def force_push_reason(tokens: list[str]) -> str | None:
+    tokens = skip_command_prefixes(tokens)
+    if len(tokens) < 3 or tokens[0:2] != ["git", "push"]:
+        return None
+
+    force_flags = {"--force", "-f", "--force-with-lease"}
+    if any(token in force_flags or token.startswith("--force=") for token in tokens[2:]):
+        return "git push --force can overwrite remote history and must be reviewed manually."
+    return None
+
+
+def sql_reason(statement: str) -> str | None:
+    if DROP_TABLE_RE.search(statement):
+        return "DROP TABLE can permanently remove database schema and data."
+    if TRUNCATE_RE.search(statement):
+        return "TRUNCATE can delete all rows from a table without row-by-row safeguards."
+    if DELETE_FROM_RE.search(statement) and not WHERE_RE.search(statement):
+        return "DELETE FROM without WHERE can remove every row in the target table."
+    return None
+
+
+def block_reason(command: str) -> str | None:
+    for segment in COMMAND_SPLIT_RE.split(command):
+        if not segment.strip():
+            continue
+
+        tokens = tokenize(segment)
+        for detector in (rm_rf_reason, force_push_reason):
+            reason = detector(tokens)
+            if reason:
+                return reason
+
+        reason = sql_reason(segment)
+        if reason:
+            return reason
+
+    return None
+
+
+def log_blocked_attempt(command: str, project_path: str, reason: str) -> None:
+    path = blocked_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+    path.open("a", encoding="utf-8").write(
+        f"{timestamp}\tproject={project_path}\treason={reason}\tcommand={command}\n"
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"Destructive command blocker could not parse hook JSON: {exc}", file=sys.stderr)
+        return 1
+
+    if payload.get("hook_event_name") != "PreToolUse" or payload.get("tool_name") != "Bash":
+        return 0
+
+    command = str(payload.get("tool_input", {}).get("command", ""))
+    reason = block_reason(command)
+    if not reason:
+        return 0
+
+    project_path = str(payload.get("cwd", "unknown"))
+    log_blocked_attempt(command, project_path, reason)
+    print(
+        "Blocked destructive Bash command.\n"
+        f"Reason: {reason}\n"
+        f"Attempted command: {command}\n"
+        "Use a narrower, reversible command or ask the user for explicit confirmation.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/test_destructive_command_blocker.py
+++ b/hooks/test_destructive_command_blocker.py
@@ -1,0 +1,104 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HOOK = Path(__file__).with_name("destructive_command_blocker.py")
+
+
+def run_hook(command: str, cwd: str = "/tmp/example-project") -> subprocess.CompletedProcess:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": cwd,
+    }
+
+    env = os.environ.copy()
+    env["CLAUDE_HOOKS_HOME"] = tempfile.mkdtemp(prefix="claude-hooks-test-")
+
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class DestructiveCommandBlockerTests(unittest.TestCase):
+    def test_allows_normal_bash_command(self) -> None:
+        result = run_hook("npm test")
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_blocks_rm_rf(self) -> None:
+        result = run_hook("rm -rf build")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("rm -rf", result.stderr)
+        self.assertIn("destructive", result.stderr.lower())
+
+    def test_blocks_rm_recursive_force_split_across_flags(self) -> None:
+        result = run_hook("rm -r -f build")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("recursive", result.stderr.lower())
+
+    def test_blocks_force_push(self) -> None:
+        result = run_hook("git push --force origin main")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("git push --force", result.stderr)
+
+    def test_blocks_table_drop_and_truncate(self) -> None:
+        for command in ("psql -c 'DROP TABLE users'", "mysql -e 'TRUNCATE sessions'"):
+            with self.subTest(command=command):
+                result = run_hook(command)
+                self.assertEqual(result.returncode, 2)
+
+    def test_blocks_delete_from_without_where(self) -> None:
+        result = run_hook("psql -c 'DELETE FROM users'")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("DELETE FROM without WHERE", result.stderr)
+
+    def test_allows_delete_from_with_where(self) -> None:
+        result = run_hook("psql -c 'DELETE FROM users WHERE id = 1'")
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_logs_blocked_attempt(self) -> None:
+        hooks_home = tempfile.mkdtemp(prefix="claude-hooks-test-")
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /tmp/example"},
+            "cwd": "/work/project",
+        }
+
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env={**os.environ, "CLAUDE_HOOKS_HOME": hooks_home},
+            check=False,
+        )
+
+        log_path = Path(hooks_home) / "hooks" / "blocked.log"
+        self.assertEqual(result.returncode, 2)
+        self.assertTrue(log_path.exists())
+        log = log_path.read_text(encoding="utf-8")
+        self.assertIn("rm -rf /tmp/example", log)
+        self.assertIn("/work/project", log)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a Python Claude Code PreToolUse hook for Bash that blocks the destructive command patterns from #3 before execution.

The hook blocks:
- `rm -rf` and split recursive-force `rm` flags
- `DROP TABLE`
- `git push --force`, `git push -f`, and `git push --force-with-lease`
- `TRUNCATE`
- `DELETE FROM` statements without `WHERE`

It also logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, attempted command, and project path, and includes a README with a two-command install path.

## Testing

- `python3 hooks/test_destructive_command_blocker.py`
- `python3 -m py_compile hooks/destructive_command_blocker.py hooks/test_destructive_command_blocker.py`

Refs #3.