### PR TITLE
Add generate changelog tool

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,9 @@
+# Generate Changelog
+
+Run the repository changelog generator:
+
+```bash
+bash changelog.sh
+```
+
+After it runs, inspect `CHANGELOG.md` for category placement and edit only if a commit subject was ambiguous.

--- a/.claude/skills/generate-changelog/SKILL.md
+++ b/.claude/skills/generate-changelog/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commits since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when a repository needs a release-ready `CHANGELOG.md` generated from git history.
+
+## Workflow
+
+Run the project script from the repository root:
+
+```bash
+bash changelog.sh
+```
+
+The script detects the latest git tag, gathers commits after that tag, categorizes them into `Added`, `Fixed`, `Changed`, and `Removed`, and writes `CHANGELOG.md`.
+
+If there are no tags, it uses the full repository history and states that in the output.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$ROOT_DIR/tools/generate-changelog/generate_changelog.py" "$@"

--- a/tools/generate-changelog/README.md
+++ b/tools/generate-changelog/README.md
@@ -1,0 +1,29 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from git commits since the latest tag. The output uses the sections required by the bounty: `Added`, `Fixed`, `Changed`, and `Removed`.
+
+## Setup
+
+1. Copy `changelog.sh` and the `tools/generate-changelog/` directory into the root of a git repository.
+2. Run `bash changelog.sh` to write `CHANGELOG.md`.
+3. Review the generated file, then commit it with the release or maintenance PR.
+
+## Usage
+
+```bash
+bash changelog.sh
+```
+
+Useful options:
+
+- `--repo path/to/repo` inspects a different local git repository.
+- `--output path/to/CHANGELOG.md` writes to a custom path.
+- `--since-tag v1.2.3` overrides latest-tag detection.
+- `--version 1.3.0` changes the heading from `Unreleased`.
+- `--stdout` prints the changelog without writing a file.
+
+## Categorization
+
+The generator first checks Conventional Commit prefixes such as `feat:`, `fix:`, `docs:`, and `remove:`. If there is no prefix, it falls back to the first verb in the subject, such as `add`, `fix`, `update`, or `delete`. Subjects that do not match a specific rule go into `Changed` so every commit is represented.
+
+If the repository has no tags, the generator uses the full repository history and says that clearly in the changelog.

