### PR TITLE
Add Next.js SQLite SaaS CLAUDE template

### DIFF
--- a/samples/nextjs-sqlite-claude-smoke.md
+++ b/samples/nextjs-sqlite-claude-smoke.md
@@ -1,0 +1,38 @@
+# Claude Code Smoke Test: Next.js SQLite Template
+
+Environment:
+
+- Project scaffold: `npx create-next-app@15.5.18 nextjs-sqlite-template-smoke-clean --ts --tailwind --eslint --app --src-dir --import-alias "@/*" --use-npm --skip-install --yes`
+- Template placement: copied `templates/nextjs-sqlite-saas/CLAUDE.md` to the scaffolded project root.
+- Claude Code: `claude -p` with file-editing tools disallowed.
+
+Prompt:
+
+```text
+Read CLAUDE.md and the project tree. Do not edit files. Do not ask clarifying questions. Return exactly two Markdown sections: 'Conventions I will follow' with five bullets grounded in CLAUDE.md, and 'Files I would create before editing' with paths for an authenticated team invite workflow using SQLite persistence.
+```
+
+Observed response:
+
+```markdown
+## Conventions I will follow
+
+- Server actions end in `.action.ts` and return typed result objects: `{ ok: true, data }` or `{ ok: false, fieldErrors, formError }`
+- Database query modules end in `.query.ts` and contain SQL access functions, keeping SQL separate from business logic
+- Validation schemas end in `.schema.ts` using Zod at every server boundary for type safety
+- SQL migrations use `YYYYMMDDHHMM_description.sql` format and are explicit forward migrations with rollback notes
+- Service functions in `server/services` coordinate use cases like `inviteTeamMember`, defining one function per user intent
+
+## Files I would create before editing
+
+- `db/migrations/202605111030_create_invites.sql` - SQL migration to create invites table with foreign keys
+- `db/queries/invites.query.ts` - SQL access functions for invite CRUD operations
+- `lib/validation/invite.schema.ts` - Zod validation schemas for invite input/output
+- `server/actions/invite-team-member.action.ts` - Server action handling invite form submission
+- `server/services/invites.ts` - Business logic service orchestrating invite workflow
+- `app/(app)/team-members/invite/page.tsx` - Authenticated invite form page
+- `components/forms/InviteForm.tsx` - Progressive form component for team member invites
+- `tests/integration/invite-team-member.action.test.ts` - Integration tests covering validation and persistence
+```
+
+Result: Claude Code used the template context to infer stack, migrations, server actions, service boundaries, validation, and test files without asking clarifying questions.

