### PR TITLE
Add changelog generator skill

### DIFF
--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${script_dir}/generate-changelog/changelog.sh" "$@"

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,32 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from Git commits since the latest tag.
+
+## Setup
+
+1. Copy `changelog.sh` and `generate-changelog/` into any Git repository.
+2. Run `bash changelog.sh` from that repository's root.
+3. Review the generated `CHANGELOG.md`.
+
+## Usage
+
+```bash
+bash changelog.sh
+```
+
+Optionally pass a custom output path:
+
+```bash
+bash changelog.sh docs/CHANGELOG.md
+```
+
+## Categories
+
+The script sorts commit subjects into:
+
+- `Added`: `feat`, `add`, `create`, and similar commit subjects.
+- `Fixed`: `fix`, `bug`, `resolve`, `repair`, and similar commit subjects.
+- `Changed`: `change`, `refactor`, `perf`, `docs`, `test`, `build`, `ci`, `chore`, `update`, and uncategorized subjects.
+- `Removed`: `remove`, `delete`, `drop`, `deprecate`, and similar commit subjects.
+
+If the repository has no tags, the script uses all commits reachable from `HEAD`.

--- a/generate-changelog/SKILL.md
+++ b/generate-changelog/SKILL.md
@@ -1,0 +1,21 @@
+# Generate Changelog
+
+Use this skill when a user asks for `/generate-changelog` or wants a structured `CHANGELOG.md` generated from Git history.
+
+## Workflow
+
+1. Confirm the current directory is the target Git repository.
+2. Run:
+
+   ```bash
+   bash changelog.sh
+   ```
+
+3. Open `CHANGELOG.md`, check that the categories match the commit history, and adjust wording only if the user asks for editorial cleanup.
+
+## Behavior
+
+- Reads commits since the latest Git tag.
+- Falls back to all reachable commits when the repository has no tags.
+- Groups entries into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a Markdown changelog suitable for review before release.

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "generate-changelog: run this script inside a Git repository." >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [ -n "$latest_tag" ]; then
+  commit_range="${latest_tag}..HEAD"
+  range_label="since ${latest_tag}"
+else
+  commit_range="HEAD"
+  range_label="from all commits"
+fi
+
+if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo "generate-changelog: this repository has no commits yet." >&2
+  exit 1
+fi
+
+declare -a added_entries=()
+declare -a fixed_entries=()
+declare -a changed_entries=()
+declare -a removed_entries=()
+
+clean_subject() {
+  printf '%s' "$1" | sed -E 's/^[a-zA-Z]+(\([^)]+\))?!?:[[:space:]]*//'
+}
+
+append_commit() {
+  subject="$1"
+  short_hash="$2"
+  lowered="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  entry="- $(clean_subject "$subject") (${short_hash})"
+
+  case "$lowered" in
+    feat:*|feat!:*|feat\(*|feature:*|feature\(*|add:*|add\(*|added:*|create:*|create\(*|created:*)
+      added_entries+=("$entry")
+      ;;
+    fix:*|fix!:*|fix\(*|fixed:*|bug:*|bug\(*|resolve:*|resolve\(*|resolved:*|repair:*|repair\(*)
+      fixed_entries+=("$entry")
+      ;;
+    remove:*|remove\(*|removed:*|delete:*|delete\(*|deleted:*|drop:*|drop\(*|dropped:*|deprecate:*|deprecate\(*|deprecated:*)
+      removed_entries+=("$entry")
+      ;;
+    change:*|change\(*|changed:*|refactor:*|refactor\(*|perf:*|perf\(*|docs:*|docs\(*|test:*|test\(*|build:*|build\(*|ci:*|ci\(*|chore:*|chore\(*|update:*|update\(*|updated:*|improve:*|improve\(*|improved:*)
+      changed_entries+=("$entry")
+      ;;
+    *)
+      changed_entries+=("$entry")
+      ;;
+  esac
+}
+
+while IFS=$'\t' read -r subject short_hash; do
+  if [ -n "$subject" ]; then
+    append_commit "$subject" "$short_hash"
+  fi
+done < <(git log --reverse --no-merges --format='%s%x09%h' "$commit_range")
+
+write_section() {
+  title="$1"
+  shift
+  printf '### %s\n\n' "$title"
+
+  if [ "$#" -eq 0 ]; then
+    printf '_No changes._\n\n'
+    return
+  fi
+
+  for entry in "$@"; do
+    printf '%s\n' "$entry"
+  done
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## Unreleased\n\n'
+  printf '_Generated from Git history %s._\n\n' "$range_label"
+  write_section "Added" "${added_entries[@]+"${added_entries[@]}"}"
+  write_section "Fixed" "${fixed_entries[@]+"${fixed_entries[@]}"}"
+  write_section "Changed" "${changed_entries[@]+"${changed_entries[@]}"}"
+  write_section "Removed" "${removed_entries[@]+"${removed_entries[@]}"}"
+} > "$output_file"
+
+echo "Generated ${output_file} ${range_label}."

--- a/generate-changelog/sample-output.md
+++ b/generate-changelog/sample-output.md
@@ -34,4 +34,5 @@ _No changes._
 ### Removed
 
 _No changes._
+
 ```

--- a/generate-changelog/sample-output.md
+++ b/generate-changelog/sample-output.md
@@ -1,0 +1,37 @@
+# Sample Output
+
+Generated from the public GitHub repository `sindresorhus/escape-string-regexp`.
+
+Command:
+
+```bash
+bash changelog.sh /tmp/escape-string-regexp-changelog.md
+```
+
+Output:
+
+```markdown
+# Changelog
+
+## Unreleased
+
+_Generated from Git history since v5.0.0._
+
+### Added
+
+_No changes._
+
+### Fixed
+
+_No changes._
+
+### Changed
+
+- Clarify that minimal escaping is done and describe edge cases (#40) (6fe67c0)
+- Meta tweaks (6ced614)
+- Document native API (cbc4240)
+
+### Removed
+
+_No changes._
+```

--- a/test_changelog.sh
+++ b/test_changelog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/generate-changelog-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+assert_contains() {
+  file="$1"
+  expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "Expected to find: $expected" >&2
+    echo "In file: $file" >&2
+    echo "--- file contents ---" >&2
+    cat "$file" >&2
+    echo "---------------------" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  file="$1"
+  unexpected="$2"
+
+  if grep -Fq -- "$unexpected" "$file"; then
+    echo "Did not expect to find: $unexpected" >&2
+    echo "In file: $file" >&2
+    echo "--- file contents ---" >&2
+    cat "$file" >&2
+    echo "---------------------" >&2
+    exit 1
+  fi
+}
+
+init_repo() {
+  repo_path="$1"
+  mkdir -p "$repo_path"
+  cd "$repo_path"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Generate Changelog Test"
+}
+
+commit_change() {
+  message="$1"
+  file_name="$2"
+  content="$3"
+
+  printf '%s\n' "$content" >> "$file_name"
+  git add "$file_name"
+  git commit -q -m "$message"
+}
+
+no_tag_repo="$work_dir/no-tag"
+init_repo "$no_tag_repo"
+commit_change "feat: add onboarding flow" "app.txt" "added"
+commit_change "fix: repair changelog grouping" "app.txt" "fixed"
+commit_change "docs: update setup notes" "docs.txt" "changed"
+commit_change "remove: delete legacy option" "legacy.txt" "removed"
+
+bash "$repo_root/changelog.sh" "$no_tag_repo/CHANGELOG.md" >/dev/null
+
+assert_contains "$no_tag_repo/CHANGELOG.md" "# Changelog"
+assert_contains "$no_tag_repo/CHANGELOG.md" "_Generated from Git history from all commits._"
+assert_contains "$no_tag_repo/CHANGELOG.md" "### Added"
+assert_contains "$no_tag_repo/CHANGELOG.md" "- add onboarding flow"
+assert_contains "$no_tag_repo/CHANGELOG.md" "### Fixed"
+assert_contains "$no_tag_repo/CHANGELOG.md" "- repair changelog grouping"
+assert_contains "$no_tag_repo/CHANGELOG.md" "### Changed"
+assert_contains "$no_tag_repo/CHANGELOG.md" "- update setup notes"
+assert_contains "$no_tag_repo/CHANGELOG.md" "### Removed"
+assert_contains "$no_tag_repo/CHANGELOG.md" "- delete legacy option"
+
+tagged_repo="$work_dir/tagged"
+init_repo "$tagged_repo"
+commit_change "feat: add released feature" "app.txt" "released"
+git tag v1.0.0
+commit_change "fix: repair post-release bug" "app.txt" "post-release"
+commit_change "chore: update package metadata" "package.txt" "metadata"
+
+bash "$repo_root/changelog.sh" "$tagged_repo/CHANGELOG.md" >/dev/null
+
+assert_contains "$tagged_repo/CHANGELOG.md" "_Generated from Git history since v1.0.0._"
+assert_not_contains "$tagged_repo/CHANGELOG.md" "- add released feature"
+assert_contains "$tagged_repo/CHANGELOG.md" "- repair post-release bug"
+assert_contains "$tagged_repo/CHANGELOG.md" "- update package metadata"
+
+echo "All changelog generator tests passed."


### PR DESCRIPTION
Summary:
- Adds a Claude Code skill and bash script to generate a structured CHANGELOG.md from git history.
- Supports commits since the latest git tag, with a no-tag fallback.
- Categorizes commits into Added, Fixed, Changed, and Removed.
- Includes README instructions and sample output from a real GitHub repo.

Bounty:
- Closes #1
- /claim #1

Verification:
- bash -n changelog.sh
- bash -n generate-changelog/changelog.sh
- bash test_changelog.sh
- Tested on a temporary no-tag repository
- Tested on a real public GitHub repository
- Sample output included in `generate-changelog/sample-output.md`

Notes:
- No paid APIs are required.
- The script is intended to run locally with standard git/bash tooling.
- shellcheck was skipped because it is not installed locally.
