### PR TITLE
Add destructive Bash guard hook

### DIFF
--- a/hooks/destructive-bash-guard/README.md
+++ b/hooks/destructive-bash-guard/README.md
@@ -1,0 +1,38 @@
+# Destructive Bash Guard
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## Install
+
+```bash
+python3 hooks/destructive-bash-guard/install.py
+```
+
+Restart Claude Code or run `/hooks` to confirm the `PreToolUse` matcher for `Bash` is enabled.
+
+## What It Blocks
+
+- Recursive forced deletes such as `rm -rf`, `rm -fr`, `rm -R --force`, and split flags like `rm -r -f`.
+- SQL table deletion commands such as `DROP TABLE`.
+- SQL truncate commands such as `TRUNCATE` or `TRUNCATE TABLE`.
+- Forced git pushes such as `git push --force`, `git push --force-with-lease`, and `git push -f`.
+- `DELETE FROM ...` statements that do not include a `WHERE` clause before the statement terminator.
+
+Allowed commands produce no output and exit normally, so routine Bash commands keep working.
+
+## Files
+
+- `destructive_bash_guard.py`: the hook invoked by Claude Code.
+- `install.py`: copies the hook to `~/.claude/hooks/` and updates `~/.claude/settings.json`.
+- `settings.example.json`: the hook configuration that `install.py` merges.
+- `test_destructive_bash_guard.py`: unit tests for dangerous and safe command cases.
+
+## Log Format
+
+Every blocked command is appended to `~/.claude/hooks/blocked.log`:
+
+```text
+2026-05-11T09:30:00Z	project=/path/to/project	rule=rm_recursive_force	command=rm -rf build
+```
+
+The hook uses Claude Code's structured `PreToolUse` response format so the attempted Bash tool call is denied and Claude sees the exact reason.

