### PR TITLE
Add changelog generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ You're in the right place.
 
 ---
 
+## Changelog Generator
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `bash changelog.sh` from inside the repository.
+3. Review and commit the generated `CHANGELOG.md`.
+
+Run `bash tests/smoke_changelog.sh` to verify that only commits after the latest tag are included and categorized into Added, Fixed, Changed, and Removed sections.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+cd "$git_root"
+
+if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+  cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## Unreleased
+
+_No commits found._
+EOF
+  echo "Generated CHANGELOG.md"
+  exit 0
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$latest_tag" ]]; then
+  log_range="${latest_tag}..HEAD"
+  range_description="after ${latest_tag}"
+else
+  log_range="HEAD"
+  range_description="from the full git history"
+fi
+
+added=()
+fixed=()
+changed=()
+removed=()
+
+strip_commit_prefix() {
+  printf '%s' "$1" | sed -E 's/^([A-Za-z]+)(\([^)]+\))?(!)?:[[:space:]]*//'
+}
+
+category_for_subject() {
+  local subject="$1"
+  local lower
+  local added_type='^(feat|feature|add|added|new)(\([^)]+\))?(!)?:'
+  local fixed_type='^(fix|fixed|bug|bugfix|hotfix)(\([^)]+\))?(!)?:'
+  local removed_type='^(remove|removed|delete|deleted|deprecate|deprecated)(\([^)]+\))?(!)?:'
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$lower" =~ $added_type ]] ||
+     [[ "$lower" =~ ^(add|added|new)[[:space:]] ]]; then
+    echo "added"
+  elif [[ "$lower" =~ $fixed_type ]] ||
+       [[ "$lower" =~ ^(fix|fixed|bugfix)[[:space:]] ]]; then
+    echo "fixed"
+  elif [[ "$lower" =~ $removed_type ]] ||
+       [[ "$lower" =~ ^(remove|removed|delete|deleted|deprecate|deprecated)[[:space:]] ]]; then
+    echo "removed"
+  else
+    echo "changed"
+  fi
+}
+
+while IFS=$'\x1f' read -r subject hash || [[ -n "${subject:-}" ]]; do
+  [[ -z "${subject:-}" ]] && continue
+
+  clean_subject="$(strip_commit_prefix "$subject")"
+  entry="- ${clean_subject} (${hash})"
+
+  case "$(category_for_subject "$subject")" in
+    added) added+=("$entry") ;;
+    fixed) fixed+=("$entry") ;;
+    removed) removed+=("$entry") ;;
+    *) changed+=("$entry") ;;
+  esac
+done < <(git log --no-merges --reverse --pretty=format:'%s%x1f%h' "$log_range")
+
+write_section() {
+  local title="$1"
+  shift
+
+  echo "### ${title}"
+  if [[ "$#" -eq 0 ]]; then
+    echo "- No changes."
+  else
+    printf '%s\n' "$@"
+  fi
+  echo
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "## Unreleased - $(date +%Y-%m-%d)"
+  echo
+  echo "_Generated from git commits ${range_description}._"
+  echo
+  write_section "Added" "${added[@]}"
+  write_section "Fixed" "${fixed[@]}"
+  write_section "Changed" "${changed[@]}"
+  write_section "Removed" "${removed[@]}"
+} > CHANGELOG.md
+
+echo "Generated CHANGELOG.md"

--- a/tests/smoke_changelog.sh
+++ b/tests/smoke_changelog.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+git -C "$tmp_dir" init -q
+git -C "$tmp_dir" config user.email "smoke@example.com"
+git -C "$tmp_dir" config user.name "Smoke Test"
+git -C "$tmp_dir" config core.autocrlf false
+
+commit_change() {
+  local message="$1"
+  local contents="$2"
+
+  printf '%s\n' "$contents" >> "$tmp_dir/app.txt"
+  git -C "$tmp_dir" add app.txt
+  git -C "$tmp_dir" commit -q -m "$message"
+}
+
+commit_change "feat: old feature before tag" "old feature"
+git -C "$tmp_dir" tag v1.0.0
+
+commit_change "feat: add dashboard filters" "filters"
+commit_change "fix(auth): handle expired sessions" "sessions"
+commit_change "refactor: simplify billing service" "billing"
+commit_change "remove: delete legacy import path" "legacy"
+
+cp "$repo_root/changelog.sh" "$tmp_dir/changelog.sh"
+
+(
+  cd "$tmp_dir"
+  bash ./changelog.sh >/dev/null
+)
+
+output="$tmp_dir/CHANGELOG.md"
+
+assert_contains() {
+  local expected="$1"
+
+  if ! grep -Fq -- "$expected" "$output"; then
+    echo "Expected CHANGELOG.md to contain: $expected" >&2
+    echo "--- CHANGELOG.md ---" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local unexpected="$1"
+
+  if grep -Fq -- "$unexpected" "$output"; then
+    echo "Expected CHANGELOG.md not to contain: $unexpected" >&2
+    echo "--- CHANGELOG.md ---" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+}
+
+assert_contains "Generated from git commits after v1.0.0"
+assert_contains "### Added"
+assert_contains "- add dashboard filters"
+assert_contains "### Fixed"
+assert_contains "- handle expired sessions"
+assert_contains "### Changed"
+assert_contains "- simplify billing service"
+assert_contains "### Removed"
+assert_contains "- delete legacy import path"
+assert_not_contains "old feature before tag"
+
+echo "Smoke test passed. Sample output:"
+cat "$output"


### PR DESCRIPTION
## Summary
- Add `changelog.sh` so the bounty works via `bash changelog.sh`.
- Detect the latest reachable git tag and generate `CHANGELOG.md` from commits after that tag.
- Categorize commit subjects into Added, Fixed, Changed, and Removed, with README setup in 3 steps.
- Add a smoke test that builds a tagged git repo and verifies pre-tag commits are excluded.

## Verification
- `C:\Program Files\Git\bin\bash.exe tests/smoke_changelog.sh`
- `C:\Program Files\Git\bin\bash.exe changelog.sh` against this cloned GitHub repo, which has no tags, to verify the full-history fallback.

## Sample output from smoke test
```md
# Changelog

## Unreleased - 2026-05-11

_Generated from git commits after v1.0.0._

### Added
- add dashboard filters (736680e)

### Fixed
- handle expired sessions (10b1ddb)

### Changed
- simplify billing service (9e4fa5d)

### Removed
- delete legacy import path (9ffe0f9)
```

Closes #1
