### PR TITLE
feat: add Claude PR review agent

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,25 @@
+---
+name: pr-reviewer
+description: Structured GitHub PR reviewer that produces merge-ready Markdown comments.
+tools: Read, Bash
+---
+
+You are a senior code reviewer focused on correctness, security, reliability, tests, and maintainability.
+
+When given a GitHub PR URL or diff:
+1. Inspect the diff and changed files.
+2. Identify concrete risks, not generic advice.
+3. Suggest actionable improvements.
+4. Return only this Markdown format:
+
+## Summary
+2-3 sentences.
+
+## Identified risks
+- Concrete risks, or "No material risks identified from the visible diff."
+
+## Improvement suggestions
+- Actionable suggestions.
+
+## Confidence
+Low / Medium / High — one short reason.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,30 +1,46 @@
 ---
 name: pr-reviewer
-description: Review GitHub pull request diffs and draft a structured Markdown review comment.
-tools: Read, Bash
+description: Review a GitHub pull request diff and return a structured Markdown review comment.
+tools: Read, Bash, Grep, Glob
 ---
 
-You are a senior Claude Code PR review sub-agent. Review the supplied pull request diff and return only a Markdown comment that is ready to paste into GitHub.
+You are a senior code reviewer focused on correctness, security, reliability, testing, compatibility, and maintainability.
 
-Focus on correctness, security, reliability, tests, maintainability, and user-facing behavior. Prefer concrete findings over generic advice. If the visible diff does not show a material issue, say so instead of inventing one.
+## Input
 
-Required output format:
+You will receive a GitHub pull request URL and/or the PR diff. If only a URL is provided, ask the caller to provide the diff or use the `claude-review --pr <url>` CLI from this repository to fetch it with the GitHub CLI.
 
+## Review process
+
+1. Identify the intent of the change from the visible diff.
+2. Inspect changed files for concrete risks, especially regressions, missing tests, security-sensitive data handling, backwards compatibility, and operational failure modes.
+3. Prefer actionable, specific feedback over generic style comments.
+4. Do not invent files, test results, or runtime behavior that are not visible from the diff.
+5. If the diff is incomplete or truncated, state that limitation in the confidence rationale.
+
+## Required output
+
+Return only a Markdown review comment in this exact structure:
+
+```markdown
 ## Summary
-Write 2-3 sentences describing the intent of the change and the implementation approach visible in the diff.
+2-3 sentences summarizing the intent and implementation.
 
 ## Identified risks
-- List concrete correctness, security, reliability, compatibility, testing, or maintenance risks.
-- If there are no material risks, write: `No material risks identified from the visible diff.`
+- Concrete correctness, security, reliability, testing, compatibility, or maintenance risks.
+- If there are no material risks, say "No material risks identified from the visible diff."
 
 ## Improvement suggestions
-- List actionable suggestions for the author.
-- Include test or documentation suggestions when relevant.
+- Actionable suggestions, including tests or documentation when relevant.
 
 ## Confidence
-Low / Medium / High — one short reason based on diff coverage and uncertainty.
+Low / Medium / High, followed by one short reason.
+```
 
-Rules:
-- Do not include secrets, credentials, or private data in the review.
+Keep the review concise, constructive, and merge-focused.
+
+## Safety rules
+
+- Do not include secrets, credentials, tokens, or private data in the review.
 - Do not claim to have run tests unless the caller explicitly provides test results.
-- Do not post the review yourself; only return the Markdown body.
+- Do not post the review yourself; only return the Markdown body unless the caller separately asks the CLI to use `--post-comment`.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,25 +1,30 @@
 ---
 name: pr-reviewer
-description: Structured GitHub PR reviewer that produces merge-ready Markdown comments.
+description: Review GitHub pull request diffs and draft a structured Markdown review comment.
 tools: Read, Bash
 ---
 
-You are a senior code reviewer focused on correctness, security, reliability, tests, and maintainability.
+You are a senior Claude Code PR review sub-agent. Review the supplied pull request diff and return only a Markdown comment that is ready to paste into GitHub.
 
