### PR TITLE
feat(issue3): pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/submissions/issue3-pre-tool-use-hook/README.md
+++ b/submissions/issue3-pre-tool-use-hook/README.md
@@ -1,0 +1,84 @@
+# Pre-tool-use Guard Hook
+
+A Claude Code `pre-tool-use` hook that blocks destructive bash commands before they execute.
+
+## Install (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks
+curl -o ~/.claude/hooks/pre_tool_use_guard.py \
+  https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/submissions/issue3-pre-tool-use-hook/pre_tool_use_guard.py
+```
+
+Then add to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/pre_tool_use_guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Blocked Patterns
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf` / `rm -fr` | Recursive force deletion |
+| `DROP TABLE` | Destructive DB operation |
+| `TRUNCATE` | Destructive DB operation |
+| `DELETE FROM <table>` (no WHERE) | Unscoped deletion |
+| `git push --force` / `-f` | Destructive force push |
+
+Safe commands are **not** blocked:
+- `rm -f specific_file.txt` — single file removal
+- `DELETE FROM logs WHERE created_at < '2020-01-01'` — scoped deletion
+- `git push origin feature-branch` — normal push
+- `grep -r 'DROP TABLE' .` — searching for patterns
+
+## Blocked Attempt Log
+
+Every blocked command is logged to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-05-11 23:30:00] BLOCKED: rm -rf: recursive force deletion
+  project: /Users/you/my-project
+  command: rm -rf ./dist
+
+[2026-05-11 23:31:00] BLOCKED: git push --force: destructive force push
+  project: /Users/you/my-project
+  command: git push origin main --force
+```
+
+## How It Works
+
+Claude Code calls the hook with a JSON payload on stdin before every `Bash` tool call:
+
+```json
+{"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/foo"}}
+```
+
+If the command matches a destructive pattern, the hook outputs:
+```json
+{"decision": "block", "reason": "...explanation for Claude..."}
+```
+
+Claude sees the reason and stops execution — it will not retry the blocked command.
+
+## Tests
+
+```bash
+python3 -m pytest tests/ -v
+```
+
+All 15 cases pass: 9 blocked, 6 allowed.

--- a/submissions/issue3-pre-tool-use-hook/pre_tool_use_guard.py
+++ b/submissions/issue3-pre-tool-use-hook/pre_tool_use_guard.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Pre-tool-use hook: blocks destructive bash commands before execution.
+Follows Claude Code hooks format. Install to ~/.claude/hooks/
+"""
+import json
+import re
+import sys
+import os
+from datetime import datetime
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+# Each entry: (pattern, reason, flags)
+# SQL patterns use a negative-lookahead approach:
+#   block bare SQL statements but not when they appear inside single/double quotes
+#   (i.e., as arguments to grep, echo, etc.)
+DESTRUCTIVE_PATTERNS = [
+    (r"\brm\s+(-\w*\s+)*-[rR][fF]\b", "rm -rf: recursive force deletion", 0),
+    (r"\brm\s+(-\w*\s+)*-[fF][rR]\b", "rm -fr: recursive force deletion", 0),
+    # Block SQL when the statement appears as a command (not inside quotes as a string arg)
+    (r"^(?!\s*(?:grep|echo|cat|awk|sed|find|printf)\b)\s*DROP\s+TABLE\b",
+     "DROP TABLE: destructive database operation", re.IGNORECASE | re.MULTILINE),
+    (r"^(?!\s*(?:grep|echo|cat|awk|sed|find|printf)\b)\s*TRUNCATE\b",
+     "TRUNCATE: destructive database operation", re.IGNORECASE | re.MULTILINE),
+    (r"^(?!\s*(?:grep|echo|cat|awk|sed|find|printf)\b)\s*DELETE\s+FROM\s+\w+\s*(?:;|$)",
+     "DELETE FROM without WHERE clause", re.IGNORECASE | re.MULTILINE),
+    (r"\bgit\s+push\s+(?:\S+\s+)*--force\b", "git push --force: destructive force push", 0),
+    (r"\bgit\s+push\s+(?:\S+\s+)*-f\b", "git push -f: destructive force push", 0),
+]
+
+
+def log_blocked(command: str, reason: str, project_path: str) -> None:
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open(LOG_FILE, "a") as f:
+        f.write(f"[{timestamp}] BLOCKED: {reason}\n")
+        f.write(f"  project: {project_path}\n")
+        f.write(f"  command: {command}\n\n")
+
+
+def check_command(command: str) -> tuple[bool, str]:
+    """Returns (is_blocked, reason)."""
+    for pattern, reason, flags in DESTRUCTIVE_PATTERNS:
+        if re.search(pattern, command, flags):
+            return True, reason
+    return False, ""
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    project_path = os.environ.get("CLAUDE_PROJECT_PATH", os.getcwd())
+
+    blocked, reason = check_command(command)
+    if not blocked:
+        sys.exit(0)
+
+    log_blocked(command, reason, project_path)
+
+    print(
+        json.dumps({
+            "decision": "block",
+            "reason": (
+                f"[BLOCKED by pre-tool-use hook] {reason}.\n"
+                f"Command: {command!r}\n"
+                f"This command has been logged to {LOG_FILE}.\n"
+                "If this was intentional, ask the user to run it manually in a terminal."
+            ),
+        })
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/issue3-pre-tool-use-hook/tests/test_pre_tool_use_guard.py
+++ b/submissions/issue3-pre-tool-use-hook/tests/test_pre_tool_use_guard.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for pre_tool_use_guard.py"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from pre_tool_use_guard import check_command
+
+
+class TestDestructivePatterns(unittest.TestCase):
+    # --- should block ---
+    def test_rm_rf(self):
+        blocked, reason = check_command("rm -rf /tmp/foo")
+        self.assertTrue(blocked)
+        self.assertIn("recursive force", reason)
+
+    def test_rm_fr(self):
+        blocked, _ = check_command("rm -fr ./build")
+        self.assertTrue(blocked)
+
+    def test_rm_rf_with_flags(self):
+        blocked, _ = check_command("rm -rf --no-preserve-root /")
+        self.assertTrue(blocked)
+
+    def test_drop_table(self):
+        blocked, _ = check_command("DROP TABLE users;")
+        self.assertTrue(blocked)
+
+    def test_drop_table_lowercase(self):
+        blocked, _ = check_command("drop table sessions;")
+        self.assertTrue(blocked)
+
+    def test_truncate(self):
+        blocked, _ = check_command("TRUNCATE orders;")
+        self.assertTrue(blocked)
+
+    def test_delete_without_where(self):
+        blocked, _ = check_command("DELETE FROM logs;")
+        self.assertTrue(blocked)
+
+    def test_git_push_force(self):
+        blocked, _ = check_command("git push origin main --force")
+        self.assertTrue(blocked)
+
+    def test_git_push_f(self):
+        blocked, _ = check_command("git push -f origin main")
+        self.assertTrue(blocked)
+
+    # --- should allow ---
+    def test_safe_rm(self):
+        blocked, _ = check_command("rm -f /tmp/specific_file.txt")
+        self.assertFalse(blocked)
+
+    def test_safe_delete_with_where(self):
+        blocked, _ = check_command("DELETE FROM logs WHERE created_at < '2020-01-01';")
+        self.assertFalse(blocked)
+
+    def test_safe_git_push(self):
+        blocked, _ = check_command("git push origin feature-branch")
+        self.assertFalse(blocked)
+
+    def test_safe_ls(self):
+        blocked, _ = check_command("ls -la")
+        self.assertFalse(blocked)
+
+    def test_safe_grep(self):
+        blocked, _ = check_command("grep -r 'DROP TABLE' .")
+        self.assertFalse(blocked)
+
+    def test_empty_command(self):
+        blocked, _ = check_command("")
+        self.assertFalse(blocked)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Summary

A Python `pre-tool-use` hook for Claude Code that intercepts dangerous bash commands before they execute.

## Files

```
submissions/issue3-pre-tool-use-hook/
├── pre_tool_use_guard.py   # The hook
├── README.md               # Install in 2 commands
└── tests/
    └── test_pre_tool_use_guard.py  # 15 unit tests
```

## Acceptance Criteria

- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, project path
- [x] Displays a clear message to Claude explaining why the command was blocked
- [x] Does not interfere with normal bash commands (safe grep, rm -f, DELETE with WHERE, normal push all pass)
- [x] README with installation in 2 commands or fewer

## Install

```bash
mkdir -p ~/.claude/hooks
curl -o ~/.claude/hooks/pre_tool_use_guard.py   https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/submissions/issue3-pre-tool-use-hook/pre_tool_use_guard.py
```

Add to `~/.claude/settings.json`:

```json
{
  "hooks": {
    "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/pre_tool_use_guard.py"}]}]
  }
}
```

## Tests

```
python3 -m pytest tests/ -v
15 passed in 0.02s
```

9 blocked cases + 6 safe cases verified. Smart SQL detection avoids false positives on `grep -r 'DROP TABLE' .`

## Opire

/opire try