--- a/templates/nextjs-sqlite-saas/CLAUDE.md
+++ b/templates/nextjs-sqlite-saas/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md - Next.js 15 + SQLite SaaS
+
+Use this file as the default project context for a greenfield SaaS app built with Next.js 15 App Router, TypeScript, Tailwind CSS, and SQLite through `better-sqlite3` for local deployments or Turso/libSQL for hosted deployments.
+
+## Stack And Versions
+
+- Runtime: Node.js 22 LTS, TypeScript strict mode, Next.js 15 App Router, React Server Components by default.
+- Database: SQLite. Use `better-sqlite3` for single-server apps and Turso/libSQL only when edge or hosted replication is required.
+- Validation: Zod at every server boundary.
+- Styling: Tailwind CSS plus small local components.
+- Testing: unit tests for pure logic, integration tests for server actions and route handlers, and one happy-path Playwright test per paid workflow.
+
+Reason: this stack keeps SaaS iteration fast while preserving a clear line between server-only data access and client interactivity.
+
+## Folder Structure
+
+```text
+app/
+  (marketing)/
+  (app)/
+    dashboard/
+    settings/
+  api/
+components/
+  ui/
+  forms/
+db/
+  client.ts
+  migrations/
+  queries/
+lib/
+  auth/
+  env.ts
+  validation/
+server/
+  actions/
+  services/
+tests/
+  integration/
+  unit/
+```
+
+- `app/(marketing)` contains public pages and must not import database clients.
+- `app/(app)` contains authenticated SaaS pages. Fetch data in server components, not client effects.
+- `db/client.ts` is the only module that opens a SQLite connection.
+- `db/queries` contains SQL access functions.
+- `server/services` coordinates use cases such as onboarding, billing, invites, exports, and account deletion.
+- `lib/env.ts` validates environment variables once at startup.
+
+Reason: this structure prevents data access from spreading into UI files and keeps refactors cheap when the SaaS grows.
+
+## Naming Conventions
+
+- Route folders use kebab-case: `team-members`, `billing-history`.
+- React components use PascalCase filenames: `PlanSelector.tsx`.
+- Server actions end in `.action.ts`: `update-profile.action.ts`.
+- Database query modules end in `.query.ts`: `users.query.ts`.
+- Validation schemas end in `.schema.ts`: `invite.schema.ts`.
+- Test files mirror the module under test: `users.query.test.ts`.
+- SQL migrations use `YYYYMMDDHHMM_description.sql`, for example `202605111030_create_users.sql`.
+
+Reason: suffixes make import direction obvious and reduce accidental client imports of server-only code.
+
+## Dev Commands
+
+Use these commands unless `package.json` says otherwise:
+
+```bash
+npm run dev
+npm run lint
+npm run typecheck
+npm run test
+npm run test:e2e
+npm run db:migrate
+npm run db:studio
+```
+
+Before opening a PR, run `lint`, `typecheck`, tests affected by the change, and `db:migrate` against a disposable SQLite database when migrations changed.
+
+Reason: SQLite migration mistakes are easy to miss until runtime, so migration verification is part of normal development.
+
+## SQL And Migration Conventions
+
+- Write explicit SQL migrations in `db/migrations`. Do not rely on implicit sync or destructive ORM push commands.
+- Every schema change gets a forward migration and a rollback note in the migration comment when rollback is practical.
+- Use additive migrations first: create nullable column, backfill, then enforce `NOT NULL` in a later migration.
+- Always enable foreign keys when opening a SQLite connection: `PRAGMA foreign_keys = ON`.
+- Use transactions for multi-step writes and any migration that touches existing data.
+- Never delete user data in a migration unless the migration name and PR description explicitly call out the deletion.
+- Store timestamps as ISO 8601 UTC text unless the existing schema already uses integer epoch milliseconds.
+- Put PII in the smallest possible table surface and document retention/deletion behavior in the service that owns it.
+
+Reason: SQLite is reliable when schema changes are deliberate; unsafe migration shortcuts create data loss risk.
+
+## Component Patterns
+
+- Default to server components. Add `"use client"` only for browser state, event handlers, focus management, or client-only APIs.
+- Keep forms progressive: server action handles the write, Zod validates input, and the UI renders field-level errors.
+- Use URL search params for shareable filters and tabs; use local state for transient UI only.
+- Keep route pages thin. Move business decisions into `server/services`.
+- Use optimistic UI only when the rollback path is obvious and tested.
+- Components should accept domain objects or view models, not database rows with unused fields.
+
+Reason: App Router works best when data loading stays server-side and client components stay intentionally small.
+
+## API And Server Action Patterns
+
+- Route handlers are for external clients, webhooks, file downloads, or integrations. Prefer server actions for first-party forms.
+- Authenticate at the top of every server action and route handler.
+- Authorize against the resource, not just the session. Check organization membership, role, and ownership before reads and writes.
+- Return typed result objects from server actions: `{ ok: true, data }` or `{ ok: false, fieldErrors, formError }`.
+- Do not throw user-facing validation errors; reserve thrown errors for unexpected failures.
+- Log server-side failures with enough context to debug, but never log secrets, tokens, full cookies, card data, or raw PII payloads.
+
+Reason: SaaS bugs are usually authorization or boundary bugs, so every boundary needs the same shape.
+
+## Patterns To Follow
+
+- Define one service function per user intent, such as `inviteTeamMember` or `cancelSubscription`.
+- Keep SQL in query modules and compose it in services.
+- Add tests around money, permissions, deletion, exports, and migrations.
+- Update docs when adding environment variables, migrations, billing states, or background jobs.
+- Prefer small PRs that include a migration, service code, UI, and tests for one workflow.
+- Use `lib/env.ts` for environment parsing and type-safe configuration instead of reading `process.env` throughout the app.
+
+Reason: user intent is a better boundary than framework file type, and configuration bugs should fail early.
+
+## Anti-Patterns To Avoid
+
+- Do not import `db/client.ts` into client components. It leaks server-only code into the browser bundle.
+- Do not put business rules in JSX. It makes testing and authorization review harder.
+- Do not create catch-all `utils` modules. Name modules after the domain they serve.
+- Do not use `any` for request input, SQL rows, or payment provider payloads.
+- Do not silently swallow server action errors. Return a typed error or log and rethrow.
+- Do not run destructive SQL outside a transaction.
+- Do not add a new dependency for a problem already solved by the platform or one small helper.
+- Do not store secrets in `.env.local.example`, docs, tests, screenshots, or fixtures.
+
+Reason: these shortcuts make a small SaaS feel faster for a week and slower for every month after.
+
+## Definition Of Done
+
+- User-facing workflow works from an empty SQLite database after `npm run db:migrate`.
+- Relevant unit or integration tests cover validation, authorization, and persistence.
+- `npm run lint` and `npm run typecheck` pass.
+- New environment variables are documented in `.env.example`.
+- New migrations are committed and named correctly.
+- PR description lists verification commands and any data migration risk.
+
+Reason: greenfield projects become production projects suddenly; this checklist keeps the handoff clean.

