### PR TITLE
Add Claude Code PR reviewer agent

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,39 @@
+name: Claude PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: GitHub PR URL to review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  review:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted workflow code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate and post PR review
+        working-directory: agents/pr-reviewer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_URL: ${{ github.event.inputs.pr || github.event.pull_request.html_url }}
+        run: node bin/claude-review.mjs --pr "$PR_URL" --post-comment

--- a/agents/pr-reviewer/.claude/agents/pr-reviewer.md
+++ b/agents/pr-reviewer/.claude/agents/pr-reviewer.md
@@ -1,0 +1,23 @@
+---
+name: pr-reviewer
+description: Review GitHub pull request diffs and produce a structured Markdown review with summary, risks, suggestions, and confidence.
+tools: Bash
+---
+
+You are a focused Claude Code PR reviewer.
+
+When given a pull request URL:
+
+1. Run `claude-review --pr <url>` from this package, or inspect the PR diff directly if the CLI is unavailable.
+2. Ground every finding in changed files, diff metadata, or visible code behavior.
+3. Return Markdown with these exact sections:
+   - `## PR Review`
+   - `### Summary`
+   - `### Identified Risks`
+   - `### Improvement Suggestions`
+   - `### Confidence`
+4. Keep the summary to 2-3 sentences or bullets.
+5. Prefer concrete risks over generic advice. If no clear risk exists, say so and name the residual verification gap.
+6. Set confidence to `Low`, `Medium`, or `High`.
+
+Do not approve, merge, or request changes automatically. The output is a review comment draft.

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,0 +1,92 @@
+# Claude PR Reviewer Agent
+
+This bounty submission adds a Claude Code PR review agent plus a zero-dependency Node CLI:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+The CLI fetches GitHub PR metadata, changed files, and the diff, then returns structured Markdown with:
+
+- Summary of changes
+- Identified risks
+- Improvement suggestions
+- Confidence score: Low, Medium, or High
+
+If `ANTHROPIC_API_KEY` is set, the CLI asks Claude Sonnet 4 to write the review. If no key is present, it falls back to deterministic diff-metadata review so the tool remains testable in CI and local development.
+
+## Setup
+
+1. Install or link the package:
+
+   ```bash
+   cd agents/pr-reviewer
+   npm install
+   npm link
+   ```
+
+2. Optional: configure credentials:
+
+   ```bash
+   export GITHUB_TOKEN=github_pat_or_token
+   export ANTHROPIC_API_KEY=sk-ant-api-key
+   ```
+
+3. Review a pull request:
+
+   ```bash
+   claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/908
+   ```
+
+## Usage
+
+Write the review to a file:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --out review.md
+```
+
+Run without Claude API calls:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --no-ai
+```
+
+Post the review as a PR comment:
+
+```bash
+GITHUB_TOKEN=github_pat_or_token claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+## Claude Code Agent
+
+The sub-agent prompt is included at:
+
+```text
+agents/pr-reviewer/.claude/agents/pr-reviewer.md
+```
+
+Copy it into a project-level `.claude/agents/pr-reviewer.md` or into your Claude Code agent directory. The agent is intentionally narrow: it produces a review comment draft and does not approve, merge, or request changes automatically.
+
+## Validation
+
+Run the format test:
+
+```bash
+npm test
+```
+
+On Windows environments with custom enterprise root certificates, Node may need the system certificate store:
+
+```bash
+NODE_OPTIONS=--use-system-ca node bin/claude-review.mjs --pr https://github.com/owner/repo/pull/123 --no-ai
+```
+
+Generate the checked sample outputs:
+
+```bash
+node bin/claude-review.mjs --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/908 --no-ai --out samples/pr-908-review.md
+node bin/claude-review.mjs --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/909 --no-ai --out samples/pr-909-review.md
+```
+
+Sample outputs from two real PRs are included in `samples/`.

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -6,6 +6,12 @@ This bounty submission adds a Claude Code PR review agent plus a zero-dependency
 claude-review --pr https://github.com/owner/repo/pull/123
 ```
 
+The CLI also accepts shorthand references such as:
+
+```bash
+claude-review --pr owner/repo#123
+```
+
 The CLI fetches GitHub PR metadata, changed files, and the diff, then returns structured Markdown with:
 
 - Summary of changes
