### PR TITLE
feat: add changelog generator skill

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,16 @@
+---
+description: Generate CHANGELOG.md from git history since the latest tag
+allowed-tools: Bash
+---
+
+Run the repository changelog generator:
+
+```bash
+bash changelog.sh
+```
+
+If the user provides an output path, pass it as the first argument:
+
+```bash
+bash changelog.sh "$ARGUMENTS"
+```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ You're in the right place.
 
 ---
 
+## Generate A Changelog
+
+This repo includes a Claude Code command, a native skill, and a Bash fallback for bounty [#1](../../issues/1).
+
+Setup in 3 steps:
+
+1. Copy `changelog.sh` into a target git repository, or invoke it by absolute path.
+2. Run `bash changelog.sh` from that repository root, or use `/generate-changelog` in Claude Code when this repo is available.
+3. Set `CHANGELOG_RANGE=v1.0.0..HEAD` before the command to override the default latest-tag range.
+
+The generated `CHANGELOG.md` groups commits into `Added`, `Fixed`, `Changed`, and `Removed`; see [examples/sample-output.md](examples/sample-output.md) for a run against a real GitHub repository.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+repo_name="$(basename "$repo_root")"
+generated_on="$(date -u +%Y-%m-%d)"
+
+range="${CHANGELOG_RANGE:-}"
+range_label=""
+
+if [[ -n "$range" ]]; then
+  range_label="for range $range"
+else
+  latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+  if [[ -n "$latest_tag" ]]; then
+    range="${latest_tag}..HEAD"
+    range_label="since $latest_tag"
+  else
+    range=""
+    range_label="for all git history"
+  fi
+fi
+
+remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+commit_base_url=""
+if [[ "$remote_url" =~ ^git@github.com:(.*)\.git$ ]]; then
+  commit_base_url="https://github.com/${BASH_REMATCH[1]}/commit"
+elif [[ "$remote_url" =~ ^https://github.com/(.*)\.git$ ]]; then
+  commit_base_url="https://github.com/${BASH_REMATCH[1]}/commit"
+elif [[ "$remote_url" =~ ^https://github.com/(.*)$ ]]; then
+  commit_base_url="https://github.com/${BASH_REMATCH[1]}/commit"
+fi
+
+added=()
+fixed=()
+changed=()
+removed=()
+
+append_commit() {
+  local category="$1"
+  local hash="$2"
+  local subject="$3"
+  local short_hash="${hash:0:7}"
+  local bullet="- ${subject}"
+
+  if [[ -n "$commit_base_url" ]]; then
+    bullet="${bullet} ([${short_hash}](${commit_base_url}/${hash}))"
+  else
+    bullet="${bullet} (${short_hash})"
+  fi
+
+  case "$category" in
+    added) added+=("$bullet") ;;
+    fixed) fixed+=("$bullet") ;;
+    removed) removed+=("$bullet") ;;
+    *) changed+=("$bullet") ;;
+  esac
+}
+
+categorize_subject() {
+  local subject_lower
+  subject_lower="$(printf "%s" "$1" | tr "[:upper:]" "[:lower:]")"
+
+  case "$subject_lower" in
+    feat* | add* | create*) printf "%s" "added" ;;
+    fix* | bug* | patch*) printf "%s" "fixed" ;;
+    remove* | delete* | drop*) printf "%s" "removed" ;;
+    *) printf "%s" "changed" ;;
+  esac
+}
+
+while IFS=$'\t' read -r hash subject; do
+  [[ -z "${hash:-}" ]] && continue
+  category="$(categorize_subject "$subject")"
+  append_commit "$category" "$hash" "$subject"
+done < <(git log --reverse --no-merges --format='%H%x09%s' ${range})
+
+write_section() {
+  local title="$1"
+  shift
+
+  printf "## %s\n\n" "$title"
+  if [[ "$#" -eq 0 ]]; then
+    printf -- "- None\n"
+  else
+    printf "%s\n" "$@"
+  fi
+  printf "\n"
+}
+
+{
+  printf "# Changelog\n\n"
+  printf "Generated on %s for \`%s\` %s.\n\n" "$generated_on" "$repo_name" "$range_label"
+  if [[ "${#added[@]}" -gt 0 ]]; then
+    write_section "Added" "${added[@]}"
+  else
+    write_section "Added"
+  fi
+  if [[ "${#fixed[@]}" -gt 0 ]]; then
+    write_section "Fixed" "${fixed[@]}"
+  else
+    write_section "Fixed"
+  fi
+  if [[ "${#changed[@]}" -gt 0 ]]; then
+    write_section "Changed" "${changed[@]}"
+  else
+    write_section "Changed"
+  fi
+  if [[ "${#removed[@]}" -gt 0 ]]; then
+    write_section "Removed" "${removed[@]}"
+  else
+    write_section "Removed"
+  fi
+} >"$output_file"
+
+echo "Wrote ${output_file}"

