### PR TITLE
Add changelog generation skill

### DIFF
--- a/.claude/skills/generate-changelog/SKILL.md
+++ b/.claude/skills/generate-changelog/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commits since the last tag, grouped into Added, Fixed, Changed, and Removed sections.
+---
+
+# Generate Changelog
+
+Use this skill when the user asks for a changelog from git history.
+
+## Workflow
+
+1. Confirm the current directory is the target git repository.
+2. Run `bash changelog.sh` to write `CHANGELOG.md`, or pass a custom output path such as `bash changelog.sh RELEASE_NOTES.md`.
+3. Review the generated sections and adjust commit categorization only if the user asks for editorial cleanup.
+
+The script reads commits since the most recent git tag. If the repository has no tags, it uses the full git history.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ You're in the right place.
 
 ---
 
+## Generate a changelog
+
+1. Run `bash changelog.sh` from the root of any git repository.
+2. Optionally pass an output path: `bash changelog.sh RELEASE_NOTES.md`.
+3. Open the generated `CHANGELOG.md` and review the Added, Fixed, Changed, and Removed sections.
+
+Claude Code users can also install the included `.claude/skills/generate-changelog/SKILL.md` skill.
+
+---
+
 ## Active Bounties
 
 | # | Task | Amount | Status |

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+version="${CHANGELOG_VERSION:-Unreleased}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: changelog.sh must be run inside a git repository." >&2
+  exit 1
+fi
+
+last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+range=()
+scope_text="full git history"
+
+if [ -n "$last_tag" ]; then
+  range=("${last_tag}..HEAD")
+  scope_text="commits since ${last_tag}"
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+added_file="${tmp_dir}/added"
+fixed_file="${tmp_dir}/fixed"
+changed_file="${tmp_dir}/changed"
+removed_file="${tmp_dir}/removed"
+: >"$added_file"
+: >"$fixed_file"
+: >"$changed_file"
+: >"$removed_file"
+
+categorize_commit() {
+  subject="$1"
+  normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$normalized" in
+    feat:*|feat\(*|feature:*|feature\(*|add:*|add\(*|added:*|added\(*)
+      printf '%s\n' "$added_file"
+      ;;
+    fix:*|fix\(*|bugfix:*|bugfix\(*|hotfix:*|hotfix\(*)
+      printf '%s\n' "$fixed_file"
+      ;;
+    remove:*|remove\(*|removed:*|removed\(*|delete:*|delete\(*|deleted:*|deleted\(*|drop:*|drop\(*)
+      printf '%s\n' "$removed_file"
+      ;;
+    *)
+      if printf '%s' "$normalized" | grep -Eq '(^|[[:space:]])(add|adds|added|introduce|introduces|introduced)([[:space:]]|$)'; then
+        printf '%s\n' "$added_file"
+      elif printf '%s' "$normalized" | grep -Eq '(^|[[:space:]])(fix|fixes|fixed|bug|bugs|repair|repairs|repaired)([[:space:]]|$)'; then
+        printf '%s\n' "$fixed_file"
+      elif printf '%s' "$normalized" | grep -Eq '(^|[[:space:]])(remove|removes|removed|delete|deletes|deleted|drop|drops|dropped)([[:space:]]|$)'; then
+        printf '%s\n' "$removed_file"
+      else
+        printf '%s\n' "$changed_file"
+      fi
+      ;;
+  esac
+}
+
+commit_count=0
+while IFS=$'\t' read -r subject short_sha; do
+  [ -n "$subject" ] || continue
+  category_file="$(categorize_commit "$subject")"
+  printf -- '- %s (`%s`)\n' "$subject" "$short_sha" >>"$category_file"
+  commit_count=$((commit_count + 1))
+done < <(git log --reverse --no-merges --format='%s%x09%h' "${range[@]}")
+
+write_section() {
+  title="$1"
+  file="$2"
+
+  printf '\n### %s\n' "$title"
+  if [ -s "$file" ]; then
+    cat "$file"
+  else
+    printf -- '- No changes.\n'
+  fi
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## %s\n\n' "$version"
+  printf '_Generated from %s on %s._\n' "$scope_text" "$(date -u '+%Y-%m-%d')"
+
+  if [ "$commit_count" -eq 0 ]; then
+    printf '\nNo commits found for this range.\n'
+  else
+    write_section "Added" "$added_file"
+    write_section "Fixed" "$fixed_file"
+    write_section "Changed" "$changed_file"
+    write_section "Removed" "$removed_file"
+  fi
+} >"$output_file"
+
+echo "Wrote $output_file from $commit_count commit(s)."

--- a/samples/CHANGELOG.sample.md
+++ b/samples/CHANGELOG.sample.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased
+
+_Generated from full git history on 2026-05-11._
+
+### Added
+- feat: initial README with bounty board (`1aeae2a`)
+
+### Fixed
+- No changes.
+
+### Changed
+- Initial commit (`a80a580`)
+
+### Removed
+- No changes.

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+cd "$work_dir"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Changelog Test"
+
+printf 'base\n' >app.txt
+git add app.txt
+git commit -q -m "chore: initial baseline"
+git tag v0.1.0
+
+printf 'feature\n' >>app.txt
+git add app.txt
+git commit -q -m "feat: add export command"
+
+printf 'fix\n' >>app.txt
+git add app.txt
+git commit -q -m "fix: handle empty tag ranges"
+
+printf 'docs\n' >>app.txt
+git add app.txt
+git commit -q -m "docs: update setup instructions"
+
+printf 'remove\n' >>app.txt
+git add app.txt
+git commit -q -m "remove: delete deprecated flag"
+
+bash "${repo_root}/changelog.sh" CHANGELOG.md >/tmp/changelog-test-output.txt
+
+grep -q "Generated from commits since v0.1.0" CHANGELOG.md
+grep -q "### Added" CHANGELOG.md
+grep -q "feat: add export command" CHANGELOG.md
+grep -q "### Fixed" CHANGELOG.md
+grep -q "fix: handle empty tag ranges" CHANGELOG.md
+grep -q "### Changed" CHANGELOG.md
+grep -q "docs: update setup instructions" CHANGELOG.md
+grep -q "### Removed" CHANGELOG.md
+grep -q "remove: delete deprecated flag" CHANGELOG.md
+
+echo "All changelog tests passed."


### PR DESCRIPTION
Closes #1.

## Summary
- Add `changelog.sh`, a Bash changelog generator that reads commits since the latest git tag and writes a structured `CHANGELOG.md`.
- Categorize commits into `Added`, `Fixed`, `Changed`, and `Removed` using conventional commit prefixes and common action words.
- Add a Claude Code skill at `.claude/skills/generate-changelog/SKILL.md` for users who want skill-based usage.
- Add a test script that creates a temporary real git repository with a tag and verifies all four changelog sections.
- Include `samples/CHANGELOG.sample.md` generated from this repository as sample output.
- Document setup in 3 steps in the README.

## Verification
- `bash tests/test_changelog.sh`
- `bash changelog.sh samples/CHANGELOG.sample.md`

## Sample output
See `samples/CHANGELOG.sample.md`.