@@ -52,11 +58,30 @@ Run without Claude API calls:
 claude-review --pr https://github.com/owner/repo/pull/123 --no-ai
 ```
 
-Post the review as a PR comment:
+Post or update the review as a PR comment:
 
 ```bash
 GITHUB_TOKEN=github_pat_or_token claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
 ```
+
+`--post-comment` is idempotent. It creates one comment containing `<!-- claude-pr-reviewer-agent -->`, then updates that same comment on later runs instead of posting duplicates.
+
+## GitHub Action
+
+The repository includes `.github/workflows/claude-review.yml` for automatic or manual PR reviews.
+
+Required configuration:
+
+- `GITHUB_TOKEN`: provided by GitHub Actions.
+- `ANTHROPIC_API_KEY`: optional repository secret. Without it, the workflow uses deterministic heuristic review output.
+
+The workflow uses `pull_request_target` but checks out the repository default branch, not the incoming PR head. The CLI fetches the PR diff through the GitHub API, which avoids executing untrusted pull request code while still allowing an idempotent review comment.
+
+Manual run:
+
+1. Open the workflow in GitHub Actions.
+2. Choose **Run workflow**.
+3. Provide a PR URL such as `https://github.com/owner/repo/pull/123`.
 
 ## Claude Code Agent
 

