### PR TITLE
Add n8n weekly dev summary workflow

### DIFF
--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -1,0 +1,29 @@
+# n8n Weekly Dev Summary
+
+Importable n8n workflow that generates a weekly narrative summary of GitHub repository activity with Claude and sends it to a Discord webhook.
+
+## Setup
+
+1. Import `weekly-dev-summary.json` into n8n.
+2. Configure these workflow variables: `GITHUB_REPO`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `DISCORD_WEBHOOK_URL`, and `SUMMARY_LANGUAGE`.
+3. Set `GITHUB_REPO` to `owner/repo` and `SUMMARY_LANGUAGE` to `EN` or `FR`.
+4. Run the workflow manually once and confirm the Discord message lands.
+5. Activate the workflow for the Friday 17:00 cron trigger.
+
+## What It Fetches
+
+- Commits from the last 7 days.
+- Closed issues from the last 7 days.
+- Closed PRs from the last 7 days, filtered to merged PRs before summarization.
+
+## Validation
+
+Run:
+
+```bash
+python3 validate_workflow.py
+python3 -m json.tool weekly-dev-summary.json >/dev/null
+```
+
+The JSON is structurally validated for the expected cron, GitHub, Claude, and Discord nodes. A real n8n execution still requires valid credentials and a Discord webhook.
+

--- a/workflows/n8n-weekly-dev-summary/validate_workflow.py
+++ b/workflows/n8n-weekly-dev-summary/validate_workflow.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+
+workflow = json.loads(Path("weekly-dev-summary.json").read_text(encoding="utf-8"))
+nodes = {node["name"]: node for node in workflow["nodes"]}
+
+required = {
+    "Weekly Friday 5pm",
+    "Fetch Commits",
+    "Fetch Closed Issues",
+    "Fetch Closed PRs",
+    "Prepare Summary Input",
+    "Generate Claude Summary",
+    "Format Discord Message",
+    "Send Discord Summary",
+}
+
+missing = required - set(nodes)
+assert not missing, f"missing nodes: {sorted(missing)}"
+assert nodes["Weekly Friday 5pm"]["parameters"]["rule"]["interval"][0]["expression"] == "0 17 * * 5"
+assert "claude-sonnet-4-20250514" in nodes["Generate Claude Summary"]["parameters"]["jsonBody"]
+assert "DISCORD_WEBHOOK_URL" in nodes["Send Discord Summary"]["parameters"]["url"]
+assert "SUMMARY_LANGUAGE" in nodes["Prepare Summary Input"]["parameters"]["jsCode"]
+
+print("workflow validation passed")
+

--- a/workflows/n8n-weekly-dev-summary/weekly-dev-summary.json
+++ b/workflows/n8n-weekly-dev-summary/weekly-dev-summary.json
@@ -1,0 +1,292 @@
+{
+  "name": "Weekly GitHub Dev Summary",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 17 * * 5"
+            }
+          ]
+        }
+      },
+      "id": "weekly-cron",
+      "name": "Weekly Friday 5pm",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{$vars.GITHUB_REPO}}/commits",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "since",
+              "value": "={{$now.minus({ days: 7 }).toISO()}}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{$vars.GITHUB_TOKEN}}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        }
+      },
+      "id": "github-commits",
+      "name": "Fetch Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [240, -160]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{$vars.GITHUB_REPO}}/issues",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "since",
+              "value": "={{$now.minus({ days: 7 }).toISO()}}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{$vars.GITHUB_TOKEN}}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        }
+      },
+      "id": "github-issues",
+      "name": "Fetch Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [240, 0]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{$vars.GITHUB_REPO}}/pulls",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{$vars.GITHUB_TOKEN}}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        }
+      },
+      "id": "github-prs",
+      "name": "Fetch Closed PRs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [240, 160]
+    },
+    {
+      "parameters": {
+        "jsCode": "const commits = $('Fetch Commits').all().map(i => i.json);\\nconst issues = $('Fetch Closed Issues').all().map(i => i.json).filter(i => !i.pull_request);\\nconst since = Date.now() - 7 * 24 * 60 * 60 * 1000;\\nconst prs = $('Fetch Closed PRs').all().map(i => i.json).filter(pr => pr.merged_at && Date.parse(pr.merged_at) >= since);\\nconst language = ($vars.SUMMARY_LANGUAGE || 'EN').toUpperCase();\\nreturn [{ json: { repo: $vars.GITHUB_REPO, language, commits, issues, prs } }];"
+      },
+      "id": "prepare-prompt",
+      "name": "Prepare Summary Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [520, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{$vars.ANTHROPIC_API_KEY}}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\"model\":\"claude-sonnet-4-20250514\",\"max_tokens\":1200,\"messages\":[{\"role\":\"user\",\"content\":\"Write a concise weekly engineering narrative in \" + $json.language + \" for repo \" + $json.repo + \". Include commits, merged PRs, closed issues, delivery themes, risk notes, and next-week focus. Data: \" + JSON.stringify({commits:$json.commits, prs:$json.prs, issues:$json.issues}).slice(0, 12000)}]}"
+      },
+      "id": "claude-summary",
+      "name": "Generate Claude Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [760, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "const content = $json.content?.[0]?.text || 'No summary generated.';\\nreturn [{ json: { content: `## Weekly Dev Summary\\\\n\\\\n${content}` } }];"
+      },
+      "id": "format-discord",
+      "name": "Format Discord Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1000, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{$vars.DISCORD_WEBHOOK_URL}}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\"content\": $json.content}"
+      },
+      "id": "send-discord",
+      "name": "Send Discord Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1240, 0]
+    }
+  ],
+  "connections": {
+    "Weekly Friday 5pm": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed Issues",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed PRs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits": {
+      "main": [
+        [
+          {
+            "node": "Prepare Summary Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed Issues": {
+      "main": [
+        [
+          {
+            "node": "Prepare Summary Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed PRs": {
+      "main": [
+        [
+          {
+            "node": "Prepare Summary Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Summary Input": {
+      "main": [
+        [
+          {
+            "node": "Generate Claude Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Claude Summary": {
+      "main": [
+        [
+          {
+            "node": "Format Discord Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Discord Message": {
+      "main": [
+        [
+          {
+            "node": "Send Discord Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}
+


### PR DESCRIPTION
Closes #5

## Summary

- Adds an importable n8n workflow JSON for weekly GitHub development summaries.
- Uses a Friday 17:00 cron trigger.
- Fetches weekly commits, closed issues, and closed PRs from the GitHub API.
- Filters merged PRs, builds an EN/FR prompt, calls `claude-sonnet-4-20250514`, and posts to Discord via webhook.
- Documents setup in five steps and includes a structural workflow validator.

## Validation

- `python3 -m json.tool workflows/n8n-weekly-dev-summary/weekly-dev-summary.json`
- `cd workflows/n8n-weekly-dev-summary && python3 validate_workflow.py`
- `git diff --check`

Note: live n8n execution requires valid GitHub, Anthropic, and Discord credentials in the reviewer environment.