--- a/templates/nextjs-sqlite-saas/README.md
+++ b/templates/nextjs-sqlite-saas/README.md
@@ -1,0 +1,21 @@
+# Next.js 15 + SQLite SaaS CLAUDE.md Template
+
+Install in 3 steps:
+
+1. Create or open a Next.js 15 App Router project.
+2. Copy `templates/nextjs-sqlite-saas/CLAUDE.md` to the project root.
+3. Start Claude Code in that root and ask it to implement a small SaaS workflow.
+
+This template is opinionated for TypeScript, server components by default, SQLite migrations, service-layer authorization, Zod validation, and small client components.
+
+## Smoke Test Prompt
+
+After copying the file into a greenfield project, run this prompt in Claude Code:
+
+```text
+Using this CLAUDE.md, add an authenticated team invite workflow with SQLite persistence. First summarize the project conventions you will follow, then list the files you would create before editing. Do not edit files.
+```
+
+The expected response should name the App Router/server-action flow, keep SQL under `db/queries`, put business logic in `server/services`, include a migration under `db/migrations`, and avoid asking which stack or database to use.
+
+See `samples/nextjs-sqlite-claude-smoke.md` for an example Claude Code response from a fresh `create-next-app` scaffold.

--- a/tests/test_nextjs_sqlite_template.py
+++ b/tests/test_nextjs_sqlite_template.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "templates" / "nextjs-sqlite-saas" / "CLAUDE.md"
+SMOKE = ROOT / "samples" / "nextjs-sqlite-claude-smoke.md"
+
+
+class NextSqliteClaudeTemplateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_expected_sections_are_present(self):
+        required_sections = [
+            "## Stack And Versions",
+            "## Folder Structure",
+            "## Naming Conventions",
+            "## Dev Commands",
+            "## SQL And Migration Conventions",
+            "## Component Patterns",
+            "## Patterns To Follow",
+            "## Anti-Patterns To Avoid",
+        ]
+        for section in required_sections:
+            with self.subTest(section=section):
+                self.assertIn(section, self.text)
+
+    def test_database_guidance_is_specific_to_sqlite(self):
+        required_terms = [
+            "better-sqlite3",
+            "Turso/libSQL",
+            "PRAGMA foreign_keys = ON",
+            "db/migrations",
+            "YYYYMMDDHHMM_description.sql",
+            "transactions",
+        ]
+        for term in required_terms:
+            with self.subTest(term=term):
+                self.assertIn(term, self.text)
+
+    def test_rules_include_reasons(self):
+        reason_count = len(re.findall(r"^Reason:", self.text, flags=re.MULTILINE))
+        self.assertGreaterEqual(reason_count, 8)
+
+    def test_template_is_not_generic(self):
+        stack_terms = [
+            "Next.js 15",
+            "App Router",
+            "React Server Components",
+            "SQLite",
+            "server actions",
+            "Zod",
+        ]
+        for term in stack_terms:
+            with self.subTest(term=term):
+                self.assertIn(term, self.text)
+
+    def test_smoke_evidence_matches_template_expectations(self):
+        smoke = SMOKE.read_text(encoding="utf-8")
+        expected_terms = [
+            "create-next-app@15.5.18",
+            "Claude Code",
+            "without asking clarifying questions",
+            "db/migrations/202605111030_create_invites.sql",
+            "server/actions/invite-team-member.action.ts",
+            "lib/validation/invite.schema.ts",
+        ]
+        for term in expected_terms:
+            with self.subTest(term=term):
+                self.assertIn(term, smoke)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an opinionated `CLAUDE.md` template for a Next.js 15 + SQLite SaaS project.
- Document stack, folder layout, naming, dev commands, SQL migration rules, component patterns, and anti-patterns with reasons.
- Add a fresh-project Claude Code smoke test transcript plus a small Python regression test for template coverage.

## Verification
- `python tests/test_nextjs_sqlite_template.py`
- `npx create-next-app@15.5.18 nextjs-sqlite-template-smoke-clean --ts --tailwind --eslint --app --src-dir --import-alias "@/*" --use-npm --skip-install --yes`
- Copied the template into the scaffold root and ran Claude Code with editing tools disallowed; it returned grounded conventions and file paths for an authenticated SQLite-backed invite workflow without clarifying questions.

Fixes #2.
/claim #2