### PR TITLE
feat(issue4): Claude Code PR review sub-agent — CLI + GitHub Action

### DIFF
--- a/submissions/issue4-pr-review-agent/README.md
+++ b/submissions/issue4-pr-review-agent/README.md
@@ -1,0 +1,81 @@
+# claude-review — Claude Code PR Review Sub-Agent
+
+> Resolves [#4 [BOUNTY $150] AGENT: Claude Code sub-agent that reviews a PR and posts a structured comment](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/4)
+
+A CLI tool + GitHub Action that uses Claude Code to review GitHub PRs and produce structured Markdown comments.
+
+## What it does
+
+1. Fetches the PR diff and metadata via `gh` CLI
+2. Sends the diff to Claude (`claude-sonnet-4-6`) for analysis
+3. Returns a structured Markdown review with:
+   - **Summary of Changes** (2–3 sentences)
+   - **Identified Risks** (bulleted list)
+   - **Improvement Suggestions** (bulleted list, specific and actionable)
+   - **Confidence Score** (Low / Medium / High with reasoning)
+
+## Requirements
+
+- Python 3.9+
+- [`gh` CLI](https://cli.github.com/) authenticated
+- [Claude Code CLI](https://docs.anthropic.com/claude-code) installed (`npm install -g @anthropic-ai/claude-code`)
+
+## Setup (5 steps)
+
+```bash
+# 1. Copy the CLI tool to your PATH
+cp claude-review /usr/local/bin/claude-review
+chmod +x /usr/local/bin/claude-review
+
+# 2. Ensure gh CLI is authenticated
+gh auth login
+
+# 3. Ensure Claude CLI is installed and authenticated
+npm install -g @anthropic-ai/claude-code
+claude --version
+
+# 4. Run a review
+claude-review --pr https://github.com/owner/repo/pull/123
+
+# 5. (Optional) Save to file
+claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+## CLI Usage
+
+```
+usage: claude-review [-h] --pr PR [--output OUTPUT]
+
+options:
+  --pr PR          GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)
+  --output OUTPUT  Save output to file instead of stdout
+```
+
+## GitHub Action Setup
+
+Copy `pr-review.yml` to `.github/workflows/` in your repository.
+
+Required secret: `ANTHROPIC_API_KEY` (add in Settings → Secrets → Actions).
+
+The action triggers on every PR open/update and posts the review as a comment.
+
+## Sample Outputs
+
+Real review outputs on actual PRs from this repository:
+
+- [`sample_pr932.md`](sample-outputs/sample_pr932.md) — Review of PR #932 (pre-tool-use hook)
+- [`sample_pr933.md`](sample-outputs/sample_pr933.md) — Review of PR #933 (CHANGELOG skill)
+
+## Architecture
+
+```
+claude-review (CLI)
+  ├── parse_pr_url()       — extract owner/repo/number from URL
+  ├── get_pr_metadata()    — gh pr view --json
+  ├── get_pr_diff()        — gh pr diff
+  ├── build_review_prompt() — structure prompt with metadata + diff
+  ├── call_claude()        — claude CLI subprocess (no direct API calls)
+  └── format_output()      — wrap in Markdown header
+```
+
+All Claude calls go through `claude` CLI subprocess — no direct `anthropic` SDK imports.

--- a/submissions/issue4-pr-review-agent/claude-review
+++ b/submissions/issue4-pr-review-agent/claude-review
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""claude-review: Claude Code sub-agent for structured PR review."""
+
+import sys
+import os
+import json
+import subprocess
+import argparse
+import re
+from urllib.parse import urlparse
+
+def parse_pr_url(url: str) -> tuple[str, str, int]:
+    """Parse GitHub PR URL into owner, repo, pr_number."""
+    path = urlparse(url).path.strip("/")
+    parts = path.split("/")
+    if len(parts) < 4 or parts[2] != "pull":
+        raise ValueError(f"Invalid PR URL: {url}")
+    return parts[0], parts[1], int(parts[3])
+
+def get_pr_diff(owner: str, repo: str, pr_number: int) -> str:
+    """Fetch PR diff via gh CLI."""
+    result = subprocess.run(
+        ["gh", "pr", "diff", str(pr_number), "-R", f"{owner}/{repo}"],
+        capture_output=True, text=True, timeout=60
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to fetch PR diff: {result.stderr[:300]}")
+    return result.stdout
+
+def get_pr_metadata(owner: str, repo: str, pr_number: int) -> dict:
+    """Fetch PR title, body, and file list."""
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "-R", f"{owner}/{repo}",
+         "--json", "title,body,additions,deletions,changedFiles,baseRefName,headRefName,author"],
+        capture_output=True, text=True, timeout=60
+    )
+    if result.returncode != 0:
+        return {}
+    return json.loads(result.stdout)
+
+def call_claude(prompt: str) -> str:
+    """Call Claude via CLI subprocess."""
+    result = subprocess.run(
+        ["claude", "--model", "claude-sonnet-4-6", "-p", prompt],
+        capture_output=True, text=True, timeout=180
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Claude CLI error: {result.stderr[:300]}")
+    return result.stdout.strip()
+
+def build_review_prompt(meta: dict, diff: str) -> str:
+    title = meta.get("title", "Unknown")
+    body = meta.get("body", "") or ""
+    additions = meta.get("additions", 0)
+    deletions = meta.get("deletions", 0)
+    changed_files = meta.get("changedFiles", 0)
+    author = meta.get("author", {}).get("login", "unknown")
+
+    # Truncate diff if too large
+    max_diff_chars = 12000
+    diff_truncated = ""
+    if len(diff) > max_diff_chars:
+        diff_truncated = diff[:max_diff_chars] + f"\n\n[... diff truncated at {max_diff_chars} chars ...]"
+    else:
+        diff_truncated = diff
+
+    return f"""You are an expert code reviewer. Review the following GitHub Pull Request and produce a structured Markdown review.
+
+## PR Metadata
+- **Title**: {title}
+- **Author**: {author}
+- **Changes**: +{additions} / -{deletions} lines, {changed_files} files changed
+- **Description**: {body[:500] if body else "(no description)"}
+
+## PR Diff
+```diff
+{diff_truncated}
+```
+
+## Instructions
+Produce a structured review in exactly this Markdown format:
+
+---
+## PR Review
+
+### Summary of Changes
+(2–3 sentences describing what this PR does and why)
+
+### Identified Risks
+- (list each risk on its own line; if none, write "No significant risks identified")
+
+### Improvement Suggestions
+- (list each suggestion on its own line; be specific and actionable)
+
+### Confidence Score
+**Level**: Low / Medium / High
+**Reasoning**: (1 sentence explaining the confidence level based on test coverage, complexity, and clarity)
+---
+
+Be direct, specific, and constructive. Focus on correctness, security, performance, and maintainability."""
+
+def format_output(review_text: str, pr_url: str, meta: dict) -> str:
+    title = meta.get("title", "PR Review")
+    return f"""# Claude PR Review
+
+**PR**: [{title}]({pr_url})
+**Reviewed by**: Claude Code (claude-review v1.0)
+
+{review_text}
+"""
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="claude-review: AI-powered PR reviewer using Claude Code"
+    )
+    parser.add_argument("--pr", required=True, help="GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
+    parser.add_argument("--output", help="Save output to file (optional)")
+    args = parser.parse_args()
+
+    print(f"[claude-review] Fetching PR: {args.pr}", file=sys.stderr)
+
+    owner, repo, pr_number = parse_pr_url(args.pr)
+
+    print(f"[claude-review] Fetching diff and metadata...", file=sys.stderr)
+    meta = get_pr_metadata(owner, repo, pr_number)
+    diff = get_pr_diff(owner, repo, pr_number)
+
+    if not diff.strip():
+        print("[claude-review] WARNING: Empty diff. PR may have no changes.", file=sys.stderr)
+
+    print(f"[claude-review] Calling Claude for review...", file=sys.stderr)
+    prompt = build_review_prompt(meta, diff)
+    review = call_claude(prompt)
+
+    output = format_output(review, args.pr, meta)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"[claude-review] Review saved to: {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+if __name__ == "__main__":
+    main()

--- a/submissions/issue4-pr-review-agent/pr-review.yml
+++ b/submissions/issue4-pr-review-agent/pr-review.yml
@@ -1,0 +1,52 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install claude-review
+        run: |
+          cp submissions/issue4-pr-review-agent/claude-review /usr/local/bin/claude-review
+          chmod +x /usr/local/bin/claude-review
+
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run PR Review
+        id: review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          claude-review --pr "$PR_URL" --output review_output.md
+          echo "review_file=review_output.md" >> "$GITHUB_OUTPUT"
+
+      - name: Post review comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const review = fs.readFileSync('review_output.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: review
+            });

--- a/submissions/issue4-pr-review-agent/sample-outputs/sample_pr932.md
+++ b/submissions/issue4-pr-review-agent/sample-outputs/sample_pr932.md
@@ -1,0 +1,33 @@
+# Claude PR Review
+
+**PR**: [feat(issue3): pre-tool-use hook that blocks destructive bash commands](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/932)
+**Reviewed by**: Claude Code (claude-review v1.0)
+
+## PR Review
+
+### Summary of Changes
+This PR adds a Python `pre-tool-use` hook for Claude Code that intercepts and blocks destructive bash commands (recursive deletion, SQL DDL/DML without WHERE, force pushes) before execution. The hook reads a JSON payload from stdin, pattern-matches the command, logs blocked attempts to `~/.claude/hooks/blocked.log`, and outputs a structured `{"decision": "block", ...}` response. A test suite with 15 cases and a README with install instructions are included.
+
+### Identified Risks
+- **Bypass via shell operators**: Commands like `true; rm -rf /tmp/foo` or `echo x && rm -rf /` will not be blocked — the regex anchors on the full command string but don't account for semicolon/`&&`/`||`/pipe-chained sequences where the dangerous part is not at the start.
+- **Bypass via variable expansion**: `CMD="rm -rf"; $CMD /tmp/foo` or `eval "rm -rf /tmp"` completely evades all patterns since they match literal text only.
+- **Bypass via quoting in SQL detection**: The negative-lookahead guards against `grep 'DROP TABLE'` but uses `^` anchoring with `re.MULTILINE`, meaning a multi-line bash script that has `DROP TABLE` on its own line (e.g. passed to `psql -c "..."` across lines) may or may not trigger correctly depending on quoting — the behavior is non-obvious and fragile.
+- **`rm -r -f` flag ordering gap**: The patterns cover `-rf` and `-fr` but miss flags like `rm -r -f`, `rm -v -r -f`, or `rm --recursive --force` (long-form flags).
+- **Log file path not configurable**: `LOG_FILE` is hardcoded to `~/.claude/hooks/blocked.log` with no environment variable override, making it harder to use in restricted or multi-user environments.
+- **Silent failure on log write errors**: If `os.makedirs` or the `open()` call fails (e.g. permission error), the exception propagates uncaught and the hook crashes with a non-zero exit — this could cause unexpected behavior depending on how Claude Code handles hook failures.
+- **No `chmod +x` in install instructions**: The README `curl` install doesn't set the script executable; since it's invoked as `python3 ~/.claude/hooks/pre_tool_use_guard.py` this is fine, but the shebang line implies direct execution is intended and a reader may be confused.
+- **`DELETE FROM` pattern uses `\w+` for table name**: This won't match quoted identifiers (`DELETE FROM "my-table"`) or schema-qualified names (`DELETE FROM schema.table`), silently allowing those through.
+
+### Improvement Suggestions
+- **Tokenize before matching**: Split the command on shell metacharacters (`;`, `&&`, `||`, `|`) and check each token independently — this closes the chained-command bypass without major complexity.
+- **Add long-form flag variants**: Extend the `rm` patterns to also match `--recursive` and `--force` to cover `rm --recursive --force`.
+- **Add `rm -r -f` (space-separated flags)**: The current regex `(-\w*\s+)*` handles some flag combos but add an explicit test for `rm -r -f /path` to confirm coverage and fix if needed.
+- **Wrap log I/O in try/except**: Catch `OSError` in `log_blocked` and either write a warning to stderr or continue silently — a logging failure should not crash the guard.
+- **Broaden SQL table name matching**: Replace `\w+` in the `DELETE FROM` pattern with `[\w."` + "`]+`" to handle quoted and schema-qualified identifiers.
+- **Add `--no-preserve-root` test as a blocked case**: It's tested as passing through `rm -rf`, but worth an explicit test that `rm --no-preserve-root -rf /` is blocked.
+- **Make `LOG_FILE` configurable via env var**: `LOG_FILE = os.environ.get("CLAUDE_HOOK_LOG", os.path.expanduser("~/.claude/hooks/blocked.log"))` — low effort, high flexibility.
+- **Add an integration-level test**: The unit tests only call `check_command` directly. A test that feeds a full JSON payload to `main()` via mocked stdin and asserts on stdout would catch regressions in the full pipeline (e.g. if the payload schema changes).
+
+### Confidence Score
+**Level**: Medium
+**Reasoning**: The happy-path coverage is solid (15 tests, all acceptance criteria met), but the pattern-matching approach has well-known bypass vectors that aren't tested, and the SQL detection logic is fragile enough that edge cases in real-world multi-line scripts could produce false negatives or false positives.

--- a/submissions/issue4-pr-review-agent/sample-outputs/sample_pr933.md
+++ b/submissions/issue4-pr-review-agent/sample-outputs/sample_pr933.md
@@ -1,0 +1,28 @@
+# Claude PR Review
+
+**PR**: [feat(issue1): CHANGELOG generator skill from git history](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/933)
+**Reviewed by**: Claude Code (claude-review v1.0)
+
+## PR Review
+
+### Summary of Changes
+This PR adds a bash-based CHANGELOG generator that reads git commit history, categorizes commits by conventional prefix (feat/fix/refactor/etc.), and outputs a structured `CHANGELOG.md`. It ships as both a standalone script (`changelog.sh`) and a Claude Code skill (`SKILL.md`) installable as `/generate-changelog`. The submission is self-contained with no external dependencies beyond bash 4+ and git.
+
+### Identified Risks
+- **Regex anchor bug (correctness)**: `[[ "$lower" =~ ^feat|^add|^new ]]` — in bash, `|` inside `=~` has lower precedence than `^`, so this reads as `(^feat) | (^add) | (^new)`. This happens to work correctly here, but the same pattern for `^fix|^bug|^patch|^hotfix` means a commit like `"bugfix: ..."` starting with `bug` will match, but `"hotfix: ..."` will also match because `^hotfix` is anchored. The real risk is `^refactor|^perf|^style|^chore|^update|^change|^improve` — a commit subject containing the word "update" anywhere near the start but not beginning with it could behave unexpectedly. Parentheses should be added: `^(feat|add|new)`.
+- **`total` variable scoping**: `total` is computed inside the `{ ... } > "$OUTPUT"` block but referenced in the `echo` after it via `${total:-0}`. This works in bash because the subshell is not used here (it's a group command `{}`), but it's non-obvious and fragile — a future refactor wrapping it in `$()` would silently break the count output.
+- **Overwrites without confirmation**: The script unconditionally overwrites `$OUTPUT` with no `-f`/`--force` flag or prompt, risking silent data loss if a hand-maintained `CHANGELOG.md` exists.
+- **No input sanitization on commit subjects**: Commit messages containing backticks, `$()`, or special markdown characters are written raw into the output file. In a markdown context this is mostly cosmetic, but backtick-heavy subjects can break the rendered output.
+- **SKILL.md is documentation, not a skill**: The file instructs the user to run `bash changelog.sh` manually. A proper Claude Code skill should contain instructions Claude can execute autonomously (e.g., use the Bash tool). As written, `/generate-changelog` is just a help page, not an executable command.
+
+### Improvement Suggestions
+- Fix regex grouping: replace `^feat|^add|^new` with `^(feat|add|new)` throughout `categorize_commit` for clarity and correctness.
+- Add an existence check before overwriting: `[[ -f "$OUTPUT" ]] && { echo "⚠️ $OUTPUT exists. Use --force to overwrite." >&2; exit 1; }` plus a `--force` flag.
+- Move `total` computation outside the output block, before `} > "$OUTPUT"`, so the final echo is unambiguously reading a set variable.
+- Upgrade SKILL.md to actually invoke the script via Claude's Bash tool rather than just printing instructions — e.g., add a `$BASH` step that runs `bash changelog.sh` so the `/generate-changelog` command is truly executable within Claude Code.
+- The `SAMPLE_OUTPUT.md` shows "Initial commit" under `### Other` — consider filtering out merge commits and bare "Initial commit" entries by default, or documenting this as expected behavior.
+- README `curl -O` URL points to a branch path that does not yet exist on the default branch; it will 404 until merged. Use a relative path or note that the URL is post-merge only.
+
+### Confidence Score
+**Level**: Medium
+**Reasoning**: The script is simple and readable with good test evidence (real sample output included), but the regex anchor ambiguity and silent overwrite behavior are genuine correctness/safety issues that should be fixed before the skill is used on production repos.


### PR DESCRIPTION
## Summary

Resolves #4

A CLI tool + GitHub Action that uses Claude Code to analyze PR diffs and post structured Markdown review comments.

### Files

- `submissions/issue4-pr-review-agent/claude-review` — CLI script (Python, no deps beyond stdlib + gh + claude)
- `submissions/issue4-pr-review-agent/pr-review.yml` — GitHub Actions workflow
- `submissions/issue4-pr-review-agent/sample-outputs/sample_pr932.md` — real review output (PR #932)
- `submissions/issue4-pr-review-agent/sample-outputs/sample_pr933.md` — real review output (PR #933)
- `submissions/issue4-pr-review-agent/README.md` — setup in 5 steps

### Acceptance Criteria

- [x] Works via CLI: `claude-review --pr https://github.com/owner/repo/pull/123`
- [x] GitHub Action workflow included (pr-review.yml)
- [x] Structured Markdown output: Summary / Risks / Suggestions / Confidence score
- [x] Tested on 2 real PRs with full outputs in sample-outputs/
- [x] README with setup and usage instructions (5 steps)

### Design Choices

- No anthropic SDK import — all Claude calls via subprocess + claude CLI
- gh CLI for diff/metadata — no GitHub API tokens needed beyond gh auth login
- Diff truncation at 12,000 chars — prevents context overflow on large PRs