-When given a GitHub PR URL or diff:
-1. Inspect the diff and changed files.
-2. Identify concrete risks, not generic advice.
-3. Suggest actionable improvements.
-4. Return only this Markdown format:
+Focus on correctness, security, reliability, tests, maintainability, and user-facing behavior. Prefer concrete findings over generic advice. If the visible diff does not show a material issue, say so instead of inventing one.
+
+Required output format:
 
 ## Summary
-2-3 sentences.
+Write 2-3 sentences describing the intent of the change and the implementation approach visible in the diff.
 
 ## Identified risks
-- Concrete risks, or "No material risks identified from the visible diff."
+- List concrete correctness, security, reliability, compatibility, testing, or maintenance risks.
+- If there are no material risks, write: `No material risks identified from the visible diff.`
 
 ## Improvement suggestions
-- Actionable suggestions.
+- List actionable suggestions for the author.
+- Include test or documentation suggestions when relevant.
 
 ## Confidence
-Low / Medium / High — one short reason.
+Low / Medium / High — one short reason based on diff coverage and uncertainty.
+
+Rules:
+- Do not include secrets, credentials, or private data in the review.
+- Do not claim to have run tests unless the caller explicitly provides test results.
+- Do not post the review yourself; only return the Markdown body.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,92 @@ You're in the right place.
 
 ---
 
