### PR TITLE
Add PreToolUse hook to block destructive Bash commands

### DIFF
--- a/block-destructive-bash/README.md
+++ b/block-destructive-bash/README.md
@@ -1,0 +1,38 @@
+# Block Destructive Bash Hook
+
+Claude Code `PreToolUse` hook that denies dangerous Bash commands before execution and logs each blocked attempt.
+
+## Install
+
+From this directory:
+
+```bash
+mkdir -p ~/.claude/hooks && cp block-destructive-bash.py ~/.claude/hooks/block-destructive-bash.py && chmod +x ~/.claude/hooks/block-destructive-bash.py
+```
+
+Add the `PreToolUse` entry from `settings-example.json` to `~/.claude/settings.json`.
+
+## What It Blocks
+
+- `rm -rf` and equivalent `rm -fr` option combinations
+- `git push --force` and `git push -f`
+- SQL containing `DROP TABLE`
+- SQL containing `TRUNCATE`
+- SQL `DELETE FROM ...` statements without a `WHERE` clause
+
+Normal Bash commands exit successfully without output, so Claude Code continues as usual.
+
+## Log Format
+
+Blocked attempts are appended to `~/.claude/hooks/blocked.log` as JSON lines:
+
+```json
+{"timestamp":"2026-05-12T10:00:00Z","project_path":"/path/to/project","command":"rm -rf build","reason":"Blocked destructive rm command with recursive and force flags"}
+```
+
+## Test
+
+```bash
+python3 -m unittest test_block_destructive_bash.py
+```
+

