### PR TITLE
Add destructive Bash command blocking hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py text eol=lf

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ You're in the right place.
 
 ---
 
+## Block destructive Bash commands
+
+Install the Claude Code PreToolUse hook in 2 commands:
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block_destructive_bash.py ~/.claude/hooks/
+python ~/.claude/hooks/block_destructive_bash.py --install
+```
+
+The hook blocks destructive Bash patterns such as `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` statements without a `WHERE` clause. Blocked attempts are written to `~/.claude/hooks/blocked.log`.
+
+---
+
 ## Active Bounties
 
 | # | Task | Amount | Status |

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import sys
+from typing import Any
+
+
+SQL_DROP_TABLE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+SQL_TRUNCATE = re.compile(r"\btruncate\b", re.IGNORECASE)
+SQL_DELETE_FROM = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+SQL_WHERE = re.compile(r"\bwhere\b", re.IGNORECASE)
+
+
+def shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def has_rm_rf(command: str) -> bool:
+    tokens = shell_tokens(command)
+
+    for index, token in enumerate(tokens):
+        if token != "rm":
+            continue
+
+        recursive = False
+        force = False
+        for option in tokens[index + 1 :]:
+            if not option.startswith("-"):
+                break
+            if "r" in option.lower() or "R" in option:
+                recursive = True
+            if "f" in option.lower():
+                force = True
+            if recursive and force:
+                return True
+
+    return bool(re.search(r"\brm\s+-[^\s;|&]*r[^\s;|&]*f|\brm\s+-[^\s;|&]*f[^\s;|&]*r", command, re.IGNORECASE))
+
+
+def has_force_push(command: str) -> bool:
+    tokens = shell_tokens(command)
+
+    for index in range(len(tokens) - 2):
+        if tokens[index : index + 2] != ["git", "push"]:
+            continue
+
+        for option in tokens[index + 2 :]:
+            if option == "--":
+                break
+            if option in {"--force", "--force-with-lease", "-f"} or option.startswith("--force="):
+                return True
+
+    return bool(re.search(r"\bgit\s+push\b[^\n;&|]*\s(--force(?:-with-lease)?|-f)\b", command))
+
+
+def has_delete_without_where(command: str) -> bool:
+    for statement in command.split(";"):
+        if SQL_DELETE_FROM.search(statement) and not SQL_WHERE.search(statement):
+            return True
+    return False
+
+
+def blocked_reason(command: str) -> str | None:
+    if has_rm_rf(command):
+        return "rm -rf"
+    if SQL_DROP_TABLE.search(command):
+        return "DROP TABLE"
+    if has_force_push(command):
+        return "git push --force"
+    if SQL_TRUNCATE.search(command):
+        return "TRUNCATE"
+    if has_delete_without_where(command):
+        return "DELETE FROM without WHERE"
+    return None
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"tool_name": "Bash", "tool_input": {"command": raw}}
+    return payload if isinstance(payload, dict) else {}
+
+
+def bash_command(payload: dict[str, Any]) -> str:
+    tool_name = payload.get("tool_name")
+    if tool_name and tool_name != "Bash":
+        return ""
+
+    tool_input = payload.get("tool_input", {})
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command", "")
+        return command if isinstance(command, str) else ""
+
+    return ""
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    for key in ("CLAUDE_PROJECT_DIR", "PWD"):
+        value = os.environ.get(key)
+        if value:
+            return value
+
+    for key in ("cwd", "project_dir", "workspace_dir"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    return os.getcwd()
+
+
+def log_block(payload: dict[str, Any], command: str, reason: str) -> None:
+    log_dir = Path.home() / ".claude" / "hooks"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "blocked.log"
+    timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    line = f"{timestamp}\t{project_path(payload)}\t{reason}\t{command}\n"
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def deny_output(command: str, reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Blocked destructive Bash command ({reason}). "
+                f"Review the command before running it manually: {command}"
+            ),
+        }
+    }
+
+
+def install_hook() -> int:
+    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if settings_path.exists():
+        with settings_path.open("r", encoding="utf-8") as handle:
+            settings = json.load(handle)
+    else:
+        settings = {}
+
+    hooks = settings.setdefault("hooks", {})
+    pre_tool = hooks.setdefault("PreToolUse", [])
+    script_path = Path(__file__).expanduser().resolve()
+    command = f'"{sys.executable}" "{script_path}"'
+    entry = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": command}],
+    }
+
+    if entry not in pre_tool:
+        pre_tool.append(entry)
+
+    with settings_path.open("w", encoding="utf-8") as handle:
+        json.dump(settings, handle, indent=2)
+        handle.write("\n")
+
+    print(f"Installed destructive command hook in {settings_path}")
+    return 0
+
+
+def run_hook() -> int:
+    payload = load_payload()
+    command = bash_command(payload)
+    if not command:
+        return 0
+
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    log_block(payload, command, reason)
+    print(json.dumps(deny_output(command, reason)))
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--install":
+        return install_hook()
+    return run_hook()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "hooks" / "block_destructive_bash.py"
+
+
+class BlockDestructiveBashHookTests(unittest.TestCase):
+    def run_hook(self, command, tool_name="Bash"):
+        with tempfile.TemporaryDirectory() as home:
+            env = os.environ.copy()
+            env["HOME"] = home
+            env["USERPROFILE"] = home
+            env["CLAUDE_PROJECT_DIR"] = "/tmp/project"
+            payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+            result = subprocess.run(
+                [sys.executable, str(HOOK)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                check=True,
+                env=env,
+            )
+            log_file = Path(home) / ".claude" / "hooks" / "blocked.log"
+            log_text = log_file.read_text(encoding="utf-8") if log_file.exists() else ""
+            return result.stdout.strip(), log_text
+
+    def assert_blocked(self, command, expected_reason):
+        stdout, log_text = self.run_hook(command)
+        self.assertTrue(stdout)
+        payload = json.loads(stdout)
+        hook_output = payload["hookSpecificOutput"]
+        self.assertEqual(hook_output["permissionDecision"], "deny")
+        self.assertIn(expected_reason, hook_output["permissionDecisionReason"])
+        self.assertIn(command, log_text)
+        self.assertIn("/tmp/project", log_text)
+
+    def test_blocks_required_patterns(self):
+        cases = [
+            ("rm -rf /tmp/build", "rm -rf"),
+            ("psql -c 'DROP TABLE users'", "DROP TABLE"),
+            ("git push --force origin main", "git push --force"),
+            ("mysql -e 'TRUNCATE audit_log'", "TRUNCATE"),
+            ("psql -c 'DELETE FROM users'", "DELETE FROM without WHERE"),
+        ]
+
+        for command, reason in cases:
+            with self.subTest(command=command):
+                self.assert_blocked(command, reason)
+
+    def test_allows_normal_bash_commands(self):
+        stdout, log_text = self.run_hook("git status && npm test")
+        self.assertEqual(stdout, "")
+        self.assertEqual(log_text, "")
+
+    def test_allows_delete_with_where_clause(self):
+        stdout, log_text = self.run_hook("psql -c 'DELETE FROM sessions WHERE expired = true'")
+        self.assertEqual(stdout, "")
+        self.assertEqual(log_text, "")
+
+    def test_ignores_non_bash_tools(self):
+        stdout, log_text = self.run_hook("rm -rf /tmp/build", tool_name="Read")
+        self.assertEqual(stdout, "")
+        self.assertEqual(log_text, "")
+
+    def test_install_writes_claude_settings(self):
+        with tempfile.TemporaryDirectory() as home:
+            env = os.environ.copy()
+            env["HOME"] = home
+            env["USERPROFILE"] = home
+            result = subprocess.run(
+                [sys.executable, str(HOOK), "--install"],
+                text=True,
+                capture_output=True,
+                check=True,
+                env=env,
+            )
+            settings_path = Path(home) / ".claude" / "settings.json"
+            self.assertTrue(settings_path.exists())
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            entry = settings["hooks"]["PreToolUse"][0]
+            self.assertEqual(entry["matcher"], "Bash")
+            self.assertEqual(entry["hooks"][0]["type"], "command")
+            self.assertIn("block_destructive_bash.py", entry["hooks"][0]["command"])
+            self.assertIn(str(settings_path), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3.

## Summary
- Add a Claude Code `PreToolUse` hook script for Bash commands.
- Deny the required destructive patterns: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause.
- Log blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, project path, rule, and command.
- Add `--install` support that writes the Claude Code hook configuration into `~/.claude/settings.json`.
- Document installation in 2 commands in the README.
- Add stdlib `unittest` coverage for all required block cases, safe commands, non-Bash tools, and installer output.

## Verification
- `python tests/test_block_destructive_bash.py`
- Manual hook smoke test returned a `PreToolUse` deny payload for a destructive command fixture.
