### PR TITLE
Add changelog generator skill

### DIFF
--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,28 @@
+# Generate Changelog
+
+Dependency-free Claude Code skill and Bash command that writes a structured `CHANGELOG.md` from git history.
+
+## Setup
+
+1. Copy this directory into a git repository.
+2. Run `bash generate-changelog/changelog.sh`.
+3. Review the generated `CHANGELOG.md`.
+
+## Behavior
+
+- Uses commits since the latest reachable git tag.
+- Falls back to the full repository history when no tag exists.
+- Groups commits into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Preserves commit hashes in the output for reviewability.
+- Writes deterministic Markdown so generated diffs are easy to audit.
+
+## Claude Code Usage
+
+Use the included `SKILL.md` as a project skill and ask:
+
+```text
+/generate-changelog
+```
+
+The skill runs the same Bash entrypoint.
+

--- a/generate-changelog/SKILL.md
+++ b/generate-changelog/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the latest tag.
+---
+
+# Generate Changelog
+
+When asked to generate a changelog:
+
+1. Run `bash generate-changelog/changelog.sh`.
+2. Open `CHANGELOG.md` and verify the categories are sensible.
+3. Mention the detected tag range and any commits that landed in `Changed` because they did not match a more specific category.
+
+Do not invent release notes. Use only commit subjects from git history.
+

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "generate-changelog: run inside a git repository" >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  heading="Unreleased changes since ${latest_tag}"
+else
+  range="HEAD"
+  heading="Unreleased changes"
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+added="$tmp_dir/added"
+fixed="$tmp_dir/fixed"
+changed="$tmp_dir/changed"
+removed="$tmp_dir/removed"
+: >"$added"
+: >"$fixed"
+: >"$changed"
+: >"$removed"
+
+while IFS=$'\t' read -r hash subject || [[ -n "${hash:-}" ]]; do
+  [[ -z "${hash:-}" ]] && continue
+  line="- ${subject} (${hash})"
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    feat:*|feature:*|add:*|added:*) echo "$line" >>"$added" ;;
+    fix:*|bugfix:*|fixed:*) echo "$line" >>"$fixed" ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*) echo "$line" >>"$removed" ;;
+    *) echo "$line" >>"$changed" ;;
+  esac
+done < <(git log --no-merges --pretty=format:'%h%x09%s' "$range")
+
+{
+  echo "# Changelog"
+  echo
+  echo "## ${heading}"
+  echo
+  for section in Added Fixed Changed Removed; do
+    file="$tmp_dir/$(printf '%s' "$section" | tr '[:upper:]' '[:lower:]')"
+    if [[ -s "$file" ]]; then
+      echo "### ${section}"
+      cat "$file"
+      echo
+    fi
+  done
+} >"$output"
+
+echo "Wrote ${output}"

--- a/generate-changelog/sample-output.md
+++ b/generate-changelog/sample-output.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## Unreleased changes since v1.0.0
+
+### Added
+- feat: add auth callback route (a1b2c3d)
+
+### Fixed
+- fix: preserve invoice totals when taxes are disabled (d4e5f6a)
+
+### Changed
+- refactor: move billing helpers into server module (c7d8e9f)
+
+### Removed
+- remove: legacy webhook secret fallback (0a1b2c3)
+

--- a/generate-changelog/test_changelog.sh
+++ b/generate-changelog/test_changelog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+script_path="$(cd -P "$(dirname "$0")" && pwd)/changelog.sh"
+
+git init "$fixture" >/dev/null
+cd "$fixture"
+git config user.name "Changelog Test"
+git config user.email "changelog-test@example.com"
+
+echo "one" > file.txt
+git add file.txt
+git commit -m "feat: add first feature" >/dev/null
+git tag v1.0.0
+
+echo "two" >> file.txt
+git add file.txt
+git commit -m "fix: correct totals" >/dev/null
+
+echo "three" >> file.txt
+git add file.txt
+git commit -m "remove: deprecated option" >/dev/null
+
+bash "$script_path" >/dev/null
+
+grep -q "Unreleased changes since v1.0.0" CHANGELOG.md
+grep -q "### Fixed" CHANGELOG.md
+grep -q "fix: correct totals" CHANGELOG.md
+grep -q "### Removed" CHANGELOG.md
+grep -q "remove: deprecated option" CHANGELOG.md
+
+echo "generate-changelog tests passed"


### PR DESCRIPTION
Closes #1

## Summary

- Adds a dependency-free Bash changelog generator.
- Adds a Claude Code `SKILL.md` wrapper for `/generate-changelog` usage.
- Detects commits since the latest git tag, with full-history fallback when no tag exists.
- Categorizes commit subjects into Added, Fixed, Changed, and Removed.
- Includes sample output and a fixture-based shell regression test.

## Validation

- `bash generate-changelog/test_changelog.sh`
- `bash -n generate-changelog/changelog.sh generate-changelog/test_changelog.sh`
- `git diff --check`