### PR TITLE
Add destructive Bash guard hook

### DIFF
--- a/bounties/003-destructive-bash-hook/README.md
+++ b/bounties/003-destructive-bash-hook/README.md
@@ -1,0 +1,65 @@
+# Destructive Bash Guard Hook
+
+Claude Code `PreToolUse` hook that blocks high-risk Bash commands before they run.
+
+## Install
+
+```bash
+python bounties/003-destructive-bash-hook/install.py
+```
+
+The installer copies the hook to `~/.claude/hooks/destructive_bash_guard.py` and adds a `PreToolUse` Bash hook to `~/.claude/settings.json`. If settings already exist, the installer first writes `~/.claude/settings.json.bak`.
+The saved hook command uses the same Python interpreter that ran the installer.
+
+## What It Blocks
+
+- `rm` with both recursive and force flags, including `rm -rf`, `rm -fr`, `rm -r -f`, and `rm --recursive --force`
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- SQL `DROP TABLE`
+- SQL `TRUNCATE`
+- SQL `DELETE FROM` statements without a `WHERE` clause
+
+Normal Bash commands exit silently with no hook output, so Claude Code continues as usual.
+
+## Log File
+
+Every blocked command appends one JSON line to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each entry contains:
+
+- UTC timestamp
+- attempted command
+- project path from the Claude Code hook input `cwd`
+- block reason
+
+## Manual Configuration
+
+If you prefer to copy the hook yourself, add this to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/hooks/destructive_bash_guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Run Tests
+
+```bash
+python -m unittest discover -s bounties/003-destructive-bash-hook/tests
+```

--- a/bounties/003-destructive-bash-hook/README.md
+++ b/bounties/003-destructive-bash-hook/README.md
@@ -15,11 +15,11 @@ The saved hook command uses the same Python interpreter that ran the installer.
 
 - `rm` with both recursive and force flags, including `rm -rf`, `rm -fr`, `rm -r -f`, and `rm --recursive --force`
 - `git push --force`, `git push -f`, and `git push --force-with-lease`
-- SQL `DROP TABLE`
-- SQL `TRUNCATE`
-- SQL `DELETE FROM` statements without a `WHERE` clause
+- SQL `DROP TABLE` sent to common SQL clients such as `psql`, `mysql`, `sqlite3`, `duckdb`, or entered as a direct SQL command
+- SQL `TRUNCATE` sent to common SQL clients or entered as a direct SQL command
+- SQL `DELETE FROM` statements without a `WHERE` clause when sent to common SQL clients or entered as direct SQL
 
-Normal Bash commands exit silently with no hook output, so Claude Code continues as usual.
+Normal Bash commands exit silently with no hook output, so Claude Code continues as usual. Text-only mentions such as `echo "DROP TABLE users"` or `grep "DELETE FROM" migrations/*.sql` are allowed unless they are piped into a SQL client.
 
 ## Log File
 