--- a/tools/generate-changelog/generate_changelog.py
+++ b/tools/generate-changelog/generate_changelog.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORY_ORDER = ("Added", "Fixed", "Changed", "Removed")
+
+CONVENTIONAL_TYPES = {
+    "feat": "Added",
+    "feature": "Added",
+    "fix": "Fixed",
+    "bugfix": "Fixed",
+    "perf": "Changed",
+    "refactor": "Changed",
+    "docs": "Changed",
+    "doc": "Changed",
+    "style": "Changed",
+    "test": "Changed",
+    "tests": "Changed",
+    "chore": "Changed",
+    "build": "Changed",
+    "ci": "Changed",
+    "revert": "Changed",
+    "remove": "Removed",
+    "removed": "Removed",
+    "delete": "Removed",
+    "deleted": "Removed",
+}
+
+KEYWORD_PREFIXES = (
+    ("Added", ("add", "adds", "added", "create", "creates", "created", "implement", "implements", "implemented", "introduce", "introduces", "introduced")),
+    ("Fixed", ("fix", "fixes", "fixed", "repair", "repairs", "repaired", "patch", "patched", "resolve", "resolves", "resolved")),
+    ("Removed", ("remove", "removes", "removed", "delete", "deletes", "deleted", "drop", "drops", "dropped", "deprecate", "deprecates", "deprecated")),
+    ("Changed", ("change", "changes", "changed", "update", "updates", "updated", "refactor", "refactors", "refactored", "improve", "improves", "improved")),
+)
+
+CONVENTIONAL_RE = re.compile(
+    r"^(?P<type>[A-Za-z]+)(?:\([^)]+\))?(?P<breaking>!)?:\s*(?P<description>.+)$"
+)
+
+
+@dataclass(frozen=True)
+class Commit:
+    subject: str
+    sha: str
+    author: str
+    date: str
+
+
+def run_git(repo: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise RuntimeError(message)
+    return result
+
+
+def normalize_repo(path: Path) -> Path:
+    repo = path.expanduser().resolve()
+    result = run_git(repo, ["rev-parse", "--is-inside-work-tree"], check=False)
+    if result.returncode != 0 or result.stdout.strip() != "true":
+        raise RuntimeError(f"{repo} is not inside a git work tree")
+    root = run_git(repo, ["rev-parse", "--show-toplevel"]).stdout.strip()
+    return Path(root)
+
+
+def latest_tag(repo: Path) -> str | None:
+    result = run_git(repo, ["describe", "--tags", "--abbrev=0"], check=False)
+    if result.returncode != 0:
+        return None
+    tag = result.stdout.strip()
+    return tag or None
+
+
+def read_commits(repo: Path, since_tag: str | None) -> list[Commit]:
+    revision = f"{since_tag}..HEAD" if since_tag else "HEAD"
+    result = run_git(
+        repo,
+        [
+            "log",
+            "--reverse",
+            "--pretty=format:%s%x1f%h%x1f%an%x1f%ad",
+            "--date=short",
+            revision,
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        if "does not have any commits yet" in message:
+            return []
+        raise RuntimeError(message)
+
+    commits: list[Commit] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\x1f")
+        if len(parts) != 4:
+            continue
+        commits.append(Commit(subject=parts[0], sha=parts[1], author=parts[2], date=parts[3]))
+    return commits
+
+
+def clean_description(subject: str) -> tuple[str, str | None]:
+    subject = subject.strip()
+    match = CONVENTIONAL_RE.match(subject)
+    if not match:
+        return subject, None
+
+    commit_type = match.group("type").lower()
+    description = match.group("description").strip()
+    if match.group("breaking"):
+        description = f"BREAKING: {description}"
+    return description, commit_type
+
+
+def categorize(subject: str) -> tuple[str, str]:
+    description, commit_type = clean_description(subject)
+    if commit_type and commit_type in CONVENTIONAL_TYPES:
+        return CONVENTIONAL_TYPES[commit_type], description
+
+    lowered = description.lower()
+    first_word = re.split(r"[\s:/_-]+", lowered, maxsplit=1)[0]
+    for category, prefixes in KEYWORD_PREFIXES:
+        if first_word in prefixes:
+            return category, description
+
+    return "Changed", description
+
+
+def grouped_entries(commits: list[Commit]) -> dict[str, list[str]]:
+    groups = {category: [] for category in CATEGORY_ORDER}
+    for commit in commits:
+        category, description = categorize(commit.subject)
+        groups[category].append(f"- {description} ({commit.sha})")
+    return groups
+
+
+def render_changelog(
+    commits: list[Commit],
+    *,
+    since_tag: str | None,
+    version: str,
+    today: str,
+) -> str:
+    groups = grouped_entries(commits)
+    if since_tag:
+        scope = f"Generated from commits since `{since_tag}`."
+    else:
+        scope = "Generated from the full repository history because no git tags were found."
+
+    lines = [
+        "# Changelog",
+        "",
+        f"## [{version}] - {today}",
+        "",
+        scope,
+        "",
+    ]
+
+    for category in CATEGORY_ORDER:
+        lines.append(f"### {category}")
+        entries = groups[category]
+        if entries:
+            lines.extend(entries)
+        else:
+            lines.append("- No changes.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def output_path(repo: Path, requested: str) -> Path:
+    path = Path(requested).expanduser()
+    if path.is_absolute():
+        return path
+    return repo / path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate a structured CHANGELOG.md from git commits since the latest tag."
+    )
+    parser.add_argument("--repo", default=".", help="Git repository to inspect. Defaults to the current directory.")
+    parser.add_argument("--output", default="CHANGELOG.md", help="Output file path. Defaults to CHANGELOG.md in the target repo.")
+    parser.add_argument("--since-tag", help="Override the detected latest tag.")
+    parser.add_argument("--version", default="Unreleased", help="Version heading to use in the generated changelog.")
+    parser.add_argument("--date", default=dt.date.today().isoformat(), help="Date to print in the generated heading.")
+    parser.add_argument("--stdout", action="store_true", help="Print the changelog instead of writing a file.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        repo = normalize_repo(Path(args.repo))
+        since_tag = args.since_tag if args.since_tag is not None else latest_tag(repo)
+        commits = read_commits(repo, since_tag)
+        changelog = render_changelog(
+            commits,
+            since_tag=since_tag,
+            version=args.version,
+            today=args.date,
+        )
+        if args.stdout:
+            sys.stdout.write(changelog)
+            return 0
+
+        destination = output_path(repo, args.output)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(changelog, encoding="utf-8")
+        print(f"Wrote {destination}")
+        return 0
+    except RuntimeError as error:
+        parser.exit(status=1, message=f"generate-changelog: {error}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate-changelog/samples/claude-builders-bounty-sample.md
+++ b/tools/generate-changelog/samples/claude-builders-bounty-sample.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [Unreleased] - 2026-05-11
+
+Generated from the full repository history because no git tags were found.
+
+### Added
+- initial README with bounty board (1aeae2a)
+
+### Fixed
+- No changes.
+
+### Changed
+- Initial commit (a80a580)
+
+### Removed
+- No changes.

--- a/tools/generate-changelog/tests/test_generate_changelog.py
+++ b/tools/generate-changelog/tests/test_generate_changelog.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GENERATOR = REPO_ROOT / "tools" / "generate-changelog" / "generate_changelog.py"
+
+
+def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def write_file(repo: Path, name: str, content: str) -> None:
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def commit(repo: Path, message: str) -> None:
+    run(["git", "add", "."], repo)
+    run(["git", "commit", "-m", message], repo)
+
+
+def init_repo(repo: Path) -> None:
+    run(["git", "init"], repo)
+    run(["git", "config", "user.email", "test@example.com"], repo)
+    run(["git", "config", "user.name", "Test User"], repo)
+
+
+class GenerateChangelogTests(unittest.TestCase):
+    def test_generates_sections_from_commits_since_latest_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            write_file(repo, "app.txt", "initial\n")
+            commit(repo, "chore: initial commit")
+            run(["git", "tag", "v0.1.0"], repo)
+
+            write_file(repo, "feature.txt", "new\n")
+            commit(repo, "feat: add export button")
+            write_file(repo, "bug.txt", "fixed\n")
+            commit(repo, "fix: handle empty response")
+            write_file(repo, "docs.txt", "docs\n")
+            commit(repo, "docs: update setup notes")
+            run(["git", "rm", "feature.txt"], repo)
+            commit(repo, "remove deprecated export fixture")
+
+            run(
+                [
+                    sys.executable,
+                    str(GENERATOR),
+                    "--repo",
+                    str(repo),
+                    "--output",
+                    "CHANGELOG.md",
+                    "--date",
+                    "2026-05-11",
+                ],
+                REPO_ROOT,
+            )
+
+            changelog = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+            self.assertIn("Generated from commits since `v0.1.0`.", changelog)
+            self.assertIn("### Added\n- add export button", changelog)
+            self.assertIn("### Fixed\n- handle empty response", changelog)
+            self.assertIn("### Changed\n- update setup notes", changelog)
+            self.assertIn("### Removed\n- remove deprecated export fixture", changelog)
+            self.assertNotIn("initial commit", changelog)
+
+    def test_no_tag_uses_full_history_and_stdout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            write_file(repo, "app.txt", "initial\n")
+            commit(repo, "add first file")
+
+            result = run(
+                [
+                    sys.executable,
+                    str(GENERATOR),
+                    "--repo",
+                    str(repo),
+                    "--stdout",
+                    "--date",
+                    "2026-05-11",
+                ],
+                REPO_ROOT,
+            )
+
+            self.assertIn("Generated from the full repository history because no git tags were found.", result.stdout)
+            self.assertIn("### Added\n- add first file", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `bash changelog.sh` as the required command entrypoint.
- - Add a Python changelog generator that reads commits since the latest git tag and categorizes them into Added, Fixed, Changed, and Removed.
- - Add a Claude Code command/skill wrapper, a three-step setup README, tests, and a sample output generated from this repository clone.
## Acceptance Criteria
- Works via `bash changelog.sh`.
- - Fetches commits since the latest git tag, with a clear full-history fallback when no tags exist.
- - Auto-categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`.
- - Writes a formatted `CHANGELOG.md`.
- - Includes real-repo sample output at `tools/generate-changelog/samples/claude-builders-bounty-sample.md`.
- - Includes s