### PR TITLE
Add Claude PR review agent CLI

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: pr-reviewer
+description: Reviews GitHub pull requests and returns a structured Markdown review. Use when asked to review a PR URL, summarize PR risk, or prepare a review comment.
+tools: Bash, Read
+---
+
+You are a pull request review specialist. Your job is to inspect the requested GitHub pull request, identify meaningful engineering risk, and return a concise Markdown review that another maintainer can paste directly into a PR conversation.
+
+When a PR URL is provided:
+
+1. Run the bundled CLI from the project root:
+
+   ```bash
+   agents/pr-review/claude-review --pr https://github.com/owner/repo/pull/123
+   ```
+
+2. Read the generated Markdown review.
+3. Improve it only when you can add concrete, diff-grounded insight. Do not invent risk that is not supported by the diff.
+4. Preserve the required structure:
+
+   - Summary of changes, in 2 to 3 sentences
+   - Identified risks
+   - Improvement suggestions
+   - Confidence score: Low, Medium, or High
+
+Review principles:
+
+- Prefer specific, actionable feedback over broad advice.
+- Call out missing tests when product or library behavior changes without matching test coverage.
+- Treat dependency, workflow, auth, security, migration, and configuration changes as higher risk.
+- Lower confidence when the diff is very large, generated, truncated, or hard to inspect.
+- If you cannot fetch the PR, explain exactly which command failed and what token or permission is likely missing.
+