--- a/agents/pr-reviewer/bin/claude-review.mjs
+++ b/agents/pr-reviewer/bin/claude-review.mjs
@@ -4,14 +4,20 @@ import { writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+export const COMMENT_MARKER = "<!-- claude-pr-reviewer-agent -->";
 
 export function parsePrUrl(url) {
-  const match = String(url || "").match(
+  const value = String(url || "").trim();
+  const urlMatch = value.match(
     /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/,
   );
+  const shorthandMatch = value.match(/^([^/\s#]+)\/([^/\s#]+)(?:#|\/pull\/|\/)(\d+)$/);
+  const match = urlMatch || shorthandMatch;
 
   if (!match) {
-    throw new Error("Expected --pr to be a GitHub pull request URL, for example https://github.com/owner/repo/pull/123");
+    throw new Error(
+      "Expected --pr to be a GitHub pull request URL or shorthand like owner/repo#123",
+    );
   }
 
   return {
@@ -46,14 +52,15 @@ function parseArgs(argv) {
 function usage() {
   return `Usage:
   claude-review --pr https://github.com/owner/repo/pull/123 [--out review.md] [--post-comment] [--no-ai]
+  claude-review --pr owner/repo#123 [--post-comment]
 
 Environment:
   ANTHROPIC_API_KEY       Enables Claude-powered review generation.
-  GITHUB_TOKEN            Raises API limits and enables --post-comment.
+  GITHUB_TOKEN            Raises API limits and enables idempotent --post-comment.
   CLAUDE_REVIEW_MODEL     Optional; defaults to ${DEFAULT_MODEL}.`;
 }
 
-async function githubRequest(url, { accept = "application/vnd.github+json" } = {}) {
+async function githubRequest(url, { accept = "application/vnd.github+json", method = "GET", body } = {}) {
   const headers = {
     "accept": accept,
     "user-agent": "claude-pr-reviewer-agent",
@@ -63,12 +70,19 @@ async function githubRequest(url, { accept = "application/vnd.github+json" } = {
     headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
   }
 
-  const response = await fetch(url, { headers });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`GitHub request failed (${response.status}) for ${url}\n${body}`);
+  const options = { method, headers };
+  if (body !== undefined) {
+    headers["content-type"] = "application/json";
+    options.body = JSON.stringify(body);
   }
 
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(`GitHub request failed (${response.status}) for ${url}\n${responseBody}`);
+  }
+
+  if (response.status === 204) return null;
   if (accept.includes("json")) return response.json();
   return response.text();
 }
@@ -260,26 +274,30 @@ ${diff.slice(0, 60000)}`;
     .trim();
 }
 
+export function withCommentMarker(markdown) {
+  const body = String(markdown || "").trimEnd();
+  if (body.startsWith(COMMENT_MARKER)) return `${body}\n`;
+  return `${COMMENT_MARKER}\n${body}\n`;
+}
+
 async function postComment({ owner, repo, number, markdown }) {
   if (!process.env.GITHUB_TOKEN) {
     throw new Error("--post-comment requires GITHUB_TOKEN with permission to comment on the pull request");
   }
 
-  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/${number}/comments`, {
-    method: "POST",
-    headers: {
-      "authorization": `Bearer ${process.env.GITHUB_TOKEN}`,
-      "accept": "application/vnd.github+json",
-      "content-type": "application/json",
-      "user-agent": "claude-pr-reviewer-agent",
-    },
-    body: JSON.stringify({ body: markdown }),
-  });
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+  const body = withCommentMarker(markdown);
+  const comments = await githubRequest(`${base}/issues/${number}/comments?per_page=100`);
+  const existing = Array.isArray(comments)
+    ? comments.find((comment) => typeof comment.body === "string" && comment.body.includes(COMMENT_MARKER))
+    : null;
 
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Could not post PR comment (${response.status})\n${body}`);
+  if (existing?.url) {
+    await githubRequest(existing.url, { method: "PATCH", body: { body } });
+    return;
   }
+
+  await githubRequest(`${base}/issues/${number}/comments`, { method: "POST", body: { body } });
 }
 
 export async function reviewPr(prUrl, options = {}) {

--- a/agents/pr-reviewer/bin/claude-review.mjs
+++ b/agents/pr-reviewer/bin/claude-review.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+
+import { writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+
+export function parsePrUrl(url) {
+  const match = String(url || "").match(
+    /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/,
+  );
+
+  if (!match) {
+    throw new Error("Expected --pr to be a GitHub pull request URL, for example https://github.com/owner/repo/pull/123");
+  }
+
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: Number(match[3]),
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    format: "markdown",
+    out: null,
+    postComment: false,
+    noAi: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--pr") args.pr = argv[++index];
+    else if (token === "--format") args.format = argv[++index];
+    else if (token === "--out") args.out = argv[++index];
+    else if (token === "--post-comment") args.postComment = true;
+    else if (token === "--no-ai") args.noAi = true;
+    else if (token === "--help" || token === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return args;
+}
+
+function usage() {
+  return `Usage:
+  claude-review --pr https://github.com/owner/repo/pull/123 [--out review.md] [--post-comment] [--no-ai]
+
+Environment:
+  ANTHROPIC_API_KEY       Enables Claude-powered review generation.
+  GITHUB_TOKEN            Raises API limits and enables --post-comment.
+  CLAUDE_REVIEW_MODEL     Optional; defaults to ${DEFAULT_MODEL}.`;
+}
+
+async function githubRequest(url, { accept = "application/vnd.github+json" } = {}) {
+  const headers = {
+    "accept": accept,
+    "user-agent": "claude-pr-reviewer-agent",
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub request failed (${response.status}) for ${url}\n${body}`);
+  }
+
+  if (accept.includes("json")) return response.json();
+  return response.text();
+}
+
+async function fetchPullRequest(owner, repo, number) {
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+  const [pull, files, diff] = await Promise.all([
+    githubRequest(`${base}/pulls/${number}`),
+    githubRequest(`${base}/pulls/${number}/files?per_page=100`),
+    githubRequest(`https://github.com/${owner}/${repo}/pull/${number}.diff`, {
+      accept: "text/plain",
+    }),
+  ]);
+
+  return { pull, files, diff };
+}
+
+function hasTestFile(files) {
+  return files.some((file) => /(^|\/)(test|tests|spec|__tests__)\/|(\.|-)(test|spec)\.[cm]?[jt]sx?$|_test\.(go|py)$/.test(file.filename));
+}
+
+function hasDocsOnly(files) {
+  return files.length > 0 && files.every((file) => /\.(md|mdx|txt|rst)$/i.test(file.filename));
+}
+
+function fileBuckets(files) {
+  const buckets = new Map();
+  for (const file of files) {
+    const ext = file.filename.includes(".") ? file.filename.split(".").pop() : "no extension";
+    buckets.set(ext, (buckets.get(ext) || 0) + 1);
+  }
+  return [...buckets.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([ext, count]) => `${count} ${ext}`)
+    .join(", ");
+}
+
+export function buildHeuristicReview({ pull, files, diff }) {
+  const additions = files.reduce((sum, file) => sum + Number(file.additions || 0), 0);
+  const deletions = files.reduce((sum, file) => sum + Number(file.deletions || 0), 0);
+  const filenames = files.map((file) => file.filename);
+  const testPresent = hasTestFile(files);
+  const docsOnly = hasDocsOnly(files);
+  const diffLines = diff.split("\n").length;
+
+  const risks = [];
+  if (files.some((file) => /hook|guard|security|auth|permission|pre[-_]?tool/i.test(file.filename))) {
+    risks.push("Security or permission-sensitive code changed; review normalization, quoting, and bypass cases rather than only the happy path.");
+  }
+  if (files.some((file) => /(^|\/)(bin|scripts)\//.test(file.filename) || /\.(sh|bash|mjs|cjs|js)$/.test(file.filename))) {
+    risks.push("CLI or script behavior changed; verify argument parsing, exit codes, and portability in a clean shell.");
+  }
+  if (/api\.github\.com|fetch\(|https?:\/\//i.test(diff)) {
+    risks.push("Network or API calls appear in the diff; check authentication, rate-limit handling, and clear failure messages.");
+  }
+  if (/anthropic_api_key|github_token|api[_-]?key|access[_-]?token|secret/i.test(diff)) {
+    risks.push("AI/API credential flow appears in the diff; confirm secrets are read from environment or credentials storage and never logged.");
+  }
+  if (!testPresent && !docsOnly) {
+    risks.push("No test file changed in this PR, so behavioral regressions may rely on manual validation.");
+  }
+  if (files.some((file) => /package-lock\.json|pnpm-lock\.yaml|yarn\.lock|Cargo\.lock|go\.sum/.test(file.filename))) {
+    risks.push("Dependency lockfile changes are present; review transitive dependency changes and generated diffs carefully.");
+  }
+  if (files.some((file) => /^\.github\/workflows\//.test(file.filename))) {
+    risks.push("CI workflow changes can affect every future contribution, including secret exposure and permission scope.");
+  }
+  if (files.some((file) => /migration|schema|database|sql/i.test(file.filename))) {
+    risks.push("Database or schema-related files changed; confirm migration order, rollback behavior, and data-safety assumptions.");
+  }
+  if (deletions > additions * 2 && deletions > 50) {
+    risks.push("The PR removes substantially more code than it adds; verify removed behavior is intentionally obsolete.");
+  }
+  if (diffLines > 1200 || files.length >= 20) {
+    risks.push("The diff is large enough that important interactions may be missed in a quick review.");
+  }
+  if (risks.length === 0) {
+    risks.push("No major structural risk is obvious from the diff metadata; still review changed logic and edge cases.");
+  }
+
+  const suggestions = [];
+  if (testPresent) {
+    suggestions.push("Run the included tests from a clean checkout and include the exact command/output in the PR before merging.");
+  }
+  if (!testPresent && !docsOnly) {
+    suggestions.push("Add at least one focused regression test or include a manual verification transcript in the PR description.");
+  }
+  if (docsOnly) {
+    suggestions.push("Confirm that examples and commands in the documentation were exercised in a clean checkout.");
+  }
+  if (files.some((file) => /config|env|secret|token|auth/i.test(file.filename))) {
+    suggestions.push("Document configuration defaults and confirm secrets are never printed, committed, or exposed in logs.");
+  }
+  suggestions.push("Ask the author to describe the riskiest changed path and the exact validation they ran.");
+
+  let confidence = "Medium";
+  if (diffLines > 1200 || files.length >= 20) confidence = "Low";
+  if ((testPresent || docsOnly) && files.length <= 8 && diffLines <= 700) confidence = "High";
+
+  return {
+    pr: `#${pull.number}`,
+    title: pull.title,
+    author: pull.user?.login || "unknown",
+    url: pull.html_url,
+    summary: [
+      `This PR changes ${files.length} file${files.length === 1 ? "" : "s"} with ${additions} additions and ${deletions} deletions.`,
+      docsOnly
+        ? "The change appears documentation-focused, so review should emphasize accuracy, copy-paste safety, and whether examples match the current project."
+        : `The touched file mix is ${fileBuckets(files) || "not available"}, so review should focus on behavior, test coverage, and integration points.`,
+    ],
+    risks,
+    suggestions,
+    confidence,
+    files: filenames,
+  };
+}
+
+function renderMarkdown(review) {
+  return [
+    "## PR Review",
+    "",
+    `**PR:** [${review.pr} - ${review.title}](${review.url})`,
+    `**Author:** @${review.author}`,
+    "",
+    "### Summary",
+    ...review.summary.map((line) => `- ${line}`),
+    "",
+    "### Identified Risks",
+    ...review.risks.map((line) => `- ${line}`),
+    "",
+    "### Improvement Suggestions",
+    ...review.suggestions.map((line) => `- ${line}`),
+    "",
+    "### Confidence",
+    review.confidence,
+    "",
+  ].join("\n");
+}
+
+async function runClaudeReview({ pull, files, diff }) {
+  if (!process.env.ANTHROPIC_API_KEY) return null;
+
+  const prompt = `You are a Claude Code pull request reviewer.
+Return only Markdown with these exact sections:
+## PR Review
+### Summary
+### Identified Risks
+### Improvement Suggestions
+### Confidence
+
+Rules:
+- Summary must be 2-3 sentences or bullets.
+- Risks and suggestions must be concise, concrete, and grounded in the diff.
+- Confidence must be one of: Low, Medium, High.
+
+PR title: ${pull.title}
+Author: ${pull.user?.login || "unknown"}
+Changed files:
+${files.map((file) => `- ${file.filename} (+${file.additions} -${file.deletions})`).join("\n")}
+
+Diff:
+${diff.slice(0, 60000)}`;
+
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+    },
+    body: JSON.stringify({
+      model: process.env.CLAUDE_REVIEW_MODEL || DEFAULT_MODEL,
+      max_tokens: 1400,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Claude API request failed (${response.status})\n${body}`);
+  }
+
+  const data = await response.json();
+  return data.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+async function postComment({ owner, repo, number, markdown }) {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error("--post-comment requires GITHUB_TOKEN with permission to comment on the pull request");
+  }
+
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/${number}/comments`, {
+    method: "POST",
+    headers: {
+      "authorization": `Bearer ${process.env.GITHUB_TOKEN}`,
+      "accept": "application/vnd.github+json",
+      "content-type": "application/json",
+      "user-agent": "claude-pr-reviewer-agent",
+    },
+    body: JSON.stringify({ body: markdown }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Could not post PR comment (${response.status})\n${body}`);
+  }
+}
+
+export async function reviewPr(prUrl, options = {}) {
+  const target = parsePrUrl(prUrl);
+  const data = await fetchPullRequest(target.owner, target.repo, target.number);
+  const claudeMarkdown = options.noAi ? null : await runClaudeReview(data);
+  const markdown = claudeMarkdown || renderMarkdown(buildHeuristicReview(data));
+
+  return { target, markdown, data };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  if (!args.pr) throw new Error("Missing required --pr argument\n\n" + usage());
+  if (!["markdown", "json"].includes(args.format)) throw new Error("--format must be markdown or json");
+
+  const result = await reviewPr(args.pr, { noAi: args.noAi });
+  const output = args.format === "json"
+    ? JSON.stringify({ target: result.target, markdown: result.markdown }, null, 2)
+    : result.markdown;
+
+  if (args.out) await writeFile(args.out, output);
+  else process.stdout.write(output);
+
+  if (args.postComment) {
+    await postComment({ ...result.target, markdown: result.markdown });
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/agents/pr-reviewer/package.json
+++ b/agents/pr-reviewer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "claude-pr-reviewer-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "claude-review": "./bin/claude-review.mjs"
+  },
+  "scripts": {
+    "test": "node test/format.test.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/agents/pr-reviewer/samples/pr-908-review.md
+++ b/agents/pr-reviewer/samples/pr-908-review.md
@@ -1,0 +1,18 @@
+## PR Review
+
+**PR:** [#908 - Add destructive Bash PreToolUse hook](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/908)
+**Author:** @douglance
+
+### Summary
+- This PR changes 3 files with 341 additions and 0 deletions.
+- The touched file mix is 2 py, 1 md, so review should focus on behavior, test coverage, and integration points.
+
+### Identified Risks
+- Security or permission-sensitive code changed; review normalization, quoting, and bypass cases rather than only the happy path.
+
+### Improvement Suggestions
+- Run the included tests from a clean checkout and include the exact command/output in the PR before merging.
+- Ask the author to describe the riskiest changed path and the exact validation they ran.
+
+### Confidence
+High

--- a/agents/pr-reviewer/samples/pr-909-review.md
+++ b/agents/pr-reviewer/samples/pr-909-review.md
@@ -1,0 +1,18 @@
+## PR Review
+
+**PR:** [#909 - Add changelog generator script](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/909)
+**Author:** @douglance
+
+### Summary
+- This PR changes 4 files with 182 additions and 0 deletions.
+- The touched file mix is 2 md, 1 sh, 1 py, so review should focus on behavior, test coverage, and integration points.
+
+### Identified Risks
+- CLI or script behavior changed; verify argument parsing, exit codes, and portability in a clean shell.
+
+### Improvement Suggestions
+- Run the included tests from a clean checkout and include the exact command/output in the PR before merging.
+- Ask the author to describe the riskiest changed path and the exact validation they ran.
+
+### Confidence
+High

--- a/agents/pr-reviewer/test/format.test.mjs
+++ b/agents/pr-reviewer/test/format.test.mjs
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
-import { buildHeuristicReview, parsePrUrl } from "../bin/claude-review.mjs";
+import { buildHeuristicReview, parsePrUrl, withCommentMarker } from "../bin/claude-review.mjs";
 
 const parsed = parsePrUrl("https://github.com/owner/repo/pull/123?foo=bar");
 assert.deepEqual(parsed, { owner: "owner", repo: "repo", number: 123 });
 
-assert.throws(() => parsePrUrl("https://example.com/not-a-pr"), /GitHub pull request URL/);
+assert.deepEqual(parsePrUrl("owner/repo#456"), { owner: "owner", repo: "repo", number: 456 });
+assert.deepEqual(parsePrUrl("owner/repo/789"), { owner: "owner", repo: "repo", number: 789 });
+
+assert.throws(() => parsePrUrl("https://example.com/not-a-pr"), /GitHub pull request URL|shorthand/);
+
+const marked = withCommentMarker("## PR Review\n");
+assert.ok(marked.startsWith("<!-- claude-pr-reviewer-agent -->"));
+assert.equal(withCommentMarker(marked), marked);
 
 const review = buildHeuristicReview({
   pull: {

--- a/agents/pr-reviewer/test/format.test.mjs
+++ b/agents/pr-reviewer/test/format.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { buildHeuristicReview, parsePrUrl } from "../bin/claude-review.mjs";
+
+const parsed = parsePrUrl("https://github.com/owner/repo/pull/123?foo=bar");
+assert.deepEqual(parsed, { owner: "owner", repo: "repo", number: 123 });
+
+assert.throws(() => parsePrUrl("https://example.com/not-a-pr"), /GitHub pull request URL/);
+
+const review = buildHeuristicReview({
+  pull: {
+    number: 123,
+    title: "Add payment export",
+    html_url: "https://github.com/owner/repo/pull/123",
+    user: { login: "dev" },
+  },
+  files: [
+    {
+      filename: "src/payments/export.ts",
+      additions: 120,
+      deletions: 20,
+    },
+    {
+      filename: "README.md",
+      additions: 12,
+      deletions: 2,
+    },
+  ],
+  diff: "diff --git a/src/payments/export.ts b/src/payments/export.ts\n".repeat(20),
+});
+
+assert.equal(review.pr, "#123");
+assert.equal(review.confidence, "Medium");
+assert.ok(review.summary.length >= 2);
+assert.ok(review.risks.some((risk) => risk.includes("No test file changed")));
+assert.ok(review.suggestions.some((suggestion) => suggestion.includes("regression test")));
+
+const docsReview = buildHeuristicReview({
+  pull: {
+    number: 124,
+    title: "Update docs",
+    html_url: "https://github.com/owner/repo/pull/124",
+    user: { login: "docs-dev" },
+  },
+  files: [
+    {
+      filename: "docs/setup.md",
+      additions: 20,
+      deletions: 3,
+    },
+  ],
+  diff: "diff --git a/docs/setup.md b/docs/setup.md\n",
+});
+
+assert.equal(docsReview.confidence, "High");
+assert.ok(docsReview.summary.join(" ").includes("documentation-focused"));
+
+console.log("format tests passed");


### PR DESCRIPTION
Closes #4

Adds a Claude Code PR reviewer agent with a zero-dependency Node CLI:
claude-review --pr https://github.com/owner/repo/pull/123

Includes:
- structured Markdown output: summary, risks, suggestions, confidence
- optional Claude Sonnet 4 generation via ANTHROPIC_API_KEY
- deterministic no-key fallback for local testing
- PR comment posting via GITHUB_TOKEN
- Claude Code sub-agent prompt
- tests
- sample outputs from two real PRs

Validation:
node test/format.test.mjs
# format tests passed