--- a/hooks/destructive-bash-guard/destructive_bash_guard.py
+++ b/hooks/destructive-bash-guard/destructive_bash_guard.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+@dataclass(frozen=True)
+class Violation:
+      rule: str
+      reason: str
+
+
+def _strip_strings(text: str) -> str:
+      """Replace quoted strings with whitespace while preserving statement shape."""
+      result: list[str] = []
+      quote: str | None = None
+      escaped = False
+
+    for char in text:
+              if escaped:
+                            result.append(" ")
+                            escaped = False
+                            continue
+                        if char == "\\":
+                                      result.append(" " if quote else char)
+                                      escaped = bool(quote)
+                                      continue
+                                  if quot. :
+                                               if char == quote:
+                                                                 quote = None
+                                                             result.append(" ")
+            continue
+        if char in {"'", '"', "`"}:
+                      quote = char
+            result.append(" ")
+            continue
+        result.append(char)
+
+    return "".join(result)
+
+
+def _shell_words(command: str) -> list[str]:
+      try:
+                return shlex.split(command, posix=True)
+except ValueError:
+          return []
+
+
+  def _has_rm_recursive_force(command: str) -> bool:
+        words = _shell_words(command)
+        for index, word in enumerate(words):
+                  if word != "rm":
+                                continue
+                            flags: set[str] = set()
+                  for arg in words[index + 1 :]:
+                                if arg == "--":
+                                                  break
+                                              if not arg.startswith("-"):
+                                                                continue
+                                                            if arg in {"--recursive", "--dir"}:
+                                                                              flags.add("r")
+elif arg == "--force":
+                flags.add("f")
+elif arg.startswith("--"):
+                continue
+else:
+                flags.update(arg.lstrip("-").lower())
+        if "r" in flags and "f" in flags:
+                      return True
+
+    return bool(re.search(r"(^|[;&|]\s*)rm\s+-(?:[^\s;&|]*r[^\s;&|]*f|[^\s;&|]*f[^\s;&|]*r)\b", command))
+
+
+def _has_force_push(command: str) -> bool:
+      words = _shell_words(command)
+      for index, word in enumerate(words):
+                if word != "git":
+                              continue
+
+                remaining = words[index + 1 :]
+                while len(remaining) >= 2 and remaining[0] in {"-C", "-c"}:
+                              remaining = remaining[2:]
+                          while remaining and remaining[0].startswith("--") and remaining[0] not in {"--force", "--force-with-lease"}:
+                                        remaining = remaining[1:]
+
+                if not remaining or remaining[0] != "push":
+                              continue
+                          if any(arg in {"--force", "--force-with-lease", "-f"} or arg.startswith("--force-with-lease=") for arg in remaining[1:]):
+                                        return True
+
+            return False
+
+
+def _delete_from_without_where(sqlish: str) -> bool:
+      for match in re.finditer(r"\bdelete\s+from\b", sqlish, flags=re.IGNORECASE):
+                tail = sqlish[match.end() :]
+                statement = re.split(r"[;\n\r]", tail, maxsplit=1)[0]
+                if not re.search(r"\bwhere\b", statement, flags=re.IGNORECASE):
+                              return True
+                      return False
+
+
+def _sql_detection_text(command: str) -> str:
+      words = _shell_words(command)
+    if not words:
+              return command
+
+    starts_as_text_output = words[0] in {"echo", "printf"}
+    pipes_to_database = bool(re.search(r"\|\s*(psql|mysql|sqlite3|duckdb)\b", command, flags=re.IGNORECASE))
+    if starts_as_text_output and not pipes_to_database:
+              return _strip_strings(command)
+    return command
+
+
+def find_violation(command: str) -> Violation | None:
+      sqlish = _sql_detection_text(command)
+
+    checks = [
+              (
+                            "rm_recursive_force",
+                            _has_rm_recursive_force(command),
+                            "Blocked destructive recursive delete. Remove either recursive or force flags, or ask the user to approve the exact deletion.",
+              ),
+              (
+                            "git_force_push",
+                            _has_force_push(command),
+                            "Blocked force push. Use a normal git push or ask the user to approve rewriting remote history.",
+              ),
+              (
+                            "drop_table",
+                            bool(re.search(r"\bdrop\s+table\b", sqlish, flags=re.IGNORECASE)),
+                            "Blocked DROP TABLE. Destructive database schema changes require explicit user approval.",
+              ),
+              (
+                            "truncate",
+                            bool(re.search(r"\btruncate(?:\s+table)?\b", sqlish, flags=re.IGNORECASE)),
+                            "Blocked TRUNCATE. Destructive database table clearing requires explicit user approval.",
+              ),
+              (
+                            "delete_from_without_where",
+                            _delete_from_without_where(sqlish),
+                            "Blocked DELETE FROM without a WHERE clause. Add a WHERE clause or ask the user to approve a full-table delete.",
+              ),
+    ]
+
+    for rule, matched, reason in checks:
+              if matched:
+                            return Violation(rule=rule, reason=reason)
+                    return None
+
+
+def _write_block_log(command: str, cwd: str, violation: Violation) -> None:
+      LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    sanitized_command = command.replace("\n", "\\n").replace("\t", "\\t")
+    sanitized_cwd = cwd.replace("\n", "\\n").replace("\t", "\\t")
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+              log_file.write(f"{timestamp}\tproject={sanitized_cwd}\trule={violation.rule}\tcommand={sanitized_command}\n")
+
+
+def _deny(reason: str) -> None:
+      response = {
+                "hookSpecificOutput": {
+                              "hookEventName": "PreToolUse",
+                              "permissionDecision": "deny",
+                              "permissionDecisionReason": reason,
+                }
+      }
+    print(json.dumps(response, separators=(",", ":")))
+
+
+def handle(payload: dict) -> int:
+      if payload.get("tool_name") != "Bash":
+                return 0
+
+    command = payload.get("tool_input", {}).get("command", "")
+    if not isinstance(command, str) or not command.strip():
+              return 0
+
+    violation = find_violation(command)
+    if not violation:
+              return 0
+
+    cwd = payload.get("cwd") or os.getcwd()
+    _write_block_log(command, str(cwd), violation)
+    _deny(violation.reason)
+    return 0
+
+
+def main() -> int:
+      try:
+                payload = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+        print(f"destructive-bash-guard: invalid hook JSON: {exc}", file=sys.stderr)
+        return 1
+
+    return handle(payload)
+
+
+if __name__ == "__main__":
+      raise SystemExit(main())