--- a/examples/sample-output.md
+++ b/examples/sample-output.md
@@ -1,0 +1,27 @@
+# Changelog
+
+Generated on 2026-05-11 for `circuit-json-to-readable-netlist` for range v0.0.11..HEAD.
+
+## Added
+
+- None
+
+## Fixed
+
+- None
+
+## Changed
+
+- v0.0.11 ([32cbeab](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/32cbeaba08d6246d2e556aa5c58db1924351b27f))
+- Disable routing in tests (#13) ([813dabf](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/813dabf4d18a2f1085d7897d52a55d6f2310bd16))
+- v0.0.12 ([f4e7fde](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/f4e7fdeb2b19007b126f8e6922c345653e0eb3ce))
+- switch to bun, fixes (#15) ([40f5950](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/40f59502aa84d92ce427d9ca3852320503a3d34e))
+- v0.0.13 ([a40178b](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/a40178bebb3167a79a7f74241bc57344a44be619))
+- chore: update the @tscircuit/circuit-json-util package (#20) ([60bdb87](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/60bdb87a95080d383aa3d77ffdefcd9c34de4ba8))
+- v0.0.14 ([5cc4fea](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/5cc4fea57c4e4c1b470dbc76c0f02c06c28b523f))
+- update util dep (#22) ([cf5a14c](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/cf5a14c8c768c90371eb01bd5bf95366286c14d3))
+- v0.0.15 ([5e306b0](https://github.com/tscircuit/circuit-json-to-readable-netlist/commit/5e306b05ae06cd2c8e138a5c2cd06b42c8052ffd))
+
+## Removed
+
+- None

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history.
+---
+
+# Generate Changelog
+
+Use this skill when a user asks to generate or refresh a project changelog from git commits.
+
+## Workflow
+
+1. Run `bash changelog.sh` from the repository root.
+2. Review the generated `CHANGELOG.md` sections: `Added`, `Fixed`, `Changed`, and `Removed`.
+3. Adjust commit messages only if the source history contains unclear wording.
+
+## Behavior
+
+- Uses commits since the latest git tag by default.
+- Supports `CHANGELOG_RANGE=<range> bash changelog.sh` for an explicit git range.
+- Writes a Markdown changelog with commit links when the origin remote is on GitHub.


### PR DESCRIPTION
Fixes #1.

## Summary
- Adds `changelog.sh`, a Bash changelog generator that uses commits since the latest git tag by default.
- Adds a Claude Code `/generate-changelog` command and a native `skills/generate-changelog/SKILL.md` workflow.
- Updates README with setup in 3 steps and includes `examples/sample-output.md` from a real GitHub repo.

## Verification
- `bash -n changelog.sh`
- `bash changelog.sh /tmp/claude-builders-generated-changelog.md`
- `CHANGELOG_RANGE=v0.0.11..HEAD bash /Users/kunpeng/bounty-work/claude-builders-bounty/changelog.sh /tmp/tscircuit-sample-changelog.md` against `tscircuit/circuit-json-to-readable-netlist`
- `git diff --check`

Sample output is committed at `examples/sample-output.md`.