--- a/bounties/003-destructive-bash-hook/destructive_bash_guard.py
+++ b/bounties/003-destructive-bash-hook/destructive_bash_guard.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCKED_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def find_block_reason(command: str) -> str | None:
+    normalized = " ".join(command.split())
+
+    if _contains_forced_recursive_rm(command):
+        return "Blocked destructive recursive remove command (rm with recursive and force flags)."
+
+    if _contains_git_force_push(command):
+        return "Blocked force-push command. Use a reviewed non-force push workflow instead."
+
+    if re.search(r"\bdrop\s+table\b", normalized, flags=re.IGNORECASE):
+        return "Blocked SQL DROP TABLE statement."
+
+    if re.search(r"\btruncate\b", normalized, flags=re.IGNORECASE):
+        return "Blocked SQL TRUNCATE statement."
+
+    if _contains_delete_without_where(normalized):
+        return "Blocked SQL DELETE FROM statement without a WHERE clause."
+
+    return None
+
+
+def build_denial(reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def log_block(input_data: dict[str, Any], command: str, reason: str) -> None:
+    project_path = input_data.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_path": project_path,
+        "command": command,
+        "reason": reason,
+    }
+    BLOCKED_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with BLOCKED_LOG.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
+def main() -> int:
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if input_data.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = input_data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = find_block_reason(command)
+    if reason is None:
+        return 0
+
+    log_block(input_data, command, reason)
+    print(json.dumps(build_denial(reason)))
+    return 0
+
+
+def _contains_forced_recursive_rm(command: str) -> bool:
+    for argv in _split_command_words(command):
+        if not argv:
+            continue
+        try:
+            rm_index = next(i for i, arg in enumerate(argv) if _is_command_name(arg, "rm"))
+        except StopIteration:
+            continue
+
+        flags = argv[rm_index + 1 :]
+        has_recursive = False
+        has_force = False
+        for flag in flags:
+            if flag == "--":
+                break
+            if flag in {"-r", "-R", "--recursive", "-d"}:
+                has_recursive = True
+            if flag in {"-f", "--force"}:
+                has_force = True
+            if flag.startswith("-") and not flag.startswith("--"):
+                has_recursive = has_recursive or "r" in flag.lower()
+                has_force = has_force or "f" in flag.lower()
+
+        if has_recursive and has_force:
+            return True
+
+    return False
+
+
+def _contains_git_force_push(command: str) -> bool:
+    for argv in _split_command_words(command):
+        if len(argv) < 3:
+            continue
+        try:
+            git_index = next(i for i, arg in enumerate(argv) if _is_command_name(arg, "git"))
+        except StopIteration:
+            continue
+        if len(argv) <= git_index + 2 or argv[git_index + 1] != "push":
+            continue
+        if any(arg in {"--force", "-f", "--force-with-lease"} for arg in argv[git_index + 2 :]):
+            return True
+    return False
+
+
+def _contains_delete_without_where(command: str) -> bool:
+    for statement in re.split(r";|&&|\|\|", command):
+        if re.search(r"\bdelete\s+from\b", statement, flags=re.IGNORECASE) and not re.search(
+            r"\bwhere\b",
+            statement,
+            flags=re.IGNORECASE,
+        ):
+            return True
+    return False
+
+
+def _split_command_words(command: str) -> list[list[str]]:
+    commands: list[list[str]] = []
+    for segment in re.split(r";|&&|\|\|", command):
+        try:
+            commands.append(shlex.split(segment, posix=True))
+        except ValueError:
+            commands.append(segment.split())
+    return commands
+
+
+def _is_command_name(arg: str, name: str) -> bool:
+    return arg == name or arg.endswith(f"/{name}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bounties/003-destructive-bash-hook/destructive_bash_guard.py
+++ b/bounties/003-destructive-bash-hook/destructive_bash_guard.py
@@ -14,24 +14,32 @@ from typing import Any
 
 
 BLOCKED_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
+SQL_CLIENTS = {
+    "clickhouse-client",
+    "cockroach",
+    "duckdb",
+    "mariadb",
+    "mysql",
+    "psql",
+    "sqlite3",
+    "sqlcmd",
+}
 
 
 def find_block_reason(command: str) -> str | None:
-    normalized = " ".join(command.split())
-
     if _contains_forced_recursive_rm(command):
         return "Blocked destructive recursive remove command (rm with recursive and force flags)."
 
     if _contains_git_force_push(command):
         return "Blocked force-push command. Use a reviewed non-force push workflow instead."
 
-    if re.search(r"\bdrop\s+table\b", normalized, flags=re.IGNORECASE):
+    if _contains_sql_pattern(command, r"\bdrop\s+table\b"):
         return "Blocked SQL DROP TABLE statement."
 
-    if re.search(r"\btruncate\b", normalized, flags=re.IGNORECASE):
+    if _contains_sql_pattern(command, r"\btruncate\b"):
         return "Blocked SQL TRUNCATE statement."
 
-    if _contains_delete_without_where(normalized):
+    if _contains_delete_without_where(command):
         return "Blocked SQL DELETE FROM statement without a WHERE clause."
 
     return None
@@ -130,8 +138,15 @@ def _contains_git_force_push(command: str) -> bool:
     return False
 
 
+def _contains_sql_pattern(command: str, pattern: str) -> bool:
+    for statement in _sql_relevant_statements(command):
+        if re.search(pattern, statement, flags=re.IGNORECASE):
+            return True
+    return False
+
+
 def _contains_delete_without_where(command: str) -> bool:
-    for statement in re.split(r";|&&|\|\|", command):
+    for statement in _sql_relevant_statements(command):
         if re.search(r"\bdelete\s+from\b", statement, flags=re.IGNORECASE) and not re.search(
             r"\bwhere\b",
             statement,
@@ -139,6 +154,28 @@ def _contains_delete_without_where(command: str) -> bool:
         ):
             return True
     return False
+
+
+def _sql_relevant_statements(command: str) -> list[str]:
+    statements: list[str] = []
+    for segment in re.split(r";|&&|\|\|", command):
+        stripped = " ".join(segment.split())
+        if not stripped:
+            continue
+        if _segment_uses_sql_client(segment) or _starts_with_sql_keyword(stripped):
+            statements.append(stripped)
+    return statements
+
+
+def _segment_uses_sql_client(segment: str) -> bool:
+    for argv in _split_command_words(segment):
+        if any(_is_command_name(arg, client) for arg in argv for client in SQL_CLIENTS):
+            return True
+    return False
+
+
+def _starts_with_sql_keyword(statement: str) -> bool:
+    return bool(re.match(r"^\s*(drop\s+table|truncate|delete\s+from)\b", statement, flags=re.IGNORECASE))
 
 
 def _split_command_words(command: str) -> list[list[str]]:

--- a/bounties/003-destructive-bash-hook/install.py
+++ b/bounties/003-destructive-bash-hook/install.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash guard into the current user's Claude settings."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SOURCE_HOOK = ROOT / "destructive_bash_guard.py"
+CLAUDE_DIR = Path.home() / ".claude"
+HOOK_DIR = CLAUDE_DIR / "hooks"
+SETTINGS_PATH = CLAUDE_DIR / "settings.json"
+INSTALLED_HOOK = HOOK_DIR / "destructive_bash_guard.py"
+HOOK_COMMAND = f"{shlex.quote(sys.executable)} {shlex.quote(str(INSTALLED_HOOK))}"
+
+
+def main() -> int:
+    HOOK_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE_HOOK, INSTALLED_HOOK)
+
+    settings = _load_settings()
+    pre_tool_hooks = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    hook_group = _bash_hook_group(pre_tool_hooks)
+    hooks = hook_group.setdefault("hooks", [])
+
+    if not any(hook.get("command") == HOOK_COMMAND for hook in hooks):
+        hooks.append({"type": "command", "command": HOOK_COMMAND})
+
+    SETTINGS_PATH.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"Installed hook at {INSTALLED_HOOK}")
+    print(f"Updated settings at {SETTINGS_PATH}")
+    return 0
+
+
+def _load_settings() -> dict:
+    if not SETTINGS_PATH.exists():
+        return {}
+    backup = SETTINGS_PATH.with_suffix(".json.bak")
+    shutil.copy2(SETTINGS_PATH, backup)
+    return json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+
+
+def _bash_hook_group(pre_tool_hooks: list[dict]) -> dict:
+    for group in pre_tool_hooks:
+        if group.get("matcher") == "Bash":
+            return group
+    group = {"matcher": "Bash", "hooks": []}
+    pre_tool_hooks.append(group)
+    return group
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bounties/003-destructive-bash-hook/tests/test_destructive_bash_guard.py
+++ b/bounties/003-destructive-bash-hook/tests/test_destructive_bash_guard.py
@@ -36,9 +36,16 @@ class DestructiveBashGuardTest(unittest.TestCase):
         self.assertIn("DROP TABLE", guard.find_block_reason('psql -c "DROP TABLE users"'))
         self.assertIn("TRUNCATE", guard.find_block_reason("mysql -e 'TRUNCATE sessions'"))
         self.assertIn("DELETE FROM", guard.find_block_reason('psql -c "DELETE FROM users"'))