--- a/hooks/destructive-bash-guard/destructive_bash_guard.py
+++ b/hooks/destructive-bash-guard/destructive_bash_guard.py
@@ -18,32 +18,32 @@ LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
 
 @dataclass(frozen=True)
 class Violation:
-      rule: str
-      reason: str
+    rule: str
+    reason: str
 
 
 def _strip_strings(text: str) -> str:
-      """Replace quoted strings with whitespace while preserving statement shape."""
-      result: list[str] = []
-      quote: str | None = None
-      escaped = False
+    """Replace quoted strings with whitespace while preserving statement shape."""
+    result: list[str] = []
+    quote: str | None = None
+    escaped = False
 
     for char in text:
-              if escaped:
-                            result.append(" ")
-                            escaped = False
-                            continue
-                        if char == "\\":
-                                      result.append(" " if quote else char)
-                                      escaped = bool(quote)
-                                      continue
-                                  if quot. :
-                                               if char == quote:
-                                                                 quote = None
-                                                             result.append(" ")
+        if escaped:
+            result.append(" ")
+            escaped = False
+            continue
+        if char == "\\":
+            result.append(" " if quote else char)
+            escaped = bool(quote)
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            result.append(" ")
             continue
         if char in {"'", '"', "`"}:
-                      quote = char
+            quote = char
             result.append(" ")
             continue
         result.append(char)
@@ -52,146 +52,146 @@ def _strip_strings(text: str) -> str:
 
 
 def _shell_words(command: str) -> list[str]:
-      try:
-                return shlex.split(command, posix=True)
-except ValueError:
-          return []
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return []
 
 
-  def _has_rm_recursive_force(command: str) -> bool:
-        words = _shell_words(command)
-        for index, word in enumerate(words):
-                  if word != "rm":
-                                continue
-                            flags: set[str] = set()
-                  for arg in words[index + 1 :]:
-                                if arg == "--":
-                                                  break
-                                              if not arg.startswith("-"):
-                                                                continue
-                                                            if arg in {"--recursive", "--dir"}:
-                                                                              flags.add("r")
-elif arg == "--force":
-                flags.add("f")
-elif arg.startswith("--"):
+def _has_rm_recursive_force(command: str) -> bool:
+    words = _shell_words(command)
+    for index, word in enumerate(words):
+        if word != "rm":
+            continue
+        flags: set[str] = set()
+        for arg in words[index + 1 :]:
+            if arg == "--":
+                break
+            if not arg.startswith("-"):
                 continue
-else:
+            if arg in {"--recursive", "--dir"}:
+                flags.add("r")
+            elif arg == "--force":
+                flags.add("f")
+            elif arg.startswith("--"):
+                continue
+            else:
                 flags.update(arg.lstrip("-").lower())
         if "r" in flags and "f" in flags:
-                      return True
+            return True
 
     return bool(re.search(r"(^|[;&|]\s*)rm\s+-(?:[^\s;&|]*r[^\s;&|]*f|[^\s;&|]*f[^\s;&|]*r)\b", command))
 
 
 def _has_force_push(command: str) -> bool:
-      words = _shell_words(command)
-      for index, word in enumerate(words):
-                if word != "git":
-                              continue
+    words = _shell_words(command)
+    for index, word in enumerate(words):
+        if word != "git":
+            continue
 
-                remaining = words[index + 1 :]
-                while len(remaining) >= 2 and remaining[0] in {"-C", "-c"}:
-                              remaining = remaining[2:]
-                          while remaining and remaining[0].startswith("--") and remaining[0] not in {"--force", "--force-with-lease"}:
-                                        remaining = remaining[1:]
+        remaining = words[index + 1 :]
+        while len(remaining) >= 2 and remaining[0] in {"-C", "-c"}:
+            remaining = remaining[2:]
+        while remaining and remaining[0].startswith("--") and remaining[0] not in {"--force", "--force-with-lease"}:
+            remaining = remaining[1:]
 