--- a/block-destructive-bash/block-destructive-bash.py
+++ b/block-destructive-bash/block-destructive-bash.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCK_RESPONSE = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "",
+    }
+}
+
+
+def _shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def _has_recursive_force_rm(command: str) -> bool:
+    words = _shell_words(command)
+    for index, word in enumerate(words):
+        if word != "rm":
+            continue
+
+        has_recursive = False
+        has_force = False
+        for option in words[index + 1 :]:
+            if not option.startswith("-") or option == "--":
+                break
+            compact = option.lstrip("-")
+            has_recursive = has_recursive or "r" in compact or "R" in compact or compact == "recursive"
+            has_force = has_force or "f" in compact or compact == "force"
+            if has_recursive and has_force:
+                return True
+
+    return False
+
+
+def _has_force_push(command: str) -> bool:
+    words = _shell_words(command)
+    for index, word in enumerate(words[:-2]):
+        if word != "git":
+            continue
+        if words[index + 1] != "push":
+            continue
+        if any(arg == "--force" or arg == "-f" or arg.startswith("--force-with-lease") for arg in words[index + 2 :]):
+            return True
+    return False
+
+
+def _sql_statement_segments(command: str) -> list[str]:
+    return [segment.strip() for segment in re.split(r";|\n", command) if segment.strip()]
+
+
+def _has_delete_without_where(command: str) -> bool:
+    for statement in _sql_statement_segments(command):
+        normalized = re.sub(r"\s+", " ", statement, flags=re.IGNORECASE).strip()
+        if re.search(r"\bDELETE\s+FROM\b", normalized, flags=re.IGNORECASE) and not re.search(
+            r"\bWHERE\b", normalized, flags=re.IGNORECASE
+        ):
+            return True
+    return False
+
+
+def _is_plain_text_command(command: str) -> bool:
+    words = _shell_words(command)
+    if not words:
+        return False
+
+    text_commands = {
+        "ack",
+        "ag",
+        "cat",
+        "echo",
+        "grep",
+        "head",
+        "less",
+        "more",
+        "printf",
+        "rg",
+        "sed",
+        "tail",
+    }
+    return Path(words[0]).name in text_commands
+
+
+def _has_destructive_sql(command: str) -> str | None:
+    if _is_plain_text_command(command):
+        return None
+
+    if re.search(r"\bDROP\s+TABLE\b", command, flags=re.IGNORECASE):
+        return "Blocked DROP TABLE statement"
+
+    if re.search(r"\bTRUNCATE\b", command, flags=re.IGNORECASE):
+        return "Blocked TRUNCATE statement"
+
+    if _has_delete_without_where(command):
+        return "Blocked DELETE FROM statement without WHERE clause"
+
+    return None
+
+
+def block_reason(command: str) -> str | None:
+    if _has_recursive_force_rm(command):
+        return "Blocked destructive rm command with recursive and force flags"
+
+    if _has_force_push(command):
+        return "Blocked force push command"
+
+    return _has_destructive_sql(command)
+
+
+def _log_path() -> Path:
+    override = os.environ.get("CLAUDE_HOOKS_LOG")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def log_blocked_attempt(command: str, project_path: str, reason: str) -> None:
+    path = _log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "project_path": project_path,
+        "command": command,
+        "reason": reason,
+    }
+    with path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
+def _deny(reason: str) -> None:
+    response = json.loads(json.dumps(BLOCK_RESPONSE))
+    response["hookSpecificOutput"]["permissionDecisionReason"] = reason
+    print(json.dumps(response, separators=(",", ":")))
+
+
+def main() -> int:
+    try:
+        payload: dict[str, Any] = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = block_reason(command)
+    if not reason:
+        return 0
+
+    project_path = str(payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
+    log_blocked_attempt(command, project_path, reason)
+    _deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/block-destructive-bash/settings-example.json
+++ b/block-destructive-bash/settings-example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/hooks/block-destructive-bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/block-destructive-bash/test_block_destructive_bash.py
+++ b/block-destructive-bash/test_block_destructive_bash.py
@@ -1,0 +1,72 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HOOK_PATH = Path(__file__).with_name("block-destructive-bash.py")
+SPEC = importlib.util.spec_from_file_location("block_destructive_bash", HOOK_PATH)
+hook = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(hook)
+
+
+class BlockDestructiveBashTests(unittest.TestCase):
+    def test_allows_normal_commands(self):
+        self.assertIsNone(hook.block_reason("npm test"))
+        self.assertIsNone(hook.block_reason("git push origin feature-branch"))
+        self.assertIsNone(hook.block_reason("DELETE FROM users WHERE id = 1"))
+        self.assertIsNone(hook.block_reason("rg 'DELETE FROM' docs"))
+        self.assertIsNone(hook.block_reason("echo 'DROP TABLE users'"))
+
+    def test_blocks_recursive_force_rm(self):
+        self.assertIsNotNone(hook.block_reason("rm -rf build"))
+        self.assertIsNotNone(hook.block_reason("rm -fr ./tmp"))
+        self.assertIsNotNone(hook.block_reason("rm -r -f ./tmp"))
+        self.assertIsNotNone(hook.block_reason("rm --recursive --force ./tmp"))
+        self.assertIsNotNone(hook.block_reason("sudo rm -Rf /tmp/demo"))
+
+    def test_blocks_force_push(self):
+        self.assertIsNotNone(hook.block_reason("git push --force origin main"))
+        self.assertIsNotNone(hook.block_reason("git push -f"))
+        self.assertIsNotNone(hook.block_reason("git push --force-with-lease origin main"))
+
+    def test_blocks_destructive_sql(self):
+        self.assertIsNotNone(hook.block_reason("psql -c 'DROP TABLE users'"))
+        self.assertIsNotNone(hook.block_reason("mysql -e 'TRUNCATE sessions'"))
+        self.assertIsNotNone(hook.block_reason("sqlite3 app.db 'DELETE FROM users'"))
+
+    def test_pretooluse_denial_logs_attempt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "blocked.log"
+            payload = {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf build"},
+                "cwd": "/tmp/example-project",
+            }
+            result = subprocess.run(
+                [sys.executable, str(HOOK_PATH)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                check=True,
+                env={**os.environ, "CLAUDE_HOOKS_LOG": str(log_path)},
+            )
+
+            response = json.loads(result.stdout)
+            output = response["hookSpecificOutput"]
+            self.assertEqual(output["hookEventName"], "PreToolUse")
+            self.assertEqual(output["permissionDecision"], "deny")
+            self.assertIn("rm", output["permissionDecisionReason"])
+
+            log_entry = json.loads(log_path.read_text(encoding="utf-8"))
+            self.assertEqual(log_entry["project_path"], "/tmp/example-project")
+            self.assertEqual(log_entry["command"], "rm -rf build")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Summary

- Adds a Python Claude Code `PreToolUse` hook for Bash commands.
- Blocks recursive force deletes, force pushes, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` statements without `WHERE`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
- Includes a Claude settings example and install instructions.
- Adds unit tests for allowed commands, blocked command patterns, hook JSON output, and log writing.

## Validation

- `python3 -m unittest block-destructive-bash/test_block_destructive_bash.py`
- `python3 -m py_compile block-destructive-bash/block-destructive-bash.py block-destructive-bash/test_block_destructive_bash.py`