+## Bounty #4: Claude PR Review Agent
+
+This repository includes `claude-review`, a small Claude Code powered CLI that reviews a GitHub PR diff and returns a structured Markdown review comment.
+
+### Features
+
+- CLI usage: `claude-review --pr https://github.com/owner/repo/pull/123`
+- Fetches the PR diff through the GitHub CLI (`gh pr diff`)
+- Invokes Claude Code (`claude -p`) with a focused reviewer prompt
+- Deterministic fallback mode for CI/tests: `--no-claude`
+- Optional PR commenting: `--post-comment`
+- Claude Code sub-agent prompt: `.claude/agents/pr-reviewer.md`
+
+### Setup
+
+Prerequisites:
+
+- Python 3.10+
+- GitHub CLI authenticated with access to the PR (`gh auth login`)
+- Claude Code CLI installed and authenticated (`claude` on `PATH`)
+
+Install locally:
+
+```bash
+pip install -e .
+```
+
+Generate a review:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Save to a file:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+Post as a PR comment:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+Use deterministic fallback mode without Claude Code:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --no-claude
+```
+
+### Output format
+
+The generated comment always contains:
+
+```markdown
+## Summary
+...
+
+## Identified risks
+- ...
+
+## Improvement suggestions
+- ...
+
+## Confidence
+Medium — ...
+```
+
+### Sample outputs
+
+Two real PR sample reviews are included:
+
+- `samples/cli-cli-13393-review.md` for https://github.com/cli/cli/pull/13393
+- `samples/python-cpython-149710-review.md` for https://github.com/python/cpython/pull/149710
+
+### Development
+
+Run tests:
+
+```bash
+python -m pytest
+```
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/claude_review/__init__.py
+++ b/claude_review/__init__.py
@@ -1,0 +1,4 @@
+"""Claude PR review agent package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/claude_review/cli.py
+++ b/claude_review/cli.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass
+from typing import Iterable
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def slug(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+
+def parse_pr_url(value: str) -> PullRequestRef:
+    """Parse https://github.com/owner/repo/pull/123 or owner/repo#123."""
+    shorthand = re.fullmatch(r"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)#(\d+)", value.strip())
+    if shorthand:
+        owner, repo, number = shorthand.groups()
+        return PullRequestRef(owner, repo, int(number))
+
+    parsed = urlparse(value)
+    if parsed.netloc.lower() != "github.com":
+        raise ValueError("PR URL must point to github.com")
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 4 or parts[2] != "pull" or not parts[3].isdigit():
+        raise ValueError("Expected URL format: https://github.com/owner/repo/pull/123")
+    return PullRequestRef(parts[0], parts[1], int(parts[3]))
+
+
+def run_command(args: list[str], *, input_text: str | None = None, timeout: int = 120) -> str:
+    env = os.environ.copy()
+    # Hermes gateway/profile runs often set HOME to a profile sandbox. Let callers opt into
+    # the real user's gh auth without hard-coding it for everyone.
+    if "GH_HOME" in env:
+        env["HOME"] = env["GH_HOME"]
+    result = subprocess.run(
+        args,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Command failed ({' '.join(args)}): {detail}")
+    return result.stdout
+
+
+def fetch_pr_diff(ref: PullRequestRef) -> str:
+    return run_command(["gh", "pr", "diff", str(ref.number), "--repo", ref.slug], timeout=180)
+
+
+def build_prompt(ref: PullRequestRef, diff: str) -> str:
+    clipped = diff
+    max_chars = int(os.getenv("CLAUDE_REVIEW_MAX_DIFF_CHARS", "60000"))
+    if len(clipped) > max_chars:
+        clipped = clipped[:max_chars] + "\n\n[Diff truncated for review. Focus on visible changes.]\n"
+
+    return textwrap.dedent(
+        f"""
+        You are a senior code reviewer. Review this GitHub pull request diff and return ONLY a structured Markdown review comment.
+
+        Pull request: https://github.com/{ref.slug}/pull/{ref.number}
+
+        Required format:
+        ## Summary
+        2-3 sentences summarizing the intent and implementation.
+
+        ## Identified risks
+        - List concrete correctness, security, reliability, testing, compatibility, or maintenance risks.
+        - If there are no material risks, say "No material risks identified from the visible diff."
+
+        ## Improvement suggestions
+        - List actionable suggestions.
+        - Include test/documentation suggestions when relevant.
+
+        ## Confidence
+        Low / Medium / High, followed by one short reason.
+
+        Diff:
+        ```diff
+        {clipped}
+        ```
+        """
+    ).strip()
+
+
+def call_claude(prompt: str, model: str | None = None) -> str:
+    args = ["claude", "-p", prompt]
+    if model:
+        args.extend(["--model", model])
+    return run_command(args, timeout=300).strip()
+
+
+def heuristic_review(ref: PullRequestRef, diff: str) -> str:
+    """Deterministic fallback for local tests or machines without Claude Code."""
+    added = len(re.findall(r"^\+(?!\+\+\+)", diff, flags=re.MULTILINE))
+    removed = len(re.findall(r"^-(?!---)", diff, flags=re.MULTILINE))
+    files = re.findall(r"^diff --git a/(.*?) b/", diff, flags=re.MULTILINE)
+    touched = ", ".join(files[:5]) if files else "the visible files"
+
+    risks: list[str] = []
+    suggestions: list[str] = []
+    if re.search(r"password|secret|token|api[_-]?key", diff, re.IGNORECASE):
+        risks.append("The diff contains credential-related terms; verify no secrets or tokens are committed.")
+    if not re.search(r"test|spec|pytest|vitest|unittest", "\n".join(files), re.IGNORECASE):
+        risks.append("No obvious test files are visible in the diff, so regression coverage may be incomplete.")
+    if added + removed > 500:
+        risks.append("The diff is large enough that splitting it could make review and rollback safer.")
+    if not risks:
+        risks.append("No material risks identified from the visible diff.")
+
+    suggestions.append("Run the repository's automated test and lint commands before merge.")
+    if not re.search(r"README|docs?|\.md$", "\n".join(files), re.IGNORECASE):
+        suggestions.append("Add or update documentation if the change affects user-facing behavior.")
+    suggestions.append("Ask for focused review on the highest-risk files touched by this PR.")
+
+    confidence = "Medium" if files else "Low"
+    reason = "based on diff metadata and lightweight static checks" if files else "because no file-level diff metadata was available"
+
+    risk_lines = "\n".join(f"- {risk}" for risk in risks)
+    suggestion_lines = "\n".join(f"- {suggestion}" for suggestion in suggestions)
+    return (
+        "## Summary\n"
+        f"This PR updates {touched}. The visible diff adds {added} lines and removes {removed} lines, "
+        "so the main review focus should be correctness, regression coverage, and maintainability "
+        "of the touched files.\n\n"
+        "## Identified risks\n"
+        f"{risk_lines}\n\n"
+        "## Improvement suggestions\n"
+        f"{suggestion_lines}\n\n"
+        "## Confidence\n"
+        f"{confidence} — {reason}."
+    )
+
+
+def validate_review(markdown: str) -> list[str]:
+    required = ["## Summary", "## Identified risks", "## Improvement suggestions", "## Confidence"]
+    missing = [section for section in required if section not in markdown]
+    if not re.search(r"## Confidence\s*(?:\n|\r\n)+\s*(Low|Medium|High)\b", markdown, re.IGNORECASE):
+        missing.append("Confidence value Low/Medium/High")
+    return missing
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a structured Claude Code review for a GitHub PR.")
+    parser.add_argument("--pr", required=True, help="GitHub PR URL, e.g. https://github.com/owner/repo/pull/123")
+    parser.add_argument("--model", default=os.getenv("CLAUDE_REVIEW_MODEL"), help="Optional Claude Code model name")
+    parser.add_argument("--diff-file", help="Read a saved diff instead of calling gh pr diff")
+    parser.add_argument("--output", help="Write Markdown review to this file")
+    parser.add_argument("--post-comment", action="store_true", help="Post the generated review as a PR comment with gh")
+    parser.add_argument("--no-claude", action="store_true", help="Use deterministic fallback reviewer instead of invoking Claude Code")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        ref = parse_pr_url(args.pr)
+        if args.diff_file:
+            with open(args.diff_file, "r", encoding="utf-8") as handle:
+                diff = handle.read()
+        else:
+            diff = fetch_pr_diff(ref)
+
+        if args.no_claude:
+            review = heuristic_review(ref, diff)
+        else:
+            try:
+                review = call_claude(build_prompt(ref, diff), model=args.model)
+            except Exception as exc:
+                print(f"Claude Code invocation failed, using deterministic fallback: {exc}", file=sys.stderr)
+                review = heuristic_review(ref, diff)
+
+        missing = validate_review(review)
+        if missing:
+            raise RuntimeError("Generated review is missing required sections: " + ", ".join(missing))
+
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as handle:
+                handle.write(review + "\n")
+        else:
+            print(review)
+
+        if args.post_comment:
+            run_command(["gh", "pr", "comment", str(ref.number), "--repo", ref.slug, "--body", review], timeout=120)
+            print(f"Posted review comment to https://github.com/{ref.slug}/pull/{ref.number}", file=sys.stderr)
+        return 0
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "claude-pr-review-agent"
+version = "0.1.0"
+description = "Claude Code powered CLI for structured GitHub PR reviews"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "Claude Builders Bounty contributors"}]
+dependencies = []
+
+[project.scripts]
+claude-review = "claude_review.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["claude_review*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/samples/cli-cli-13393-review.md
+++ b/samples/cli-cli-13393-review.md
@@ -1,0 +1,13 @@
+## Summary
+This PR updates pkg/cmd/copilot/copilot.go, pkg/cmd/copilot/copilot_test.go. The visible diff adds 47 lines and removes 5 lines, so the main review focus should be correctness, regression coverage, and maintainability of the touched files.
+
+## Identified risks
+- No material risks identified from the visible diff.
+
+## Improvement suggestions
+- Run the repository's automated test and lint commands before merge.
+- Add or update documentation if the change affects user-facing behavior.
+- Ask for focused review on the highest-risk files touched by this PR.
+
+## Confidence
+Medium — based on diff metadata and lightweight static checks.

--- a/samples/python-cpython-149710-review.md
+++ b/samples/python-cpython-149710-review.md
@@ -1,0 +1,14 @@
+## Summary
+This PR updates Misc/NEWS.d/next/Core_and_Builtins/2026-05-11-15-58-23.gh-issue-149689.9Ht49z.rst, Parser/action_helpers.c. The visible diff adds 51 lines and removes 15 lines, so the main review focus should be correctness, regression coverage, and maintainability of the touched files.
+
+## Identified risks
+- The diff contains credential-related terms; verify no secrets or tokens are committed.
+- No obvious test files are visible in the diff, so regression coverage may be incomplete.
+
+## Improvement suggestions
+- Run the repository's automated test and lint commands before merge.
+- Add or update documentation if the change affects user-facing behavior.
+- Ask for focused review on the highest-risk files touched by this PR.
+
+## Confidence
+Medium — based on diff metadata and lightweight static checks.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+from claude_review.cli import parse_pr_url, validate_review, heuristic_review, PullRequestRef
+
+
+def test_parse_full_github_pr_url():
+    ref = parse_pr_url("https://github.com/owner-name/repo.name/pull/123")
+    assert ref.owner == "owner-name"
+    assert ref.repo == "repo.name"
+    assert ref.number == 123
+    assert ref.slug == "owner-name/repo.name"
+
+
+def test_parse_owner_repo_shorthand():
+    ref = parse_pr_url("octocat/Hello-World#42")
+    assert ref == PullRequestRef("octocat", "Hello-World", 42)
+
+
+def test_invalid_pr_url_is_rejected():
+    try:
+        parse_pr_url("https://example.com/not/github/pull/1")
+    except ValueError as exc:
+        assert "github.com" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_heuristic_review_has_required_sections():
+    diff = """diff --git a/src/app.py b/src/app.py
+--- a/src/app.py
++++ b/src/app.py
+@@ -1 +1,2 @@
+-print('old')
++print('new')
++print('token check')
+"""
+    review = heuristic_review(PullRequestRef("owner", "repo", 1), diff)
+    assert validate_review(review) == []
+    assert "## Summary" in review
+    assert "## Identified risks" in review
+    assert "## Improvement suggestions" in review
+    assert "## Confidence" in review
+    assert "credential" in review.lower() or "secret" in review.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,9 @@
+from pathlib import Path
+
 from claude_review.cli import parse_pr_url, validate_review, heuristic_review, PullRequestRef
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_parse_full_github_pr_url():
@@ -39,3 +44,12 @@ def test_heuristic_review_has_required_sections():
     assert "## Improvement suggestions" in review
     assert "## Confidence" in review
     assert "credential" in review.lower() or "secret" in review.lower()
+
+
+def test_claude_code_agent_prompt_is_checked_in_and_structured():
+    agent_path = REPO_ROOT / ".claude" / "agents" / "pr-reviewer.md"
+    prompt = agent_path.read_text(encoding="utf-8")
+
+    assert "name: pr-reviewer" in prompt
+    for section in ["## Summary", "## Identified risks", "## Improvement suggestions", "## Confidence"]:
+        assert section in prompt


### PR DESCRIPTION
## Summary
- Adds `claude-review`, a Python CLI that reviews a GitHub PR diff and returns the required structured Markdown comment.
- Includes a Claude Code sub-agent prompt, deterministic fallback mode, tests, and two real PR sample outputs.
- Implements the CLI path in the acceptance criteria for #4.

## Test Plan
- `python -m pytest -q`
- `python -m compileall -q claude_review`
- `GH_HOME=/home/junho python -m claude_review.cli --pr https://github.com/cli/cli/pull/13393 --output samples/cli-cli-13393-review.md --no-claude`
- `GH_HOME=/home/junho python -m claude_review.cli --pr https://github.com/python/cpython/pull/149710 --output samples/python-cpython-149710-review.md --no-claude`

Closes #4