-                if not remaining or remaining[0] != "push":
-                              continue
-                          if any(arg in {"--force", "--force-with-lease", "-f"} or arg.startswith("--force-with-lease=") for arg in remaining[1:]):
-                                        return True
+        if not remaining or remaining[0] != "push":
+            continue
+        if any(arg in {"--force", "--force-with-lease", "-f"} or arg.startswith("--force-with-lease=") for arg in remaining[1:]):
+            return True
 
-            return False
+    return False
 
 
 def _delete_from_without_where(sqlish: str) -> bool:
-      for match in re.finditer(r"\bdelete\s+from\b", sqlish, flags=re.IGNORECASE):
-                tail = sqlish[match.end() :]
-                statement = re.split(r"[;\n\r]", tail, maxsplit=1)[0]
-                if not re.search(r"\bwhere\b", statement, flags=re.IGNORECASE):
-                              return True
-                      return False
+    for match in re.finditer(r"\bdelete\s+from\b", sqlish, flags=re.IGNORECASE):
+        tail = sqlish[match.end() :]
+        statement = re.split(r"[;\n\r]", tail, maxsplit=1)[0]
+        if not re.search(r"\bwhere\b", statement, flags=re.IGNORECASE):
+            return True
+    return False
 
 
 def _sql_detection_text(command: str) -> str:
-      words = _shell_words(command)
+    words = _shell_words(command)
     if not words:
-              return command
+        return command
 
     starts_as_text_output = words[0] in {"echo", "printf"}
     pipes_to_database = bool(re.search(r"\|\s*(psql|mysql|sqlite3|duckdb)\b", command, flags=re.IGNORECASE))
     if starts_as_text_output and not pipes_to_database:
-              return _strip_strings(command)
+        return _strip_strings(command)
     return command
 
 
 def find_violation(command: str) -> Violation | None:
-      sqlish = _sql_detection_text(command)
+    sqlish = _sql_detection_text(command)
 
     checks = [
-              (
-                            "rm_recursive_force",
-                            _has_rm_recursive_force(command),
-                            "Blocked destructive recursive delete. Remove either recursive or force flags, or ask the user to approve the exact deletion.",
-              ),
-              (
-                            "git_force_push",
-                            _has_force_push(command),
-                            "Blocked force push. Use a normal git push or ask the user to approve rewriting remote history.",
-              ),
-              (
-                            "drop_table",
-                            bool(re.search(r"\bdrop\s+table\b", sqlish, flags=re.IGNORECASE)),
-                            "Blocked DROP TABLE. Destructive database schema changes require explicit user approval.",
-              ),
-              (
-                            "truncate",
-                            bool(re.search(r"\btruncate(?:\s+table)?\b", sqlish, flags=re.IGNORECASE)),
-                            "Blocked TRUNCATE. Destructive database table clearing requires explicit user approval.",
-              ),
-              (
-                            "delete_from_without_where",
-                            _delete_from_without_where(sqlish),
-                            "Blocked DELETE FROM without a WHERE clause. Add a WHERE clause or ask the user to approve a full-table delete.",
-              ),
+        (
+            "rm_recursive_force",
+            _has_rm_recursive_force(command),
+            "Blocked destructive recursive delete. Remove either recursive or force flags, or ask the user to approve the exact deletion.",
+        ),
+        (
+            "git_force_push",
+            _has_force_push(command),
+            "Blocked force push. Use a normal git push or ask the user to approve rewriting remote history.",
+        ),
+        (
+            "drop_table",
+            bool(re.search(r"\bdrop\s+table\b", sqlish, flags=re.IGNORECASE)),
+            "Blocked DROP TABLE. Destructive database schema changes require explicit user approval.",
+        ),
+        (
+            "truncate",
+            bool(re.search(r"\btruncate(?:\s+table)?\b", sqlish, flags=re.IGNORECASE)),
+            "Blocked TRUNCATE. Destructive database table clearing requires explicit user approval.",
+        ),
+        (
+            "delete_from_without_where",
+            _delete_from_without_where(sqlish),
+            "Blocked DELETE FROM without a WHERE clause. Add a WHERE clause or ask the user to approve a full-table delete.",
+        ),
     ]
 
     for rule, matched, reason in checks:
-              if matched:
-                            return Violation(rule=rule, reason=reason)
-                    return None
+        if matched:
+            return Violation(rule=rule, reason=reason)
+    return None
 
 
 def _write_block_log(command: str, cwd: str, violation: Violation) -> None:
-      LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     sanitized_command = command.replace("\n", "\\n").replace("\t", "\\t")
     sanitized_cwd = cwd.replace("\n", "\\n").replace("\t", "\\t")
     with LOG_PATH.open("a", encoding="utf-8") as log_file:
-              log_file.write(f"{timestamp}\tproject={sanitized_cwd}\trule={violation.rule}\tcommand={sanitized_command}\n")
+        log_file.write(f"{timestamp}\tproject={sanitized_cwd}\trule={violation.rule}\tcommand={sanitized_command}\n")
 
 
 def _deny(reason: str) -> None:
-      response = {
-                "hookSpecificOutput": {
-                              "hookEventName": "PreToolUse",
-                              "permissionDecision": "deny",
-                              "permissionDecisionReason": reason,
-                }
-      }
+    response = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
     print(json.dumps(response, separators=(",", ":")))
 
 
 def handle(payload: dict) -> int:
-      if payload.get("tool_name") != "Bash":
-                return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
 
     command = payload.get("tool_input", {}).get("command", "")
     if not isinstance(command, str) or not command.strip():
-              return 0
+        return 0
 
     violation = find_violation(command)
     if not violation:
-              return 0
+        return 0
 
     cwd = payload.get("cwd") or os.getcwd()
     _write_block_log(command, str(cwd), violation)
@@ -200,9 +200,9 @@ def handle(payload: dict) -> int:
 
 
 def main() -> int:
-      try:
-                payload = json.load(sys.stdin)
-except json.JSONDecodeError as exc:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
         print(f"destructive-bash-guard: invalid hook JSON: {exc}", file=sys.stderr)
         return 1
 
@@ -210,4 +210,4 @@ except json.JSONDecodeError as exc:
 
 
 if __name__ == "__main__":
-      raise SystemExit(main())
+    raise SystemExit(main())

