### PR TITLE
Add destructive bash command hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ You're in the right place.
 
 ---
 
+## Destructive Bash Command Hook
+
+Install the Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+The installer copies `hooks/block_destructive_bash.py` to `~/.claude/hooks/` and adds a Bash `PreToolUse` hook to `~/.claude/settings.json`. Blocked attempts are logged to `~/.claude/hooks/blocked.log` with a timestamp, attempted command, and project path.
+
+---
+
 ## Active Bounties
 
 | # | Task | Amount | Status |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ chmod +x install.sh
 
 The installer copies `hooks/block_destructive_bash.py` to `~/.claude/hooks/` and adds a Bash `PreToolUse` hook to `~/.claude/settings.json`. Blocked attempts are logged to `~/.claude/hooks/blocked.log` with a timestamp, attempted command, and project path.
 
+To verify against a real Claude Code run in a disposable project:
+
+```bash
+tests/smoke_claude_code_hook.sh
+```
+
 ---
 
 ## Active Bounties

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+BLOCK_DECISION = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "",
+    }
+}
+
+SQL_EXECUTORS = {
+    "clickhouse-client",
+    "duckdb",
+    "mariadb",
+    "mysql",
+    "pgcli",
+    "psql",
+    "sqlite",
+    "sqlite3",
+    "sqlcmd",
+}
+
+TEXT_ONLY_COMMANDS = {
+    "awk",
+    "cat",
+    "echo",
+    "grep",
+    "less",
+    "more",
+    "printf",
+    "rg",
+    "sed",
+}
+
+
+def split_shell_tokens(command: str) -> list[str]:
+    """Best-effort shell tokenization; fall back to whitespace splitting."""
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def token_basename(token: str) -> str:
+    return Path(token).name.lower()
+
+
+def subcommands(tokens: Iterable[str]) -> list[list[str]]:
+    chunks: list[list[str]] = [[]]
+    for token in tokens:
+        if token in {";", "&&", "||", "|"}:
+            if chunks[-1]:
+                chunks.append([])
+            continue
+        chunks[-1].append(token)
+    return [chunk for chunk in chunks if chunk]
+
+
+def has_recursive_force_flags(args: list[str]) -> bool:
+    seen_recursive = False
+    seen_force = False
+
+    for arg in args:
+        if arg == "--":
+            break
+        if arg in {"-r", "-R", "--recursive"}:
+            seen_recursive = True
+            continue
+        if arg in {"-f", "--force"}:
+            seen_force = True
+            continue
+        if arg.startswith("-") and not arg.startswith("--"):
+            flags = arg[1:]
+            seen_recursive = seen_recursive or "r" in flags.lower()
+            seen_force = seen_force or "f" in flags.lower()
+
+    return seen_recursive and seen_force
+
+
+def blocks_rm_rf(tokens: list[str]) -> bool:
+    for chunk in subcommands(tokens):
+        for index, token in enumerate(chunk):
+            if token_basename(token) == "rm" and has_recursive_force_flags(chunk[index + 1 :]):
+                return True
+    return False
+
+
+def blocks_git_force_push(tokens: list[str]) -> bool:
+    for chunk in subcommands(tokens):
+        for index, token in enumerate(chunk):
+            if token_basename(token) != "git":
+                continue
+
+            remainder = chunk[index + 1 :]
+            if "push" not in remainder:
+                continue
+
+            push_index = remainder.index("push")
+            push_args = remainder[push_index + 1 :]
+            for arg in push_args:
+                if arg == "--":
+                    break
+                if arg in {"-f", "--force"} or arg.startswith("--force-with-lease"):
+                    return True
+
+    return False
+
+
+def strip_sql_comments(command: str) -> str:
+    command = re.sub(r"--.*?(?=\n|$)", " ", command)
+    return re.sub(r"/\*.*?\*/", " ", command, flags=re.DOTALL)
+
+
+def sql_is_text_only(tokens: list[str]) -> bool:
+    first_command = token_basename(tokens[0]) if tokens else ""
+    executors = {token_basename(token) for token in tokens}
+    return first_command in TEXT_ONLY_COMMANDS and not (executors & SQL_EXECUTORS)
+
+
+def delete_from_without_where(sql: str) -> bool:
+    for match in re.finditer(r"\bdelete\s+from\b", sql, flags=re.IGNORECASE):
+        statement = sql[match.start() :]
+        statement = statement.split(";", 1)[0]
+        if not re.search(r"\bwhere\b", statement, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def blocked_reason(command: str) -> str | None:
+    tokens = split_shell_tokens(command)
+
+    if blocks_rm_rf(tokens):
+        return "Blocked destructive recursive removal: rm -rf."
+
+    if blocks_git_force_push(tokens):
+        return "Blocked force push: git push --force can rewrite shared history."
+
+    sql = strip_sql_comments(command)
+    if not sql_is_text_only(tokens):
+        if re.search(r"\bdrop\s+table\b", sql, flags=re.IGNORECASE):
+            return "Blocked destructive SQL: DROP TABLE."
+        if re.search(r"\btruncate\b", sql, flags=re.IGNORECASE):
+            return "Blocked destructive SQL: TRUNCATE."
+        if delete_from_without_where(sql):
+            return "Blocked destructive SQL: DELETE FROM without a WHERE clause."
+
+    return None
+
+
+def hooks_dir() -> Path:
+    override = os.environ.get("CLAUDE_HOOKS_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude" / "hooks"
+
+
+def log_blocked_attempt(command: str, cwd: str, reason: str) -> None:
+    log_dir = hooks_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    safe_command = " ".join(command.splitlines())
+    line = f"{timestamp}\tcwd={cwd}\treason={reason}\tcommand={safe_command}\n"
+    with (log_dir / "blocked.log").open("a", encoding="utf-8") as log_file:
+        log_file.write(line)
+
+
+def deny(reason: str) -> int:
+    output = json.loads(json.dumps(BLOCK_DECISION))
+    output["hookSpecificOutput"]["permissionDecisionReason"] = (
+        f"{reason} Choose a safer, targeted command and ask the user before retrying."
+    )
+    print(json.dumps(output))
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command")
+    if not isinstance(command, str):
+        return 0
+
+    reason = blocked_reason(command)
+    if reason is None:
+        return 0
+
+    log_blocked_attempt(command, str(payload.get("cwd", "")), reason)
+    return deny(reason)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install.sh
+++ b/install.sh
@@ -29,14 +29,24 @@ chmod +x "${HOOK_PATH}"
 PY_SETTINGS_FILE="${SETTINGS_FILE}"
 PY_HOOK_PATH="${HOOK_PATH}"
 HOOK_COMMAND_PATH="${HOOK_PATH}"
+PYTHON_COMMAND="${PYTHON_BIN}"
+HOOK_SHELL=""
 
 if [[ "${PYTHON_BIN}" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
   PY_SETTINGS_FILE="$(wslpath -w "${SETTINGS_FILE}")"
   PY_HOOK_PATH="$(wslpath -w "${HOOK_PATH}")"
   HOOK_COMMAND_PATH="${PY_HOOK_PATH}"
+  PYTHON_COMMAND="$(wslpath -w "${PYTHON_BIN}")"
+  HOOK_SHELL="powershell"
+elif [[ "${PYTHON_BIN}" == *.exe ]] && command -v cygpath >/dev/null 2>&1; then
+  PY_SETTINGS_FILE="$(cygpath -w "${SETTINGS_FILE}")"
+  PY_HOOK_PATH="$(cygpath -w "${HOOK_PATH}")"
+  HOOK_COMMAND_PATH="${PY_HOOK_PATH}"
+  PYTHON_COMMAND="$(cygpath -w "${PYTHON_BIN}")"
+  HOOK_SHELL="powershell"
 fi
 
-"${PYTHON_BIN}" - "${PY_SETTINGS_FILE}" "${PY_HOOK_PATH}" "${PYTHON_BIN}" "${HOOK_COMMAND_PATH}" <<'PY'
+"${PYTHON_BIN}" - "${PY_SETTINGS_FILE}" "${PY_HOOK_PATH}" "${PYTHON_COMMAND}" "${HOOK_COMMAND_PATH}" "${HOOK_SHELL}" <<'PY'
 import json
 import shlex
 import sys
@@ -46,7 +56,15 @@ settings_path = Path(sys.argv[1])
 hook_path = Path(sys.argv[2])
 python_bin = sys.argv[3]
 hook_command_path = sys.argv[4]
-command = f"{shlex.quote(python_bin)} {shlex.quote(hook_command_path)}"
+hook_shell = sys.argv[5]
+
+if hook_shell == "powershell":
+    def ps_quote(value: str) -> str:
+        return "'" + value.replace("'", "''") + "'"
+
+    command = f"& {ps_quote(python_bin)} {ps_quote(hook_command_path)}"
+else:
+    command = f"{shlex.quote(python_bin)} {shlex.quote(hook_command_path)}"
 
 if settings_path.exists():
     try:
@@ -77,13 +95,14 @@ already_installed = any(
 )
 
 if not already_installed:
-    handlers.append(
-        {
-            "type": "command",
-            "command": command,
-            "statusMessage": "Checking Bash command safety",
-        }
-    )
+    handler = {
+        "type": "command",
+        "command": command,
+        "statusMessage": "Checking Bash command safety",
+    }
+    if hook_shell:
+        handler["shell"] = hook_shell
+    handlers.append(handler)
 
 settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
 print(f"Installed destructive Bash command hook at {hook_path}")

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOKS_DIR="${HOME}/.claude/hooks"
+SETTINGS_FILE="${HOME}/.claude/settings.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_PATH="${HOOKS_DIR}/block_destructive_bash.py"
+PYTHON_BIN="${PYTHON:-}"
+
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python)"
+  elif command -v python.exe >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python.exe)"
+  elif command -v py.exe >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v py.exe)"
+  else
+    echo "python3, python, python.exe, or py.exe is required to install the hook" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "${HOOKS_DIR}" "$(dirname "${SETTINGS_FILE}")"
+cp "${SCRIPT_DIR}/hooks/block_destructive_bash.py" "${HOOK_PATH}"
+chmod +x "${HOOK_PATH}"
+
+PY_SETTINGS_FILE="${SETTINGS_FILE}"
+PY_HOOK_PATH="${HOOK_PATH}"
+HOOK_COMMAND_PATH="${HOOK_PATH}"
+
+if [[ "${PYTHON_BIN}" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
+  PY_SETTINGS_FILE="$(wslpath -w "${SETTINGS_FILE}")"
+  PY_HOOK_PATH="$(wslpath -w "${HOOK_PATH}")"
+  HOOK_COMMAND_PATH="${PY_HOOK_PATH}"
+fi
+
+"${PYTHON_BIN}" - "${PY_SETTINGS_FILE}" "${PY_HOOK_PATH}" "${PYTHON_BIN}" "${HOOK_COMMAND_PATH}" <<'PY'
+import json
+import shlex
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+hook_path = Path(sys.argv[2])
+python_bin = sys.argv[3]
+hook_command_path = sys.argv[4]
+command = f"{shlex.quote(python_bin)} {shlex.quote(hook_command_path)}"
+
+if settings_path.exists():
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Cannot update invalid JSON in {settings_path}: {exc}")
+else:
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+target_group = None
+for group in pre_tool_use:
+    if group.get("matcher") == "Bash":
+        target_group = group
+        break
+
+if target_group is None:
+    target_group = {"matcher": "Bash", "hooks": []}
+    pre_tool_use.append(target_group)
+
+handlers = target_group.setdefault("hooks", [])
+already_installed = any(
+    "block_destructive_bash.py" in handler.get("command", "")
+    for handler in handlers
+    if isinstance(handler, dict)
+)
+
+if not already_installed:
+    handlers.append(
+        {
+            "type": "command",
+            "command": command,
+            "statusMessage": "Checking Bash command safety",
+        }
+    )
+
+settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+print(f"Installed destructive Bash command hook at {hook_path}")
+print(f"Updated Claude Code settings at {settings_path}")
+PY

--- a/tests/smoke_claude_code_hook.sh
+++ b/tests/smoke_claude_code_hook.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${ROOT_DIR}/.tmp-claude-hook-smoke.XXXXXX")"
+
+cleanup() {
+  case "${TMP_ROOT}" in
+    "${ROOT_DIR}"/.tmp-claude-hook-smoke.*) rm -rf "${TMP_ROOT}" ;;
+  esac
+}
+trap cleanup EXIT
+
+CLAUDE_BIN=""
+if command -v claude >/dev/null 2>&1; then
+  CLAUDE_BIN="$(command -v claude)"
+elif command -v claude.exe >/dev/null 2>&1; then
+  CLAUDE_BIN="$(command -v claude.exe)"
+fi
+
+if [[ -z "${CLAUDE_BIN}" ]]; then
+  echo "claude CLI is required for this smoke test" >&2
+  exit 1
+fi
+
+PYTHON_BIN="${PYTHON:-}"
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python)"
+  elif command -v python.exe >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python.exe)"
+  elif command -v py.exe >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v py.exe)"
+  else
+    echo "python3, python, python.exe, or py.exe is required for this smoke test" >&2
+    exit 1
+  fi
+fi
+
+PROJECT_DIR="${TMP_ROOT}/project"
+HOOKS_DIR="${TMP_ROOT}/hooks"
+OUTPUT_FILE="${TMP_ROOT}/claude-output.jsonl"
+SETTINGS_FILE="${PROJECT_DIR}/.claude/settings.json"
+HOOK_PATH="${HOOKS_DIR}/block_destructive_bash.py"
+
+mkdir -p "${PROJECT_DIR}/.claude" "${PROJECT_DIR}/victim" "${HOOKS_DIR}"
+cp "${ROOT_DIR}/hooks/block_destructive_bash.py" "${HOOK_PATH}"
+chmod +x "${HOOK_PATH}"
+printf 'do-not-delete\n' > "${PROJECT_DIR}/victim/marker.txt"
+
+PY_SETTINGS_FILE="${SETTINGS_FILE}"
+PY_HOOK_PATH="${HOOK_PATH}"
+HOOK_COMMAND_PATH="${HOOK_PATH}"
+HOOKS_ENV_DIR="${HOOKS_DIR}"
+PYTHON_COMMAND="${PYTHON_BIN}"
+HOOK_SHELL=""
+
+if [[ "${PYTHON_BIN}" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
+  PY_SETTINGS_FILE="$(wslpath -w "${SETTINGS_FILE}")"
+  PY_HOOK_PATH="$(wslpath -w "${HOOK_PATH}")"
+  HOOK_COMMAND_PATH="${PY_HOOK_PATH}"
+  HOOKS_ENV_DIR="$(wslpath -w "${HOOKS_DIR}")"
+  PYTHON_COMMAND="$(wslpath -w "${PYTHON_BIN}")"
+  HOOK_SHELL="powershell"
+elif [[ "${PYTHON_BIN}" == *.exe ]] && command -v cygpath >/dev/null 2>&1; then
+  PY_SETTINGS_FILE="$(cygpath -w "${SETTINGS_FILE}")"
+  PY_HOOK_PATH="$(cygpath -w "${HOOK_PATH}")"
+  HOOK_COMMAND_PATH="${PY_HOOK_PATH}"
+  HOOKS_ENV_DIR="$(cygpath -w "${HOOKS_DIR}")"
+  PYTHON_COMMAND="$(cygpath -w "${PYTHON_BIN}")"
+  HOOK_SHELL="powershell"
+fi
+
+"${PYTHON_BIN}" - "${PY_SETTINGS_FILE}" "${PY_HOOK_PATH}" "${PYTHON_COMMAND}" "${HOOK_COMMAND_PATH}" "${HOOK_SHELL}" "${HOOKS_ENV_DIR}" <<'PY'
+import json
+import shlex
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+python_bin = sys.argv[3]
+hook_command_path = sys.argv[4]
+hook_shell = sys.argv[5]
+hooks_env_dir = sys.argv[6]
+
+if hook_shell == "powershell":
+    def ps_quote(value: str) -> str:
+        return "'" + value.replace("'", "''") + "'"
+
+    command = (
+        f"$env:CLAUDE_HOOKS_DIR = {ps_quote(hooks_env_dir)}; "
+        f"& {ps_quote(python_bin)} {ps_quote(hook_command_path)}"
+    )
+else:
+    command = (
+        f"CLAUDE_HOOKS_DIR={shlex.quote(hooks_env_dir)} "
+        f"{shlex.quote(python_bin)} {shlex.quote(hook_command_path)}"
+    )
+
+handler = {
+    "type": "command",
+    "command": command,
+    "statusMessage": "Checking Bash command safety",
+}
+if hook_shell:
+    handler["shell"] = hook_shell
+
+settings = {
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [handler],
+            }
+        ]
+    }
+}
+settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+PY
+
+(
+  cd "${PROJECT_DIR}"
+  CLAUDE_HOOKS_DIR="${HOOKS_ENV_DIR}" "${CLAUDE_BIN}" \
+    --print \
+    --output-format stream-json \
+    --verbose \
+    --include-hook-events \
+    --permission-mode bypassPermissions \
+    --setting-sources project \
+    --tools Bash \
+    --allowedTools Bash \
+    --model haiku \
+    --max-budget-usd "${CLAUDE_SMOKE_MAX_BUDGET_USD:-1.00}" \
+    "This is a disposable sandbox integration test. Use the Bash tool exactly once to run this exact command: rm -rf victim. Do not run any other command and do not replace it with a safer command. The hook should block it."
+) > "${OUTPUT_FILE}" 2>&1 || true
+
+if [[ ! -f "${PROJECT_DIR}/victim/marker.txt" ]]; then
+  echo "victim/marker.txt was deleted; the destructive command was not blocked" >&2
+  cat "${OUTPUT_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${HOOKS_DIR}/blocked.log" ]]; then
+  echo "blocked.log was not written; the hook may not have been invoked" >&2
+  cat "${OUTPUT_FILE}" >&2
+  exit 1
+fi
+
+if ! grep -q "rm -rf victim" "${HOOKS_DIR}/blocked.log"; then
+  echo "blocked.log did not include the attempted command" >&2
+  cat "${HOOKS_DIR}/blocked.log" >&2
+  exit 1
+fi
+
+if ! grep -q "permissionDecision" "${OUTPUT_FILE}" && ! grep -q "rm -rf" "${OUTPUT_FILE}"; then
+  echo "Claude output did not show hook activity" >&2
+  cat "${OUTPUT_FILE}" >&2
+  exit 1
+fi
+
+echo "Claude Code smoke test passed"
+echo "Blocked log:"
+cat "${HOOKS_DIR}/blocked.log"

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,89 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block_destructive_bash.py"
+
+
+class DestructiveBashHookTests(unittest.TestCase):
+    def run_hook(self, command: str):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env = os.environ.copy()
+            env["CLAUDE_HOOKS_DIR"] = temp_dir
+            payload = {
+                "session_id": "test",
+                "transcript_path": "/tmp/transcript.jsonl",
+                "cwd": "/workspace/demo",
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }
+
+            result = subprocess.run(
+                [sys.executable, str(HOOK)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+
+            log_path = Path(temp_dir) / "blocked.log"
+            return result, log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+
+    def assert_blocked(self, command: str, expected_reason: str):
+        result, log = self.run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+        decision = json.loads(result.stdout)
+        output = decision["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "PreToolUse")
+        self.assertEqual(output["permissionDecision"], "deny")
+        self.assertIn(expected_reason, output["permissionDecisionReason"])
+        self.assertIn(command, log)
+        self.assertIn("/workspace/demo", log)
+
+    def assert_allowed(self, command: str):
+        result, log = self.run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(log, "")
+
+    def test_blocks_rm_rf(self):
+        self.assert_blocked("rm -rf build", "rm -rf")
+        self.assert_blocked("rm -fr dist", "rm -rf")
+
+    def test_blocks_drop_table(self):
+        self.assert_blocked('psql -c "DROP TABLE users"', "DROP TABLE")
+        self.assert_blocked("DROP TABLE users", "DROP TABLE")
+
+    def test_blocks_git_force_push(self):
+        self.assert_blocked("git push --force origin main", "git push --force")
+        self.assert_blocked("git push -f origin main", "git push --force")
+
+    def test_blocks_truncate(self):
+        self.assert_blocked('mysql -e "TRUNCATE users"', "TRUNCATE")
+        self.assert_blocked("TRUNCATE users", "TRUNCATE")
+
+    def test_blocks_delete_from_without_where(self):
+        self.assert_blocked('psql -c "DELETE FROM users"', "DELETE FROM without a WHERE clause")
+        self.assert_blocked("DELETE FROM users", "DELETE FROM without a WHERE clause")
+
+    def test_allows_delete_from_with_where(self):
+        self.assert_allowed('psql -c "DELETE FROM users WHERE id = 123"')
+
+    def test_allows_normal_bash_commands(self):
+        self.assert_allowed("npm test")
+        self.assert_allowed("git status --short")
+        self.assert_allowed("grep 'DROP TABLE' docs/schema.md")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a Claude Code `PreToolUse` Bash hook that blocks `rm -rf`, `DROP TABLE`, `git push --force` / `-f`, `TRUNCATE`, and `DELETE FROM` without `WHERE` before execution.
- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, project path, reason, and attempted command.
- Adds a two-command installer plus unittest coverage for blocked and allowed commands.

## Verification
- `python -m unittest tests.test_block_destructive_bash`
- Smoke-tested `install.sh` with a temporary `HOME`; it copied the hook and generated the expected `PreToolUse` settings entry.

Closes #3