--- a/agents/pr-review/README.md
+++ b/agents/pr-review/README.md
@@ -1,0 +1,106 @@
+# Claude PR Review Agent
+
+This folder contains a Claude Code project subagent and a standalone CLI for reviewing GitHub pull requests.
+
+The main command is:
+
+```bash
+agents/pr-review/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+It fetches PR metadata and the unified diff, analyzes the changed files, and prints a structured Markdown review comment with:
+
+- A 2 to 3 sentence summary
+- Identified risks
+- Improvement suggestions
+- A Low, Medium, or High confidence score
+
+## Setup
+
+From the repository root:
+
+```bash
+chmod +x agents/pr-review/claude-review
+ln -sf "$PWD/agents/pr-review/claude-review" /usr/local/bin/claude-review
+```
+
+If `/usr/local/bin` is not writable, run the script directly from the repo:
+
+```bash
+agents/pr-review/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+## Usage
+
+Print a review comment to stdout:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Save the review to a file:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+Post the review as a PR comment:
+
+```bash
+GITHUB_TOKEN=ghp_your_token claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+The token needs permission to read the PR and write issue comments in the target repository. Public PRs can usually be reviewed without a token, but unauthenticated GitHub API requests are rate limited.
+
+## Claude Code Subagent
+
+The project-level subagent lives at:
+
+```text
+.claude/agents/pr-reviewer.md
+```
+
+In Claude Code, invoke it with a request like:
+
+```text
+Use the pr-reviewer subagent to review https://github.com/owner/repo/pull/123
+```
+
+The subagent runs the CLI, inspects the output, and keeps the review in the required Markdown structure.
+
+## Heuristics
+
+The CLI combines PR metadata with diff inspection. It raises risk for:
+
+- Source changes without matching test changes
+- Dependency manifest or lockfile edits
+- Auth, security, permission, or token-handling paths
+- Database schema or migration changes
+- CI workflow edits
+- Environment or deployment configuration changes
+- Large diffs that are hard to review safely
+
+These heuristics are intentionally conservative. They are designed to produce a useful first-pass review that Claude Code can refine with project-specific context.
+
+## Sample Outputs
+
+Two real GitHub PR sample outputs are included:
+
+- `sample-outputs/claude-builders-bounty-pr-889.md`
+- `sample-outputs/claude-builders-bounty-pr-870.md`
+
+Regenerate them with:
+
+```bash
+agents/pr-review/claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/889 --output agents/pr-review/sample-outputs/claude-builders-bounty-pr-889.md
+agents/pr-review/claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/870 --output agents/pr-review/sample-outputs/claude-builders-bounty-pr-870.md
+```
+
+## Tests
+
+Run the unit tests from the repository root:
+
+```bash
+python3 agents/pr-review/tests/test_claude_review.py
+```
+

--- a/agents/pr-review/claude-review
+++ b/agents/pr-review/claude-review
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Review a GitHub pull request and emit a structured Markdown comment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+PR_URL_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)(?:[/?#].*)?$"
+)
+
+SOURCE_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".go",
+    ".java",
+    ".js",
+    ".jsx",
+    ".kt",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".swift",
+    ".ts",
+    ".tsx",
+}
+
+TEST_PATH_HINTS = (
+    "/test/",
+    "/tests/",
+    "/spec/",
+    "/specs/",
+    "__tests__",
+    ".test.",
+    ".spec.",
+    "_test.",
+    "test_",
+)
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def api_url(self) -> str:
+        return f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls/{self.number}"
+
+    @property
+    def html_url(self) -> str:
+        return f"https://github.com/{self.owner}/{self.repo}/pull/{self.number}"
+
+
+@dataclass
+class PullRequestMetadata:
+    title: str
+    author: str
+    base: str
+    head: str
+    additions: int
+    deletions: int
+    changed_files: int
+    html_url: str
+
+
+@dataclass
+class DiffFile:
+    path: str
+    additions: int = 0
+    deletions: int = 0
+    added_lines: list[str] = field(default_factory=list)
+    removed_lines: list[str] = field(default_factory=list)
+
+    @property
+    def suffix(self) -> str:
+        return Path(self.path).suffix.lower()
+
+    @property
+    def is_source(self) -> bool:
+        return self.suffix in SOURCE_SUFFIXES
+
+    @property
+    def is_test(self) -> bool:
+        lowered = f"/{self.path.lower()}"
+        return any(hint in lowered for hint in TEST_PATH_HINTS)
+
+
+@dataclass
+class DiffAnalysis:
+    files: list[DiffFile]
+    total_additions: int
+    total_deletions: int
+
+    @property
+    def source_files(self) -> list[DiffFile]:
+        return [file for file in self.files if file.is_source and not file.is_test]
+
+    @property
+    def test_files(self) -> list[DiffFile]:
+        return [file for file in self.files if file.is_test]
+
+
+def parse_pr_url(url: str) -> PullRequestRef:
+    match = PR_URL_RE.match(url.strip())
+    if not match:
+        raise ValueError("Expected a GitHub PR URL like https://github.com/owner/repo/pull/123")
+    return PullRequestRef(
+        owner=match.group("owner"),
+        repo=match.group("repo"),
+        number=int(match.group("number")),
+    )
+
+
+def github_request(url: str, *, accept: str, token: str | None = None) -> str:
+    headers = {
+        "Accept": accept,
+        "User-Agent": "claude-pr-review-agent",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub request failed with HTTP {exc.code}: {details}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"GitHub request failed: {exc.reason}") from exc
+
+
+def fetch_pull_request(pr: PullRequestRef, token: str | None) -> tuple[PullRequestMetadata, str]:
+    metadata_payload = github_request(
+        pr.api_url,
+        accept="application/vnd.github+json",
+        token=token,
+    )
+    metadata_json = json.loads(metadata_payload)
+    metadata = PullRequestMetadata(
+        title=metadata_json["title"],
+        author=metadata_json["user"]["login"],
+        base=metadata_json["base"]["ref"],
+        head=metadata_json["head"]["ref"],
+        additions=int(metadata_json.get("additions", 0)),
+        deletions=int(metadata_json.get("deletions", 0)),
+        changed_files=int(metadata_json.get("changed_files", 0)),
+        html_url=metadata_json["html_url"],
+    )
+    diff = github_request(
+        pr.api_url,
+        accept="application/vnd.github.v3.diff",
+        token=token,
+    )
+    return metadata, diff
+
+
+def post_issue_comment(pr: PullRequestRef, body: str, token: str | None) -> str:
+    if not token:
+        raise RuntimeError("Posting a PR comment requires GITHUB_TOKEN.")
+
+    url = f"https://api.github.com/repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments"
+    payload = json.dumps({"body": body}).encode("utf-8")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "claude-pr-review-agent",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    request = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            created = json.loads(response.read().decode("utf-8"))
+            return created["html_url"]
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Could not post comment. HTTP {exc.code}: {details}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Could not post comment: {exc.reason}") from exc
+
+
+def parse_diff(diff: str) -> DiffAnalysis:
+    files: list[DiffFile] = []
+    current: DiffFile | None = None
+
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            path = line.split(" b/", 1)[-1].strip()
+            current = DiffFile(path=path)
+            files.append(current)
+            continue
+
+        if current is None:
+            continue
+
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            current.additions += 1
+            current.added_lines.append(line[1:])
+        elif line.startswith("-"):
+            current.deletions += 1
+            current.removed_lines.append(line[1:])
+
+    return DiffAnalysis(
+        files=files,
+        total_additions=sum(file.additions for file in files),
+        total_deletions=sum(file.deletions for file in files),
+    )
+
+
+def has_any_path(files: Iterable[DiffFile], patterns: Iterable[str]) -> bool:
+    lowered_patterns = tuple(pattern.lower() for pattern in patterns)
+    return any(any(pattern in file.path.lower() for pattern in lowered_patterns) for file in files)
+
+
+def has_added_content(files: Iterable[DiffFile], patterns: Iterable[str]) -> bool:
+    lowered_patterns = tuple(pattern.lower() for pattern in patterns)
+    for file in files:
+        added = "\n".join(file.added_lines).lower()
+        if any(pattern in added for pattern in lowered_patterns):
+            return True
+    return False
+
+
+def summarize_files(analysis: DiffAnalysis) -> str:
+    if not analysis.files:
+        return "No changed files were present in the fetched diff."
+
+    shown = ", ".join(file.path for file in analysis.files[:4])
+    remaining = len(analysis.files) - 4
+    if remaining > 0:
+        shown = f"{shown}, and {remaining} more"
+    return shown
+
+
+def build_summary(metadata: PullRequestMetadata, analysis: DiffAnalysis) -> str:
+    changed_files = metadata.changed_files or len(analysis.files)
+    additions = metadata.additions or analysis.total_additions
+    deletions = metadata.deletions or analysis.total_deletions
+    files = summarize_files(analysis)
+    sentence_one = (
+        f"This PR, `{metadata.title}`, proposes changes from `{metadata.head}` into "
+        f"`{metadata.base}` across {changed_files} file(s), with {additions} additions "
+        f"and {deletions} deletions."
+    )
+    sentence_two = f"The main touched paths are {files}."
+    return f"{sentence_one} {sentence_two}"
+
+
+def identify_risks(analysis: DiffAnalysis) -> list[str]:
+    risks: list[str] = []
+
+    if analysis.source_files and not analysis.test_files:
+        risks.append(
+            "Source files changed without matching test files, so behavior may regress without automated coverage."
+        )
+
+    if has_any_path(
+        analysis.files,
+        ("package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", "requirements.txt", "Cargo.toml"),
+    ):
+        risks.append(
+            "Dependency or lockfile changes can affect install reproducibility and should be reviewed for transitive risk."
+        )
+
+    if has_any_path(analysis.files, ("auth", "session", "permission", "security", "token", "secret")) or has_added_content(
+        analysis.files,
+        ("authorization", "password", "secret", "token", "api_key", "apikey"),
+    ):
+        risks.append(
+            "Auth, permission, or secret-handling code appears in the diff, which raises security review importance."
+        )
+
+    if has_any_path(analysis.files, ("migration", "schema", "database", "db/")):
+        risks.append(
+            "Database or schema-related files changed, so rollback and migration ordering should be checked."
+        )
+
+    if has_any_path(analysis.files, (".github/workflows", "ci.yml", "release.yml")):
+        risks.append(
+            "CI or workflow files changed, which can affect build enforcement, release automation, or repository permissions."
+        )
+
+    if has_any_path(analysis.files, (".env", "docker", "deploy", "config", "settings")):
+        risks.append(
+            "Configuration or deployment paths changed, so environment-specific behavior should be verified."
+        )
+
+    if len(analysis.files) > 12 or analysis.total_additions + analysis.total_deletions > 700:
+        risks.append(
+            "The diff is large enough that review confidence drops unless it is split or backed by focused tests."
+        )
+
+    if any(file.deletions > file.additions * 3 and file.deletions > 30 for file in analysis.files):
+        risks.append(
+            "One or more files remove substantially more code than they add, so deleted behavior should be intentional."
+        )
+
+    return risks or ["No obvious high-risk areas were detected from the diff alone."]
+
+
+def build_suggestions(analysis: DiffAnalysis, risks: list[str]) -> list[str]:
+    suggestions: list[str] = []
+
+    if analysis.source_files and not analysis.test_files:
+        suggestions.append("Add or update tests for the changed source behavior before merging.")
+
+    if any("Dependency" in risk for risk in risks):
+        suggestions.append("Confirm the dependency changes are necessary and run a clean install from the lockfile.")
+
+    if any("Auth" in risk for risk in risks):
+        suggestions.append("Check authorization boundaries, secret handling, and error messages for information leaks.")
+
+    if any("Database" in risk for risk in risks):
+        suggestions.append("Run migrations against a disposable database and document the rollback path.")
+
+    if any("CI" in risk for risk in risks):
+        suggestions.append("Verify required checks still run on pull requests from forks and protected branches.")
+
+    if any("Configuration" in risk for risk in risks):
+        suggestions.append("Document any new environment variables or deployment assumptions in the README or runbook.")
+
+    if len(analysis.files) > 12 or analysis.total_additions + analysis.total_deletions > 700:
+        suggestions.append("Consider splitting unrelated changes into smaller PRs to improve review quality.")
+
+    suggestions.append("Ask the author to confirm the exact manual or automated validation performed.")
+    return dedupe(suggestions)
+
+
+def dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result
+
+
+def confidence_score(metadata: PullRequestMetadata, analysis: DiffAnalysis, risks: list[str]) -> str:
+    size = (metadata.additions or analysis.total_additions) + (metadata.deletions or analysis.total_deletions)
+    if size > 1200 or len(analysis.files) > 20:
+        return "Low"
+    if any(risk.startswith("No obvious") for risk in risks) and analysis.test_files:
+        return "High"
+    if len(risks) >= 4 or (analysis.source_files and not analysis.test_files):
+        return "Medium"
+    return "High"
+
+
+def markdown_list(items: Iterable[str]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def render_review(metadata: PullRequestMetadata, analysis: DiffAnalysis) -> str:
+    risks = identify_risks(analysis)
+    suggestions = build_suggestions(analysis, risks)
+    confidence = confidence_score(metadata, analysis, risks)
+    summary = build_summary(metadata, analysis)
+
+    return (
+        "## Claude PR Review\n\n"
+        f"**PR:** [{metadata.title}]({metadata.html_url})\n"
+        f"**Author:** @{metadata.author}\n\n"
+        "### Summary\n"
+        f"{summary}\n\n"
+        "### Identified risks\n"
+        f"{markdown_list(risks)}\n\n"
+        "### Improvement suggestions\n"
+        f"{markdown_list(suggestions)}\n\n"
+        f"### Confidence score: {confidence}\n"
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="claude-review",
+        description="Fetch a GitHub PR diff and print a structured Markdown review comment.",
+    )
+    parser.add_argument("--pr", required=True, help="GitHub PR URL, for example https://github.com/owner/repo/pull/123")
+    parser.add_argument("--output", help="Optional path to write the Markdown review.")
+    parser.add_argument(
+        "--post-comment",
+        action="store_true",
+        help="Post the generated review as a PR conversation comment. Requires GITHUB_TOKEN.",
+    )
+    parser.add_argument(
+        "--diff-file",
+        help="Read a local unified diff instead of fetching the PR diff. Metadata is still fetched from GitHub.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        pr = parse_pr_url(args.pr)
+        metadata, diff = fetch_pull_request(pr, token)
+        if args.diff_file:
+            diff = Path(args.diff_file).read_text(encoding="utf-8")
+
+        analysis = parse_diff(diff)
+        review = render_review(metadata, analysis)
+
+        if args.output:
+            Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.output).write_text(review, encoding="utf-8")
+        else:
+            sys.stdout.write(review)
+
+        if args.post_comment:
+            comment_url = post_issue_comment(pr, review, token)
+            print(f"Posted review comment: {comment_url}", file=sys.stderr)
+
+    except Exception as exc:
+        print(f"claude-review: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-review/sample-outputs/claude-builders-bounty-pr-870.md
+++ b/agents/pr-review/sample-outputs/claude-builders-bounty-pr-870.md
@@ -1,0 +1,16 @@
+## Claude PR Review
+
+**PR:** [Add Claude PR reviewer agent](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/870)
+**Author:** @minyanyi
+
+### Summary
+This PR, `Add Claude PR reviewer agent`, proposes changes from `fix/claude-pr-review-agent` into `main` across 9 file(s), with 482 additions and 0 deletions. The main touched paths are .gitattributes, agents/pr-reviewer/README.md, agents/pr-reviewer/claude-review, agents/pr-reviewer/claude_review.py, and 5 more.
+
+### Identified risks
+- Auth, permission, or secret-handling code appears in the diff, which raises security review importance.
+
+### Improvement suggestions
+- Check authorization boundaries, secret handling, and error messages for information leaks.
+- Ask the author to confirm the exact manual or automated validation performed.
+
+### Confidence score: High

--- a/agents/pr-review/sample-outputs/claude-builders-bounty-pr-889.md
+++ b/agents/pr-review/sample-outputs/claude-builders-bounty-pr-889.md
@@ -1,0 +1,16 @@
+## Claude PR Review
+
+**PR:** [Add destructive command hook](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/889)
+**Author:** @alexgduarte
+
+### Summary
+This PR, `Add destructive command hook`, proposes changes from `add-destructive-command-hook` into `main` across 3 file(s), with 300 additions and 0 deletions. The main touched paths are hooks/README.md, hooks/destructive_command_blocker.py, hooks/test_destructive_command_blocker.py.
+
+### Identified risks
+- Auth, permission, or secret-handling code appears in the diff, which raises security review importance.
+
+### Improvement suggestions
+- Check authorization boundaries, secret handling, and error messages for information leaks.
+- Ask the author to confirm the exact manual or automated validation performed.
+
+### Confidence score: High

--- a/agents/pr-review/tests/test_claude_review.py
+++ b/agents/pr-review/tests/test_claude_review.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Unit tests for the claude-review CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+
+
+CLI_PATH = pathlib.Path(__file__).resolve().parents[1] / "claude-review"
+LOADER = SourceFileLoader("claude_review", str(CLI_PATH))
+SPEC = importlib.util.spec_from_loader("claude_review", LOADER)
+assert SPEC and SPEC.loader
+claude_review = importlib.util.module_from_spec(SPEC)
+sys.modules["claude_review"] = claude_review
+SPEC.loader.exec_module(claude_review)
+
+
+SAMPLE_DIFF = """\
+diff --git a/src/auth/session.ts b/src/auth/session.ts
+index 0000000..1111111 100644
+--- a/src/auth/session.ts
++++ b/src/auth/session.ts
+@@ -1,3 +1,7 @@
+ export function getSession() {
+-  return null
++  const token = process.env.API_TOKEN
++  if (!token) {
++    throw new Error("missing token")
++  }
++  return { token }
+ }
+diff --git a/README.md b/README.md
+index 2222222..3333333 100644
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
+ # Example
++Documented new session behavior.
+"""
+
+
+class ClaudeReviewTests(unittest.TestCase):
+    def test_parse_pr_url(self) -> None:
+        parsed = claude_review.parse_pr_url("https://github.com/example/project/pull/42")
+        self.assertEqual(parsed.owner, "example")
+        self.assertEqual(parsed.repo, "project")
+        self.assertEqual(parsed.number, 42)
+
+    def test_parse_pr_url_rejects_non_pr_url(self) -> None:
+        with self.assertRaises(ValueError):
+            claude_review.parse_pr_url("https://github.com/example/project/issues/42")
+
+    def test_parse_diff_counts_files_and_lines(self) -> None:
+        analysis = claude_review.parse_diff(SAMPLE_DIFF)
+        self.assertEqual(len(analysis.files), 2)
+        self.assertEqual(analysis.total_additions, 6)
+        self.assertEqual(analysis.total_deletions, 1)
+        self.assertEqual(analysis.files[0].path, "src/auth/session.ts")
+
+    def test_identifies_missing_tests_and_security_risk(self) -> None:
+        analysis = claude_review.parse_diff(SAMPLE_DIFF)
+        risks = claude_review.identify_risks(analysis)
+        self.assertTrue(any("without matching test files" in risk for risk in risks))
+        self.assertTrue(any("Auth, permission, or secret-handling" in risk for risk in risks))
+
+    def test_rendered_review_has_required_sections(self) -> None:
+        metadata = claude_review.PullRequestMetadata(
+            title="Add session handling",
+            author="octoctat",
+            base="main",
+            head="session",
+            additions=6,
+            deletions=1,
+            changed_files=2,
+            html_url="https://github.com/example/project/pull/42",
+        )
+        review = claude_review.render_review(metadata, claude_review.parse_diff(SAMPLE_DIFF))
+        self.assertIn("### Summary", review)
+        self.assertIn("### Identified risks", review)
+        self.assertIn("### Improvement suggestions", review)
+        self.assertRegex(review, r"### Confidence score: (Low|Medium|High)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/pr-review/tests/test_claude_review.py
+++ b/agents/pr-review/tests/test_claude_review.py
@@ -70,7 +70,7 @@ class ClaudeReviewTests(unittest.TestCase):
     def test_rendered_review_has_required_sections(self) -> None:
         metadata = claude_review.PullRequestMetadata(
             title="Add session handling",
-            author="octoctat",
+            author="octocat",
             base="main",
             head="session",
             additions=6,


### PR DESCRIPTION
## Summary

Adds a Claude Code PR review agent for #4 with both a project-level subagent and a standalone `claude-review --pr <url>` CLI.

The implementation:
- fetches PR metadata and unified diffs from GitHub
- - returns a structured Markdown review with summary, risks, suggestions, and confidence score
- - supports `--output` for saving reviews and `--post-comment` for posting them when `GITHUB_TOKEN` is available
- - includes README setup and usage instructions
- - includes sample outputs generated from two real GitHub PRs
## Testing

- `python3 agents/pr-review/tests/test_claude_review.py`
- - `python3 -m py_compile agents/pr-review/claude-review agents/pr-review/tests/test_claude_review.py`
- - `agents/pr-review/claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/889 --output agents/pr-review/sample-outputs/claude-builders-bounty-pr-889.md`
- - `agents/pr-review/claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/870 --output agents/pr-review/sample-outputs/claude-builders-bounty-pr-870.md`
Refs #4.