--- a/hooks/destructive-bash-guard/install.py
+++ b/hooks/destructive-bash-guard/install.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Install Destructive Bash Guard into the user's Claude Code hooks."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("destructive_bash_guard.py")
+HOOK_DIR = Path.home() / ".claude" / "hooks"
+TARGET = HOOK_DIR / "destructive_bash_guard.py"
+SETTINGS = Path.home() / ".claude" / "settings.json"
+HOOK_COMMAND = 'python3 "$HOME/.claude/hooks/destructive_bash_guard.py"'
+
+
+def load_settings() -> dict:
+    if not SETTINGS.exists():
+        return {}
+    with SETTINGS.open("r", encoding="utf-8") as settings_file:
+        return json.load(settings_file)
+
+
+def install_hook_file() -> None:
+    HOOK_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE, TARGET)
+    TARGET.chmod(0o755)
+
+
+def merge_settings(settings: dict) -> dict:
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    bash_group = None
+    for group in pre_tool_use:
+        if group.get("matcher") == "Bash":
+            bash_group = group
+            break
+
+    if bash_group is None:
+        bash_group = {"matcher": "Bash", "hooks": []}
+        pre_tool_use.append(bash_group)
+
+    command_hooks = bash_group.setdefault("hooks", [])
+    if not any(hook.get("type") == "command" and hook.get("command") == HOOK_COMMAND for hook in command_hooks):
+        command_hooks.append(
+            {
+                "type": "command",
+                "command": HOOK_COMMAND,
+                "timeout": 5,
+            }
+        )
+
+    return settings
+
+
+def save_settings(settings: dict) -> None:
+    SETTINGS.parent.mkdir(parents=True, exist_ok=True)
+    with SETTINGS.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+
+def main() -> int:
+    install_hook_file()
+    save_settings(merge_settings(load_settings()))
+    print(f"Installed hook: {TARGET}")
+    print(f"Updated settings: {SETTINGS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-bash-guard/settings.example.json
+++ b/hooks/destructive-bash-guard/settings.example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/destructive_bash_guard.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/destructive-bash-guard/test_destructive_bash_guard.py
+++ b/hooks/destructive-bash-guard/test_destructive_bash_guard.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for Destructive Bash Guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase, main
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).with_name("destructive_bash_guard.py")
+SPEC = importlib.util.spec_from_file_location("destructive_bash_guard", MODULE_PATH)
+guard = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = guard
+SPEC.loader.exec_module(guard)
+
+
+def payload(command: str) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": "/tmp/example-project",
+        "tool_input": {"command": command},
+    }
+
+
+class DetectionTests(TestCase):
+    def assert_rule(self, command: str, rule: str) -> None:
+        violation = guard.find_violation(command)
+        self.assertIsNotNone(violation, command)
+        self.assertEqual(violation.rule, rule)
+
+    def assert_allowed(self, command: str) -> None:
+        self.assertIsNone(guard.find_violation(command), command)
+
+    def test_blocks_recursive_forced_rm_variants(self) -> None:
+        for command in ("rm -rf build", "rm -fr build", "rm -R --force dist", "rm -r -f node_modules"):
+            self.assert_rule(command, "rm_recursive_force")
+
+    def test_blocks_force_push_variants(self) -> None:
+        for command in ("git push --force", "git push -f origin main", "git -C repo push --force-with-lease"):
+            self.assert_rule(command, "git_force_push")
+
+    def test_blocks_destructive_sql(self) -> None:
+        self.assert_rule('psql -c "DROP TABLE users"', "drop_table")
+        self.assert_rule("mysql -e 'TRUNCATE TABLE audit_log'", "truncate")
+        self.assert_rule('psql -c "DELETE FROM users"', "delete_from_without_where")
+
+    def test_allows_safe_commands(self) -> None:
+        for command in (
+            "rm build.log",
+            "git push origin main",
+            'psql -c "DELETE FROM users WHERE id = 1"',
+            "python3 -m pytest",
+            "echo 'DROP TABLE appears in docs only'",
+        ):
+            self.assert_allowed(command)
+
+
+class HookBehaviorTests(TestCase):
+    def test_allowed_command_is_silent(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(MODULE_PATH)],
+            input=json.dumps(payload("python3 -m pytest")),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+
+    def test_blocked_command_logs_and_denies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "blocked.log"
+            with patch.object(guard, "LOG_PATH", log_path):
+                with patch("sys.stdout") as stdout:
+                    code = guard.handle(payload("rm -rf build"))
+
+            self.assertEqual(code, 0)
+            response = json.loads("".join(call.args[0] for call in stdout.write.call_args_list if call.args))
+            hook_output = response["hookSpecificOutput"]
+            self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+            self.assertEqual(hook_output["permissionDecision"], "deny")
+            self.assertIn("recursive delete", hook_output["permissionDecisionReason"])
+            log_text = log_path.read_text(encoding="utf-8")
+            self.assertIn("project=/tmp/example-project", log_text)
+            self.assertIn("rule=rm_recursive_force", log_text)
+            self.assertIn("command=rm -rf build", log_text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a Claude Code PreToolUse Bash hook that denies destructive shell/database commands before execution
- Adds an installer that copies the hook into ~/.claude/hooks and merges ~/.claude/settings.json
- Documents install/blocked command behavior and adds unit tests

## Validation
- python3 hooks/destructive-bash-guard/test_destructive_bash_guard.py
- python3 -m compileall hooks/destructive-bash-guard
- Tested installer with a temporary HOME

Closes #3