### PR TITLE
feat: add destructive bash command blocker hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Every blocked command is appended to `~/.claude/hooks/blocked.log` as JSON with
 the timestamp, attempted command, project path, and matched rule. Normal Bash
 commands such as `ls`, `cat README.md`, and `npm test` pass through without
 output. Searches such as `grep -R 'DROP TABLE' migrations/` are treated as
-normal commands instead of destructive SQL execution.
+normal commands instead of destructive SQL execution. Blocked commands return
+Claude Code `PreToolUse` JSON with `permissionDecision: "deny"` and a clear
+reason for Claude.
 
 Install in one command from this repository:
 
@@ -105,13 +107,7 @@ Demo transcript:
 
 ```text
 $ printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./dist"},"cwd":"/repo"}' | python3 hooks/block_destructive_bash.py
-Blocked destructive Bash command before execution.
-Reason: recursive forced removal
-Project: /repo
-The attempted command was logged to ~/.claude/hooks/blocked.log.
-
-$ echo $?
-2
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Blocked destructive Bash command before execution.\nReason: recursive forced removal\nProject: /repo\nThe attempted command was logged to ~/.claude/hooks/blocked.log."}}
 
 $ printf '{"tool_name":"Bash","tool_input":{"command":"npm test"},"cwd":"/repo"}' | python3 hooks/block_destructive_bash.py
 $ echo $?

--- a/README.md
+++ b/README.md
@@ -34,6 +34,98 @@ You're in the right place.
 
 ---
 
+## Destructive Bash Command Hook
+
+The `hooks/block_destructive_bash.py` hook protects Claude Code projects by
+checking each Bash command before execution. It blocks commands that match the
+bounty requirements:
+
+- `rm -rf`
+- `DROP TABLE` in direct SQL or database CLI invocations
+- `git push --force` and `git push --force-with-lease`
+- `TRUNCATE` in direct SQL or database CLI invocations
+- `DELETE FROM` statements without a `WHERE` clause in direct SQL or database CLI invocations
+
+Every blocked command is appended to `~/.claude/hooks/blocked.log` as JSON with
+the timestamp, attempted command, project path, and matched rule. Normal Bash
+commands such as `ls`, `cat README.md`, and `npm test` pass through without
+output. Searches such as `grep -R 'DROP TABLE' migrations/` are treated as
+normal commands instead of destructive SQL execution.
+
+Install in one command from this repository:
+
+```bash
+python3 scripts/install_block_destructive_bash_hook.py
+```
+
+The installer copies the hook into `~/.claude/hooks/` and adds this Claude Code
+settings entry for the Bash tool:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Optional custom rules can be loaded with `DESTRUCTIVE_BASH_HOOK_CONFIG`:
+
+```json
+{
+  "allow": [
+    {
+      "name": "fixture cleanup",
+      "pattern": "^rm -rf \\.pytest_cache$"
+    }
+  ],
+  "deny": [
+    {
+      "name": "remove build output",
+      "pattern": "^rm -rf dist$"
+    }
+  ]
+}
+```
+
+Allow rules are checked before deny rules, so teams can create narrow exceptions
+without turning the blocker off.
+
+Demo transcript:
+
+```text
+$ printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./dist"},"cwd":"/repo"}' | python3 hooks/block_destructive_bash.py
+Blocked destructive Bash command before execution.
+Reason: recursive forced removal
+Project: /repo
+The attempted command was logged to ~/.claude/hooks/blocked.log.
+
+$ echo $?
+2
+
+$ printf '{"tool_name":"Bash","tool_input":{"command":"npm test"},"cwd":"/repo"}' | python3 hooks/block_destructive_bash.py
+$ echo $?
+0
+```
+
+Run tests:
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -16,11 +16,11 @@ from typing import Any
 DEFAULT_DENY_RULES = [
     {
         "name": "recursive forced removal",
-        "pattern": r"(?is)(^|[;&|]\s*)rm\s+(?:-[^\s]*r[^\s]*f|-+[^\s]*f[^\s]*r|(?:-[^\s]+\s+)*-r\s+(?:-[^\s]+\s+)*-f|(?:-[^\s]+\s+)*-f\s+(?:-[^\s]+\s+)*-r)\b",
+        "pattern": r"(?is)(^|[;&|]\s*)(?:sudo\s+|command\s+)?rm\s+(?=[^\n;&|]*?(?:-[^\s]*r[^\s]*\b|--recursive\b))(?=[^\n;&|]*?(?:-[^\s]*f[^\s]*\b|--force\b))",
     },
     {
         "name": "forced git push",
-        "pattern": r"(?is)\bgit\s+push\b[^\n;|&]*(?:--force(?:-with-lease)?\b|(?:^|\s)-f(?:\s|$))",
+        "pattern": r"(?is)(^|[;&|]\s*)git\s+(?:-[A-Za-z]\s+\S+\s+)*push\b[^\n;|&]*(?:--force(?:-with-lease)?\b|(?:^|\s)-f(?:\s|$))",
     },
 ]
 

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -185,14 +185,24 @@ def append_block_log(command: str, project_path: str, reason: str) -> None:
 
 def block(command: str, project_path: str, reason: str) -> int:
     append_block_log(command, project_path, reason)
-    print(
+    message = (
         "Blocked destructive Bash command before execution.\n"
         f"Reason: {reason}\n"
         f"Project: {project_path}\n"
-        "The attempted command was logged to ~/.claude/hooks/blocked.log.",
-        file=sys.stderr,
+        "The attempted command was logged to ~/.claude/hooks/blocked.log."
     )
-    return 2
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": message,
+                }
+            }
+        )
+    )
+    return 0
 
 
 def main() -> int:

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DENY_RULES = [
+    {
+        "name": "recursive forced removal",
+        "pattern": r"(?is)(^|[;&|]\s*)rm\s+(?:-[^\s]*r[^\s]*f|-+[^\s]*f[^\s]*r|(?:-[^\s]+\s+)*-r\s+(?:-[^\s]+\s+)*-f|(?:-[^\s]+\s+)*-f\s+(?:-[^\s]+\s+)*-r)\b",
+    },
+    {
+        "name": "forced git push",
+        "pattern": r"(?is)\bgit\s+push\b[^\n;|&]*(?:--force(?:-with-lease)?\b|(?:^|\s)-f(?:\s|$))",
+    },
+]
+
+
+DEFAULT_ALLOW_RULES: list[dict[str, str]] = []
+DATABASE_CLIENTS = {
+    "duckdb",
+    "mariadb",
+    "mysql",
+    "psql",
+    "sqlite3",
+}
+SQL_START_RE = re.compile(r"(?is)^\s*(?:DROP\s+TABLE|TRUNCATE|DELETE\s+FROM)\b")
+
+
+def load_event() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"Destructive command hook could not parse JSON input: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if not isinstance(event, dict):
+        print("Destructive command hook expected a JSON object from Claude Code.", file=sys.stderr)
+        sys.exit(2)
+    return event
+
+
+def normalize_rules(raw_rules: Any, default: list[dict[str, str]]) -> list[dict[str, str]]:
+    if raw_rules is None:
+        return list(default)
+    if not isinstance(raw_rules, list):
+        raise ValueError("rules must be a list")
+
+    rules: list[dict[str, str]] = []
+    for index, rule in enumerate(raw_rules):
+        if isinstance(rule, str):
+            rules.append({"name": rule, "pattern": rule})
+            continue
+        if isinstance(rule, dict) and isinstance(rule.get("pattern"), str):
+            rules.append({"name": str(rule.get("name") or f"rule {index + 1}"), "pattern": rule["pattern"]})
+            continue
+        raise ValueError(f"rule {index + 1} must be a string or object with a pattern")
+    return rules
+
+
+def load_config() -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    config_path = os.environ.get("DESTRUCTIVE_BASH_HOOK_CONFIG")
+    if not config_path:
+        return list(DEFAULT_DENY_RULES), list(DEFAULT_ALLOW_RULES)
+
+    path = Path(config_path).expanduser()
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise ValueError(f"config file does not exist: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"config file is not valid JSON: {exc}") from exc
+
+    if not isinstance(config, dict):
+        raise ValueError("config file must contain a JSON object")
+
+    deny = normalize_rules(config.get("deny"), DEFAULT_DENY_RULES)
+    allow = normalize_rules(config.get("allow"), DEFAULT_ALLOW_RULES)
+    return deny, allow
+
+
+def get_tool_name(event: dict[str, Any]) -> str:
+    for key in ("tool_name", "toolName", "name"):
+        value = event.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def get_command(event: dict[str, Any]) -> str | None:
+    candidates = [
+        event.get("tool_input"),
+        event.get("toolInput"),
+        event.get("input"),
+        event.get("parameters"),
+        event,
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, dict) and isinstance(candidate.get("command"), str):
+            return candidate["command"]
+    return None
+
+
+def get_project_path(event: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "projectPath", "workspace", "workspace_path"):
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return os.getcwd()
+
+
+def delete_from_without_where(command: str) -> bool:
+    statements = re.split(r";|\n", command, flags=re.IGNORECASE)
+    for statement in statements:
+        if re.search(r"(?is)\bDELETE\s+FROM\b", statement) and not re.search(r"(?is)\bWHERE\b", statement):
+            return True
+    return False
+
+
+def shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        return []
+
+
+def includes_database_client(command: str) -> bool:
+    words = shell_words(command)
+    for word in words:
+        binary = Path(word).name.lower()
+        if binary in DATABASE_CLIENTS:
+            return True
+    return bool(re.search(r"(?is)(?:^|[|;&]\s*)(?:psql|mysql|mariadb|sqlite3|duckdb)\b", command))
+
+
+def should_inspect_sql(command: str) -> bool:
+    return bool(SQL_START_RE.search(command)) or includes_database_client(command)
+
+
+def destructive_sql_reason(command: str) -> str | None:
+    if not should_inspect_sql(command):
+        return None
+    if re.search(r"(?is)\bDROP\s+TABLE\b", command):
+        return "drop table statement"
+    if re.search(r"(?is)\bTRUNCATE\b", command):
+        return "truncate statement"
+    if delete_from_without_where(command):
+        return "DELETE FROM without a WHERE clause"
+    return None
+
+
+def match_rule(command: str, rules: list[dict[str, str]]) -> str | None:
+    for rule in rules:
+        try:
+            if re.search(rule["pattern"], command):
+                return rule["name"]
+        except re.error as exc:
+            print(f"Ignoring invalid destructive command hook regex {rule['name']!r}: {exc}", file=sys.stderr)
+    return None
+
+
+def append_block_log(command: str, project_path: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "command": command,
+        "project_path": project_path,
+        "reason": reason,
+    }
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def block(command: str, project_path: str, reason: str) -> int:
+    append_block_log(command, project_path, reason)
+    print(
+        "Blocked destructive Bash command before execution.\n"
+        f"Reason: {reason}\n"
+        f"Project: {project_path}\n"
+        "The attempted command was logged to ~/.claude/hooks/blocked.log.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def main() -> int:
+    event = load_event()
+    tool_name = get_tool_name(event)
+    command = get_command(event)
+    if tool_name and tool_name.lower() != "bash":
+        return 0
+    if not command:
+        return 0
+
+    try:
+        deny_rules, allow_rules = load_config()
+    except ValueError as exc:
+        print(f"Destructive command hook configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    allowed = match_rule(command, allow_rules)
+    if allowed:
+        return 0
+
+    denied = match_rule(command, deny_rules)
+    if denied:
+        return block(command, get_project_path(event), denied)
+
+    destructive_sql = destructive_sql_reason(command)
+    if destructive_sql:
+        return block(command, get_project_path(event), destructive_sql)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_block_destructive_bash_hook.py
+++ b/scripts/install_block_destructive_bash_hook.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash command blocker into Claude Code settings."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+from pathlib import Path
+
+
+HOOK_NAME = "block_destructive_bash.py"
+
+
+def command_for(path: Path) -> str:
+    return f"python3 {path}"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    source_hook = repo_root / "hooks" / HOOK_NAME
+    claude_dir = Path.home() / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    settings_path = claude_dir / "settings.json"
+    target_hook = hooks_dir / HOOK_NAME
+
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_hook, target_hook)
+    target_hook.chmod(target_hook.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    if settings_path.exists():
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        if not isinstance(settings, dict):
+            raise ValueError(f"{settings_path} must contain a JSON object")
+    else:
+        settings = {}
+
+    pre_tool_use = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    hook_command = command_for(target_hook)
+    entry = {"type": "command", "command": hook_command}
+    matcher_block = next(
+        (item for item in pre_tool_use if isinstance(item, dict) and item.get("matcher") == "Bash"),
+        None,
+    )
+    if matcher_block is None:
+        pre_tool_use.append({"matcher": "Bash", "hooks": [entry]})
+    else:
+        hooks = matcher_block.setdefault("hooks", [])
+        if entry not in hooks:
+            hooks.append(entry)
+
+    settings_path.write_text(json.dumps(settings, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.chmod(settings_path, 0o600)
+
+    print(f"Installed {target_hook}")
+    print(f"Updated {settings_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -36,12 +36,20 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
             "cwd": "/tmp/example-project",
         }
 
+    def assert_blocked(self, result: subprocess.CompletedProcess[str], reason: str) -> None:
+        output = json.loads(result.stdout)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output["hookSpecificOutput"]["hookEventName"], "PreToolUse")
+        self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn(reason, output["hookSpecificOutput"]["permissionDecisionReason"])
+
     def test_allows_normal_bash_commands(self) -> None:
         with tempfile.TemporaryDirectory() as home:
             result = self.run_hook(self.bash_event("ls && cat README.md && npm test"), home)
 
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stderr, "")
+        self.assertEqual(result.stdout, "")
 
     def test_allows_searching_for_dangerous_sql_text(self) -> None:
         with tempfile.TemporaryDirectory() as home:
@@ -55,8 +63,7 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
             log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
             log = json.loads(log_path.read_text(encoding="utf-8").strip())
 
-        self.assertEqual(result.returncode, 2)
-        self.assertIn("recursive forced removal", result.stderr)
+        self.assert_blocked(result, "recursive forced removal")
         self.assertEqual(log["command"], "rm -rf ./dist")
         self.assertEqual(log["project_path"], "/tmp/example-project")
         self.assertEqual(log["reason"], "recursive forced removal")
@@ -67,7 +74,7 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
         for command in variants:
             with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
                 result = self.run_hook(self.bash_event(command), home)
-                self.assertEqual(result.returncode, 2)
+                self.assert_blocked(result, "recursive forced removal")
 
     def test_blocks_required_sql_patterns(self) -> None:
         destructive_commands = [
@@ -80,7 +87,8 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
         for command in destructive_commands:
             with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
                 result = self.run_hook(self.bash_event(command), home)
-                self.assertEqual(result.returncode, 2)
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(json.loads(result.stdout)["hookSpecificOutput"]["permissionDecision"], "deny")
 
     def test_delete_with_where_is_allowed(self) -> None:
         with tempfile.TemporaryDirectory() as home:
@@ -94,8 +102,7 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
             with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
                 result = self.run_hook(self.bash_event(command), home)
 
-            self.assertEqual(result.returncode, 2)
-            self.assertIn("forced git push", result.stderr)
+            self.assert_blocked(result, "forced git push")
 
     def test_custom_allow_rule_overrides_default_deny_rule(self) -> None:
         with tempfile.TemporaryDirectory() as home:

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "hooks" / "block_destructive_bash.py"
+
+
+class BlockDestructiveBashHookTest(unittest.TestCase):
+    def run_hook(self, event: dict, home: str, config: Path | None = None) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["HOME"] = home
+        if config is not None:
+            env["DESTRUCTIVE_BASH_HOOK_CONFIG"] = str(config)
+        return subprocess.run(
+            ["python3", str(HOOK)],
+            input=json.dumps(event),
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+    def bash_event(self, command: str) -> dict:
+        return {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": "/tmp/example-project",
+        }
+
+    def test_allows_normal_bash_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = self.run_hook(self.bash_event("ls && cat README.md && npm test"), home)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_allows_searching_for_dangerous_sql_text(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = self.run_hook(self.bash_event("grep -R 'DROP TABLE' migrations/"), home)
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_blocks_rm_rf_and_logs_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = self.run_hook(self.bash_event("rm -rf ./dist"), home)
+            log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
+            log = json.loads(log_path.read_text(encoding="utf-8").strip())
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("recursive forced removal", result.stderr)
+        self.assertEqual(log["command"], "rm -rf ./dist")
+        self.assertEqual(log["project_path"], "/tmp/example-project")
+        self.assertEqual(log["reason"], "recursive forced removal")
+        self.assertIsNotNone(datetime.fromisoformat(log["timestamp"]))
+
+    def test_blocks_rm_force_recursive_variants(self) -> None:
+        variants = ["rm -fr ./dist", "rm -r -f ./dist", "rm -f -r ./dist"]
+        for command in variants:
+            with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
+                result = self.run_hook(self.bash_event(command), home)
+                self.assertEqual(result.returncode, 2)
+
+    def test_blocks_required_sql_patterns(self) -> None:
+        destructive_commands = [
+            "DROP TABLE users",
+            "psql -c 'DROP TABLE users'",
+            "mysql -e 'TRUNCATE sessions'",
+            "psql -c 'DELETE FROM audit_log'",
+            "echo 'DROP TABLE users' | psql",
+        ]
+        for command in destructive_commands:
+            with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
+                result = self.run_hook(self.bash_event(command), home)
+                self.assertEqual(result.returncode, 2)
+
+    def test_delete_with_where_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = self.run_hook(self.bash_event("psql -c 'DELETE FROM sessions WHERE id = 1'"), home)
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_blocks_force_push(self) -> None:
+        force_pushes = ["git push origin main --force-with-lease", "git push origin main -f"]
+        for command in force_pushes:
+            with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
+                result = self.run_hook(self.bash_event(command), home)
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("forced git push", result.stderr)
+
+    def test_custom_allow_rule_overrides_default_deny_rule(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            config = Path(home) / "hook-config.json"
+            config.write_text(
+                json.dumps({"allow": [{"name": "fixture cleanup", "pattern": r"^rm -rf \.pytest_cache$"}]}),
+                encoding="utf-8",
+            )
+            result = self.run_hook(self.bash_event("rm -rf .pytest_cache"), home, config)
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_ignores_non_bash_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = self.run_hook({"tool_name": "Read", "tool_input": {"command": "rm -rf ."}}, home)
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_installer_writes_hook_and_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = subprocess.run(
+                ["python3", str(REPO_ROOT / "scripts" / "install_block_destructive_bash_hook.py")],
+                text=True,
+                capture_output=True,
+                env={**os.environ, "HOME": home},
+                check=False,
+            )
+            settings_path = Path(home) / ".claude" / "settings.json"
+            hook_path = Path(home) / ".claude" / "hooks" / "block_destructive_bash.py"
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(hook_path.exists())
+            self.assertIn("PreToolUse", settings["hooks"])
+            self.assertEqual(settings["hooks"]["PreToolUse"][0]["matcher"], "Bash")
+
+    def test_installer_preserves_existing_hooks_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            settings_path = Path(home) / ".claude" / "settings.json"
+            settings_path.parent.mkdir(parents=True)
+            settings_path.write_text(
+                json.dumps(
+                    {
+                        "theme": "dark",
+                        "hooks": {
+                            "PreToolUse": [
+                                {
+                                    "matcher": "Read",
+                                    "hooks": [{"type": "command", "command": "echo read"}],
+                                }
+                            ]
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            for _ in range(2):
+                result = subprocess.run(
+                    ["python3", str(REPO_ROOT / "scripts" / "install_block_destructive_bash_hook.py")],
+                    text=True,
+                    capture_output=True,
+                    env={**os.environ, "HOME": home},
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            pre_tool_use = settings["hooks"]["PreToolUse"]
+            bash_blocks = [item for item in pre_tool_use if item["matcher"] == "Bash"]
+
+            self.assertEqual(settings["theme"], "dark")
+            self.assertEqual(pre_tool_use[0]["matcher"], "Read")
+            self.assertEqual(len(bash_blocks), 1)
+            self.assertEqual(len(bash_blocks[0]["hooks"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -57,6 +57,12 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0)
 
+    def test_allows_echoing_dangerous_shell_text(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = self.run_hook(self.bash_event("echo 'rm -rf ./dist'"), home)
+
+        self.assertEqual(result.returncode, 0)
+
     def test_blocks_rm_rf_and_logs_attempt(self) -> None:
         with tempfile.TemporaryDirectory() as home:
             result = self.run_hook(self.bash_event("rm -rf ./dist"), home)
@@ -70,7 +76,13 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
         self.assertIsNotNone(datetime.fromisoformat(log["timestamp"]))
 
     def test_blocks_rm_force_recursive_variants(self) -> None:
-        variants = ["rm -fr ./dist", "rm -r -f ./dist", "rm -f -r ./dist"]
+        variants = [
+            "rm -fr ./dist",
+            "rm -r -f ./dist",
+            "rm -f -r ./dist",
+            "sudo rm -rf ./dist",
+            "command rm --recursive --force ./dist",
+        ]
         for command in variants:
             with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
                 result = self.run_hook(self.bash_event(command), home)
@@ -97,7 +109,11 @@ class BlockDestructiveBashHookTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
 
     def test_blocks_force_push(self) -> None:
-        force_pushes = ["git push origin main --force-with-lease", "git push origin main -f"]
+        force_pushes = [
+            "git push origin main --force-with-lease",
+            "git push origin main -f",
+            "git -C ../repo push origin main --force",
+        ]
         for command in force_pushes:
             with self.subTest(command=command), tempfile.TemporaryDirectory() as home:
                 result = self.run_hook(self.bash_event(command), home)


### PR DESCRIPTION
Closes #3.

## Summary

- Adds a Claude Code `PreToolUse` Bash hook at `hooks/block_destructive_bash.py`.
- Blocks the required destructive patterns: `rm -rf`, `DROP TABLE`, forced git pushes, `TRUNCATE`, and `DELETE FROM` statements without `WHERE`.
- Logs every blocked command to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and matched rule.
- Adds a one-command installer that copies the hook into `~/.claude/hooks/` and updates `~/.claude/settings.json`.
- Documents install, configuration, examples, and a demo transcript in the README.
- Avoids false positives for normal text-search commands such as `grep -R 'DROP TABLE' migrations/` while still blocking destructive SQL passed to database CLIs.
- Includes installer regression coverage for preserving existing Claude Code hooks and avoiding duplicate entries on repeated installs.
- Returns Claude Code `PreToolUse` JSON with `permissionDecision: "deny"` for blocked commands.

## Configuration

The hook supports optional JSON configuration through `DESTRUCTIVE_BASH_HOOK_CONFIG`.
Allow rules are evaluated before deny rules so teams can add narrow exceptions without disabling the blocker.

## Demo Transcript

```text
$ printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./dist"},"cwd":"/repo"}' | python3 hooks/block_destructive_bash.py
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Blocked destructive Bash command before execution.\nReason: recursive forced removal\nProject: /repo\nThe attempted command was logged to ~/.claude/hooks/blocked.log."}}

$ printf '{"tool_name":"Bash","tool_input":{"command":"npm test"},"cwd":"/repo"}' | python3 hooks/block_destructive_bash.py
$ echo $?
0
```

## Verification

```bash
python3 -m unittest discover -s tests
python3 -m py_compile hooks/block_destructive_bash.py scripts/install_block_destructive_bash_hook.py tests/test_block_destructive_bash.py
```

Both commands pass locally. The unittest suite currently has 11 tests.
