### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/submissions/duct-tape2/destructive-bash-hook/README.md
+++ b/submissions/duct-tape2/destructive-bash-hook/README.md
@@ -1,0 +1,62 @@
+# Destructive Bash PreToolUse Hook
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## Install in 2 commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block-destructive-bash.py ~/.claude/hooks/block-destructive-bash.py && chmod +x ~/.claude/hooks/block-destructive-bash.py
+python3 scripts/install-settings.py
+```
+
+## What it blocks
+
+- `rm` with both recursive and force flags, including `rm -rf`, `rm -fr`, and split flags like `rm -r -f`.
+- `git push --force`, `git push -f`, and `git push --force-with-lease`.
+- SQL `DROP TABLE`.
+- SQL `TRUNCATE` / `TRUNCATE TABLE`.
+- SQL `DELETE FROM` statements that do not include a `WHERE` clause.
+
+## What it allows
+
+- Normal Bash commands such as `ls`, `npm test`, `git push`, `rm file.txt`, and `DELETE FROM ... WHERE ...`.
+- Passive text inspection such as `echo "DROP TABLE users"` or `grep "DELETE FROM" migration.sql`.
+- Non-Bash Claude Code tool calls.
+
+## Hook behavior
+
+The hook reads Claude Code's JSON hook payload from stdin. When the tool is `Bash` and the command matches a blocked pattern, it:
+
+1. Appends a JSON line to `~/.claude/hooks/blocked.log`.
+2. Includes timestamp, attempted command, project path, matched rule, and reason.
+3. Returns a Claude Code `hookSpecificOutput` response with `permissionDecision: "deny"`.
+
+Safe commands exit with status 0 and no stdout, so they do not interfere with normal Bash usage.
+
+## Example settings
+
+The installer writes this shape into `~/.claude/settings.json` without removing existing hooks:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/you/.claude/hooks/block-destructive-bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Run tests
+
+```bash
+python3 -m unittest tests/test_block_destructive_bash.py
+```

--- a/submissions/duct-tape2/destructive-bash-hook/hooks/block-destructive-bash.py
+++ b/submissions/duct-tape2/destructive-bash-hook/hooks/block-destructive-bash.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+PASSIVE_COMMANDS = {
+    "cat",
+    "echo",
+    "grep",
+    "rg",
+    "sed",
+    "printf",
+    "awk",
+    "less",
+    "more",
+}
+
+SQL_CLIENT_TOKENS = {
+    "sqlite3",
+    "psql",
+    "mysql",
+    "mariadb",
+    "duckdb",
+    "sqlcmd",
+}
+
+
+def _read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _tokenize(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def _base_name(token: str) -> str:
+    return os.path.basename(token)
+
+
+def _first_real_command(tokens: list[str]) -> str:
+    skip = {"sudo", "env", "command", "builtin", "time"}
+    for token in tokens:
+        base = _base_name(token)
+        if base in skip or "=" in token and not token.startswith("-"):
+            continue
+        return base
+    return ""
+
+
+def _has_recursive_force_rm(tokens: list[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if _base_name(token) != "rm":
+            continue
+
+        has_recursive = False
+        has_force = False
+        for arg in tokens[index + 1 :]:
+            if arg in {";", "&&", "||", "|"}:
+                break
+            if arg == "--":
+                continue
+            if arg in {"-r", "-R", "--recursive"}:
+                has_recursive = True
+            elif arg in {"-f", "--force"}:
+                has_force = True
+            elif arg.startswith("-") and not arg.startswith("--"):
+                flags = arg[1:]
+                has_recursive = has_recursive or "r" in flags or "R" in flags
+                has_force = has_force or "f" in flags
+        if has_recursive and has_force:
+            return True
+    return False
+
+
+def _has_force_push(tokens: list[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if _base_name(token) != "git":
+            continue
+        try:
+            push_index = tokens.index("push", index + 1)
+        except ValueError:
+            continue
+        for arg in tokens[push_index + 1 :]:
+            if arg in {";", "&&", "||", "|"}:
+                break
+            if arg in {"-f", "--force", "--force-with-lease"}:
+                return True
+            if arg.startswith("--force-with-lease="):
+                return True
+    return False
+
+
+def _looks_like_sql_context(command: str, tokens: list[str]) -> bool:
+    first = _first_real_command(tokens)
+    if first in PASSIVE_COMMANDS:
+        return False
+    if any(_base_name(token) in SQL_CLIENT_TOKENS for token in tokens):
+        return True
+    if re.match(r"^\s*(DROP\s+TABLE|TRUNCATE(\s+TABLE)?|DELETE\s+FROM)\b", command, re.I):
+        return True
+    if re.search(r"\|\s*(sqlite3|psql|mysql|mariadb|duckdb|sqlcmd)\b", command):
+        return True
+    return False
+
+
+def _delete_without_where(command: str) -> bool:
+    for statement in re.split(r";|\n", command):
+        match = re.search(r"\bDELETE\s+FROM\b", statement, re.I)
+        if match and not re.search(r"\bWHERE\b", statement[match.end() :], re.I):
+            return True
+    return False
+
+
+def _has_sql_truncate(command: str, tokens: list[str]) -> bool:
+    first = _first_real_command(tokens)
+    has_sql_client = any(_base_name(token) in SQL_CLIENT_TOKENS for token in tokens)
+    if first == "truncate" and not has_sql_client:
+        return False
+    return bool(re.search(r"\bTRUNCATE\b", command, re.I))
+
+
+def _classify(command: str) -> tuple[bool, str, str]:
+    tokens = _tokenize(command)
+
+    if _has_recursive_force_rm(tokens):
+        return True, "rm_recursive_force", "Blocked rm with both recursive and force flags because it can delete large paths irreversibly."
+
+    if _has_force_push(tokens):
+        return True, "git_force_push", "Blocked git push with a force flag because it can overwrite remote history."
+
+    if _looks_like_sql_context(command, tokens):
+        if re.search(r"\bDROP\s+TABLE\b", command, re.I):
+            return True, "drop_table", "Blocked DROP TABLE because it can destroy database schema and data."
+        if _has_sql_truncate(command, tokens):
+            return True, "truncate", "Blocked TRUNCATE because it can remove table data without row-level review."
+        if _delete_without_where(command):
+            return True, "delete_without_where", "Blocked DELETE FROM without WHERE because it can remove every row in a table."
+
+    return False, "", ""
+
+
+def _log_block(command: str, project_path: str, matched_rule: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": project_path,
+        "matched_rule": matched_rule,
+        "reason": reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _deny(reason: str) -> None:
+    response = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(response, sort_keys=True))
+
+
+def main() -> int:
+    payload = _read_payload()
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    blocked, matched_rule, reason = _classify(command)
+    if not blocked:
+        return 0
+
+    project_path = str(payload.get("cwd") or os.getcwd())
+    _log_block(command, project_path, matched_rule, reason)
+    _deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/submissions/duct-tape2/destructive-bash-hook/scripts/install-settings.py
+++ b/submissions/duct-tape2/destructive-bash-hook/scripts/install-settings.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Install the Bash blocker hook into ~/.claude/settings.json without clobbering other hooks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+HOOK_COMMAND = str(Path.home() / ".claude" / "hooks" / "block-destructive-bash.py")
+
+
+def main() -> int:
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if SETTINGS_PATH.exists():
+        data = json.loads(SETTINGS_PATH.read_text(encoding="utf-8") or "{}")
+    else:
+        data = {}
+
+    hooks = data.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    group = None
+    for item in pre_tool_use:
+        if item.get("matcher") == "Bash":
+            group = item
+            break
+    if group is None:
+        group = {"matcher": "Bash", "hooks": []}
+        pre_tool_use.append(group)
+
+    handlers = group.setdefault("hooks", [])
+    handler = {"type": "command", "command": HOOK_COMMAND}
+    if not any(h.get("type") == "command" and h.get("command") == HOOK_COMMAND for h in handlers):
+        handlers.append(handler)
+
+    SETTINGS_PATH.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Installed PreToolUse Bash hook in {SETTINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/submissions/duct-tape2/destructive-bash-hook/tests/test_block_destructive_bash.py
+++ b/submissions/duct-tape2/destructive-bash-hook/tests/test_block_destructive_bash.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block-destructive-bash.py"
+
+
+class BlockDestructiveBashTests(unittest.TestCase):
+    def run_hook(self, command: str, *, tool_name: str = "Bash") -> tuple[subprocess.CompletedProcess[str], Path]:
+        home = Path(tempfile.mkdtemp())
+        payload = {
+            "tool_name": tool_name,
+            "tool_input": {"command": command},
+            "cwd": "/tmp/example-project",
+            "hook_event_name": "PreToolUse",
+        }
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+        return result, home / ".claude" / "hooks" / "blocked.log"
+
+    def assert_blocked(self, command: str, reason_fragment: str) -> None:
+        result, log_path = self.run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+        response = json.loads(result.stdout)
+        output = response["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "PreToolUse")
+        self.assertEqual(output["permissionDecision"], "deny")
+        self.assertIn(reason_fragment, output["permissionDecisionReason"])
+
+        self.assertTrue(log_path.exists())
+        entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+        self.assertEqual(entry["attempted_command"], command)
+        self.assertEqual(entry["project_path"], "/tmp/example-project")
+        self.assertIn(reason_fragment, entry["reason"])
+        self.assertIn("matched_rule", entry)
+        self.assertIn("timestamp", entry)
+
+    def assert_allowed(self, command: str, *, tool_name: str = "Bash") -> None:
+        result, log_path = self.run_hook(command, tool_name=tool_name)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        self.assertFalse(log_path.exists())
+
+    def test_blocks_rm_recursive_force_variants(self) -> None:
+        self.assert_blocked("rm -rf build", "recursive and force")
+        self.assert_blocked("sudo rm -r -f /tmp/demo", "recursive and force")
+        self.assert_blocked("rm --recursive --force old-cache", "recursive and force")
+
+    def test_blocks_git_force_push_variants(self) -> None:
+        self.assert_blocked("git push --force origin main", "remote history")
+        self.assert_blocked("git push -f", "remote history")
+        self.assert_blocked("git push --force-with-lease", "remote history")
+
+    def test_blocks_destructive_sql_in_sql_context(self) -> None:
+        self.assert_blocked("sqlite3 app.db 'DROP TABLE users;'", "DROP TABLE")
+        self.assert_blocked("psql -c 'truncate table events;'", "TRUNCATE")
+        self.assert_blocked("mysql -e 'DELETE FROM sessions;'", "DELETE FROM without WHERE")
+
+    def test_allows_safe_commands_and_passive_text(self) -> None:
+        self.assert_allowed("ls -la")
+        self.assert_allowed("npm test")
+        self.assert_allowed("git push origin main")
+        self.assert_allowed("rm file.txt")
+        self.assert_allowed("rm -r old-folder")
+        self.assert_allowed("sqlite3 app.db 'DELETE FROM sessions WHERE expires_at < 123;'")
+        self.assert_allowed("truncate -s 0 app.log")
+        self.assert_allowed("echo 'DROP TABLE users;'")
+        self.assert_allowed("grep 'DELETE FROM' migrations/*.sql")
+
+    def test_ignores_non_bash_tools(self) -> None:
+        self.assert_allowed("rm -rf build", tool_name="Read")
+
+    def test_malformed_json_is_allowed_safely(self) -> None:
+        home = Path(tempfile.mkdtemp())
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input="{not-json",
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        self.assertFalse((home / ".claude" / "hooks" / "blocked.log").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/submissions/duct-tape2/destructive-bash-hook/verification.md
+++ b/submissions/duct-tape2/destructive-bash-hook/verification.md
@@ -1,0 +1,33 @@
+# Verification
+
+This submission implements a Claude Code `PreToolUse` hook for Issue #3.
+
+## Acceptance checklist
+
+- Hook follows current Claude Code hook format with a `PreToolUse` event and `Bash` matcher.
+- Blocks `rm -rf` style recursive force delete commands.
+- Blocks `DROP TABLE`.
+- Blocks `git push --force`, `git push -f`, and `git push --force-with-lease`.
+- Blocks `TRUNCATE`.
+- Blocks `DELETE FROM` without a `WHERE` clause.
+- Logs every blocked attempt to `~/.claude/hooks/blocked.log`.
+- Log entries include timestamp, attempted command, project path, matched rule, and reason.
+- Returns a clear `permissionDecision: "deny"` reason to Claude.
+- Allows normal Bash commands and passive text inspection.
+- README installation is 2 commands.
+
+## Local test command
+
+```bash
+cd submissions/duct-tape2/destructive-bash-hook
+python3 -m unittest tests/test_block_destructive_bash.py
+```
+
+## Expected test coverage
+
+- Required destructive patterns are blocked.
+- Safe shell commands are allowed.
+- `DELETE FROM ... WHERE ...` is allowed.
+- Passive examples such as `echo "DROP TABLE users"` and `grep "DELETE FROM"` are allowed.
+- Non-Bash tool calls are ignored.
+- Malformed JSON input is handled safely without blocking or crashing.


### PR DESCRIPTION
Summary:
- Adds a Claude Code `PreToolUse` Bash hook that blocks destructive commands before execution.
- Blocks recursive force delete, force push, destructive SQL table operations, and `DELETE FROM` without `WHERE`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, matched rule, and reason.
- Includes a non-clobbering settings installer, 2-command README installation, and unittest coverage.

Bounty:
- Closes #3
- /claim #3

Verification:
- python3 -m py_compile hook, installer, and tests
- python3 -m unittest submissions/duct-tape2/destructive-bash-hook/tests/test_block_destructive_bash.py
- git diff --check
- Hidden Unicode / BOM / NBSP / CRLF / non-ASCII scan passed
- Temporary HOME installer test wrote valid Claude Code settings JSON

Notes:
- No paid APIs are required.
- The hook only inspects Claude Code Bash tool calls and ignores non-Bash tools.
- Safe commands such as `git push`, `rm file.txt`, `DELETE FROM ... WHERE ...`, and passive text inspection are allowed.
- Payment setup, if any, will be handled manually by the contributor after merge.