+        self.assertIn("DROP TABLE", guard.find_block_reason('echo "DROP TABLE users" | psql'))
+        self.assertIn("DELETE FROM", guard.find_block_reason("DELETE FROM users"))
 
     def test_allows_delete_with_where(self) -> None:
         self.assertIsNone(guard.find_block_reason('psql -c "DELETE FROM users WHERE id = 1"'))
+
+    def test_allows_text_only_sql_mentions(self) -> None:
+        self.assertIsNone(guard.find_block_reason('echo "DROP TABLE users"'))
+        self.assertIsNone(guard.find_block_reason('grep "DELETE FROM" migrations/*.sql'))
+        self.assertIsNone(guard.find_block_reason('printf "TRUNCATE sessions"'))
 
     def test_denies_and_logs_blocked_pre_tool_use(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/bounties/003-destructive-bash-hook/tests/test_destructive_bash_guard.py
+++ b/bounties/003-destructive-bash-hook/tests/test_destructive_bash_guard.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "destructive_bash_guard.py"
+SPEC = importlib.util.spec_from_file_location("destructive_bash_guard", HOOK_PATH)
+guard = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(guard)
+
+
+class DestructiveBashGuardTest(unittest.TestCase):
+    def test_allows_normal_bash_command(self) -> None:
+        self.assertIsNone(guard.find_block_reason("npm test"))
+
+    def test_blocks_rm_rf_variants(self) -> None:
+        self.assertIn("recursive remove", guard.find_block_reason("rm -rf /tmp/build"))
+        self.assertIn("recursive remove", guard.find_block_reason("sudo rm -r -f ./dist"))
+        self.assertIn("recursive remove", guard.find_block_reason("/bin/rm -rf ./dist"))
+        self.assertIn("recursive remove", guard.find_block_reason("rm --recursive --force old-cache"))
+
+    def test_blocks_force_push_variants(self) -> None:
+        self.assertIn("force-push", guard.find_block_reason("git push --force origin main"))
+        self.assertIn("force-push", guard.find_block_reason("git push -f origin main"))
+        self.assertIn("force-push", guard.find_block_reason("/usr/bin/git push --force origin main"))
+
+    def test_blocks_drop_truncate_and_delete_without_where(self) -> None:
+        self.assertIn("DROP TABLE", guard.find_block_reason('psql -c "DROP TABLE users"'))
+        self.assertIn("TRUNCATE", guard.find_block_reason("mysql -e 'TRUNCATE sessions'"))
+        self.assertIn("DELETE FROM", guard.find_block_reason('psql -c "DELETE FROM users"'))
+
+    def test_allows_delete_with_where(self) -> None:
+        self.assertIsNone(guard.find_block_reason('psql -c "DELETE FROM users WHERE id = 1"'))
+
+    def test_denies_and_logs_blocked_pre_tool_use(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            guard.BLOCKED_LOG = Path(tmpdir) / "blocked.log"
+            payload = {
+                "cwd": "/workspace/demo",
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf build"},
+            }
+
+            stdin = io.StringIO(json.dumps(payload))
+            stdout = io.StringIO()
+            with mock.patch("sys.stdin", stdin), redirect_stdout(stdout):
+                self.assertEqual(guard.main(), 0)
+
+            output = json.loads(stdout.getvalue())
+            hook_output = output["hookSpecificOutput"]
+            self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+            self.assertEqual(hook_output["permissionDecision"], "deny")
+
+            log_entry = json.loads(guard.BLOCKED_LOG.read_text(encoding="utf-8").strip())
+            self.assertEqual(log_entry["project_path"], "/workspace/demo")
+            self.assertEqual(log_entry["command"], "rm -rf build")
+
+    def test_ignores_non_bash_tools(self) -> None:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/example"},
+        }
+
+        stdin = io.StringIO(json.dumps(payload))
+        stdout = io.StringIO()
+        with mock.patch("sys.stdin", stdin), redirect_stdout(stdout):
+            self.assertEqual(guard.main(), 0)
+
+        self.assertEqual(stdout.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a Claude Code `PreToolUse` Bash hook that blocks destructive commands before execution.

## Root Cause
Claude Code Bash tool calls can include high-risk commands such as recursive forced deletion, destructive SQL, or force-pushing git history. This bounty asks for a local hook that intercepts those commands before they run.

## Fix
- Adds `destructive_bash_guard.py`, a Python PreToolUse hook for Bash.
- Blocks:
  - `rm` with recursive + force flags, including `/bin/rm -rf`
  - `git push --force`, `git push -f`, and `--force-with-lease`
  - SQL `DROP TABLE`
  - SQL `TRUNCATE`
  - SQL `DELETE FROM` without `WHERE`
- Logs blocked attempts to `~/.claude/hooks/blocked.log` as JSONL.
- Returns Claude Code structured JSON with `permissionDecision: "deny"` and a clear reason.
- Adds a one-command installer and README.
- Adds unit tests for blocked and allowed cases.

## Tests Run
- `python -m unittest discover -s bounties/003-destructive-bash-hook/tests`
- `python -m py_compile bounties/003-destructive-bash-hook/destructive_bash_guard.py bounties/003-destructive-bash-hook/install.py`

## Security Impact
This reduces accidental execution of destructive Bash commands in Claude Code projects. It is a defensive local hook and does not contact or test any third-party systems.

## Limitations
This is pattern-based command detection, not a full shell or SQL parser. It is intended as a practical safety guard, not a sandbox.


Addresses #3.