### PR TITLE
Add builder toolkit artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,0 +1,26 @@
+# PR Reviewer Agent
+
+This agent reviews a GitHub pull request diff and returns a structured Markdown comment with a summary, risks, suggestions, and confidence score.
+
+## Setup
+
+```bash
+python agents/pr-reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123
+```
+
+To save the review:
+
+```bash
+python agents/pr-reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+## Output Format
+
+- `Summary`: 2 or 3 sentences describing scope and touched areas.
+- `Identified Risks`: concrete risks detected from the diff.
+- `Improvement Suggestions`: practical next steps for reviewers or authors.
+- `Confidence`: `Low`, `Medium`, or `High`.
+
+## Notes
+
+The CLI can also review a local diff with `--diff-file path/to/change.diff`, which makes it useful in CI or local pre-review workflows.

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Generate a structured Markdown review from a GitHub PR diff."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DiffStats:
+    files: list[str]
+    additions: int
+    deletions: int
+    risks: list[str]
+
+
+def fetch_pr_diff(pr_url: str) -> str:
+    diff_url = pr_url.rstrip("/") + ".diff"
+    request = urllib.request.Request(diff_url, headers={"User-Agent": "claude-review"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def parse_diff(diff: str) -> DiffStats:
+    files: list[str] = []
+    additions = 0
+    deletions = 0
+    risks: list[str] = []
+
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            match = re.search(r" b/(.+)$", line)
+            if match:
+                files.append(match.group(1))
+        elif line.startswith("+") and not line.startswith("+++"):
+            additions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            deletions += 1
+
+    lowered = diff.lower()
+    if any(name.endswith((".env", ".pem", ".key")) for name in files):
+        risks.append("Changes touch sensitive configuration or secret-adjacent files.")
+    if any("migration" in name.lower() or "schema" in name.lower() for name in files):
+        risks.append("Database or schema changes may need migration and rollback review.")
+    if re.search(r"\b(subprocess|exec\(|eval\(|shell=True)\b", diff):
+        risks.append("Command execution paths need input validation and quoting review.")
+    if re.search(r"\bdelete\s+from\b", lowered) and not re.search(r"\bwhere\b", lowered):
+        risks.append("SQL deletion appears without an obvious WHERE clause.")
+    if any(name.endswith(("package-lock.json", "pnpm-lock.yaml", "yarn.lock")) for name in files):
+        risks.append("Dependency lockfile changes should be checked for unexpected upgrades.")
+    if additions + deletions > 500:
+        risks.append("Large diff size increases review risk and may hide unrelated changes.")
+
+    return DiffStats(files=files, additions=additions, deletions=deletions, risks=risks)
+
+
+def confidence(stats: DiffStats) -> str:
+    churn = stats.additions + stats.deletions
+    if churn > 500 or len(stats.risks) >= 3:
+        return "Low"
+    if churn > 150 or stats.risks:
+        return "Medium"
+    return "High"
+
+
+def render_review(pr_url: str, diff: str) -> str:
+    stats = parse_diff(diff)
+    file_count = len(stats.files)
+    churn = stats.additions + stats.deletions
+    changed = ", ".join(stats.files[:5]) if stats.files else "no files detected"
+    if len(stats.files) > 5:
+        changed += f", and {len(stats.files) - 5} more"
+
+    summary = (
+        f"This PR changes {file_count} file{'s' if file_count != 1 else ''} with "
+        f"{stats.additions} additions and {stats.deletions} deletions. "
+        f"The main touched paths are {changed}."
+    )
+
+    risks = stats.risks or ["No obvious high-risk patterns were detected from the diff alone."]
+    suggestions = [
+        "Run the repository's focused tests for the touched area before merge.",
+        "Confirm the PR scope matches the linked issue and does not include unrelated cleanup.",
+    ]
+    if churn > 150:
+        suggestions.append("Consider splitting follow-up cleanup from behavior changes if reviewers need a smaller diff.")
+    if any("schema" in risk.lower() or "database" in risk.lower() for risk in risks):
+        suggestions.append("Verify migration ordering, rollback behavior, and existing-data compatibility.")
+
+    lines = [
+        "# PR Review",
+        "",
+        f"Source: {pr_url}",
+        "",
+        "## Summary",
+        "",
+        summary,
+        "",
+        "## Identified Risks",
+        "",
+        *[f"- {risk}" for risk in risks],
+        "",
+        "## Improvement Suggestions",
+        "",
+        *[f"- {suggestion}" for suggestion in suggestions],
+        "",
+        "## Confidence",
+        "",
+        confidence(stats),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Review a GitHub PR diff and print structured Markdown.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--pr", help="GitHub pull request URL.")
+    source.add_argument("--diff-file", help="Local diff file to review.")
+    parser.add_argument("--output", help="Optional markdown output path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.pr:
+        pr_url = args.pr
+        diff = fetch_pr_diff(pr_url)
+    else:
+        pr_url = f"file://{Path(args.diff_file).resolve()}"
+        diff = Path(args.diff_file).read_text(encoding="utf-8")
+
+    review = render_review(pr_url, diff)
+    if args.output:
+        Path(args.output).write_text(review, encoding="utf-8")
+    else:
+        sys.stdout.write(review)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-reviewer/pr-reviewer.agent.md
+++ b/agents/pr-reviewer/pr-reviewer.agent.md
@@ -1,0 +1,30 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request diff and return a structured Markdown comment.
+tools: Bash, Read, WebFetch
+---
+
+# PR Reviewer Agent
+
+You review one pull request at a time. Your output must be a single Markdown review comment with these sections:
+
+1. `Summary`
+2. `Identified Risks`
+3. `Improvement Suggestions`
+4. `Confidence`
+
+## Process
+
+1. Fetch the pull request diff.
+2. Identify changed files, risky areas, dependency changes, migrations, and command execution paths.
+3. Keep the summary to 2 or 3 sentences.
+4. Use concrete file or behavior references when possible.
+5. Set confidence to `Low`, `Medium`, or `High` based on diff size, test evidence, and risk.
+
+## CLI Companion
+
+Run the included CLI when shell access is available:
+
+```bash
+python agents/pr-reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123
+```

--- a/agents/pr-reviewer/samples/pr-84-review.md
+++ b/agents/pr-reviewer/samples/pr-84-review.md
@@ -1,0 +1,20 @@
+# PR Review
+
+Source: https://github.com/claude-builders-bounty/claude-builders-bounty/pull/84
+
+## Summary
+
+This PR changes 1 file with 38 additions and 0 deletions. The main touched paths are fix_1.py.
+
+## Identified Risks
+
+- No obvious high-risk patterns were detected from the diff alone.
+
+## Improvement Suggestions
+
+- Run the repository's focused tests for the touched area before merge.
+- Confirm the PR scope matches the linked issue and does not include unrelated cleanup.
+
+## Confidence
+
+High

--- a/agents/pr-reviewer/samples/pr-92-review.md
+++ b/agents/pr-reviewer/samples/pr-92-review.md
@@ -1,0 +1,21 @@
+# PR Review
+
+Source: https://github.com/claude-builders-bounty/claude-builders-bounty/pull/92
+
+## Summary
+
+This PR changes 5 files with 508 additions and 0 deletions. The main touched paths are hooks/README.md, hooks/pre-tool-use, skills/changelog-generator/SKILL.md, skills/changelog-generator/changelog.sh, templates/nextjs-sqlite-saas/CLAUDE.md.
+
+## Identified Risks
+
+- Large diff size increases review risk and may hide unrelated changes.
+
+## Improvement Suggestions
+
+- Run the repository's focused tests for the touched area before merge.
+- Confirm the PR scope matches the linked issue and does not include unrelated cleanup.
+- Consider splitting follow-up cleanup from behavior changes if reviewers need a smaller diff.
+
+## Confidence
+
+Low

--- a/hooks/block-destructive-bash/README.md
+++ b/hooks/block-destructive-bash/README.md
@@ -1,0 +1,22 @@
+# Destructive Bash Command Hook
+
+This pre-tool-use hook blocks high-risk shell commands before they run and records every blocked attempt in `~/.claude/hooks/blocked.log`.
+
+## Install In 2 Commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block-destructive-bash/block_destructive_bash.py ~/.claude/hooks/block_destructive_bash.py
+chmod +x ~/.claude/hooks/block_destructive_bash.py
+```
+
+Then reference `~/.claude/hooks/block_destructive_bash.py` from your pre-tool-use hook configuration.
+
+## Blocked Patterns
+
+- `rm -rf` and `rm -fr`
+- `DROP TABLE`
+- `TRUNCATE`
+- `git push --force` and `git push --force-with-lease`
+- `DELETE FROM` statements that do not include a `WHERE` clause
+
+Normal commands exit with code `0`. Blocked commands exit with code `2`, print a clear explanation, and append a JSON line with timestamp, attempted command, reason, and project path.

--- a/hooks/block-destructive-bash/block_destructive_bash.py
+++ b/hooks/block-destructive-bash/block_destructive_bash.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Claude Code pre-tool-use hook that blocks destructive shell commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCK_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("drop table statement", re.compile(r"\bdrop\s+table\b", re.I)),
+    ("truncate statement", re.compile(r"\btruncate\b", re.I)),
+    ("force push", re.compile(r"\bgit\s+push\b[^\n;]*\s--force(?:-with-lease)?\b", re.I)),
+)
+
+
+def read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"command": raw}
+    return payload if isinstance(payload, dict) else {}
+
+
+def nested_get(data: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = data
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    candidates = (
+        nested_get(payload, ("tool_input", "command")),
+        nested_get(payload, ("input", "command")),
+        payload.get("command"),
+        os.environ.get("CLAUDE_TOOL_COMMAND"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
+def extract_project_path(payload: dict[str, Any]) -> str:
+    candidates = (
+        nested_get(payload, ("tool_input", "cwd")),
+        nested_get(payload, ("input", "cwd")),
+        payload.get("cwd"),
+        payload.get("project_path"),
+        os.environ.get("PWD"),
+        os.getcwd(),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return os.getcwd()
+
+
+def delete_without_where(command: str) -> bool:
+    for statement in re.split(r";|\n", command):
+        lowered = statement.lower()
+        if re.search(r"\bdelete\s+from\b", lowered) and not re.search(r"\bwhere\b", lowered):
+            return True
+    return False
+
+
+def has_recursive_force_delete(command: str) -> bool:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    for index, token in enumerate(tokens):
+        if token != "rm":
+            continue
+        flags = ""
+        for next_token in tokens[index + 1 :]:
+            if not next_token.startswith("-") or next_token == "--":
+                break
+            flags += next_token.lstrip("-")
+        if "r" in flags.lower() and "f" in flags.lower():
+            return True
+    return False
+
+
+def block_reason(command: str) -> str | None:
+    if has_recursive_force_delete(command):
+        return "recursive force delete"
+    for reason, pattern in BLOCK_PATTERNS:
+        if pattern.search(command):
+            return reason
+    if delete_without_where(command):
+        return "delete statement without WHERE clause"
+    return None
+
+
+def log_block(command: str, project_path: str, reason: str) -> Path:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    entry = {
+        "timestamp": timestamp,
+        "reason": reason,
+        "project_path": project_path,
+        "command": command,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+    return log_path
+
+
+def main() -> int:
+    payload = read_payload()
+    command = extract_command(payload)
+    if not command:
+        return 0
+
+    reason = block_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = extract_project_path(payload)
+    log_path = log_block(command, project_path, reason)
+    print(
+        "Blocked command before execution: "
+        f"{reason}. Review the command and use a safer, narrower operation. "
+        f"Attempt logged to {log_path}.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,25 @@
+# Generate Changelog Skill
+
+This skill creates a structured `CHANGELOG.md` from commits since the last git tag, grouped into `Added`, `Fixed`, `Changed`, and `Removed`.
+
+## Setup
+
+1. Copy this folder into a project or run it directly from this repository.
+2. Run `python skills/generate-changelog/changelog.py --repo /path/to/repo`.
+3. Review the generated `CHANGELOG.md` before committing it.
+
+## Usage
+
+```bash
+python skills/generate-changelog/changelog.py --repo . --output CHANGELOG.md
+```
+
+Use `--since v1.2.0` to generate from a specific tag or revision instead of auto-detecting the latest tag.
+
+## Output Rules
+
+- Conventional commit prefixes are honored when present.
+- Fixes and regressions go under `Fixed`.
+- New capabilities go under `Added`.
+- Removals, deletions, drops, and deprecations go under `Removed`.
+- Everything else is grouped under `Changed`.

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from a repository's git history.
+---
+
+# Generate Changelog
+
+Use this skill when a project needs a changelog section generated from recent commits.
+
+## Command
+
+Run:
+
+```bash
+python skills/generate-changelog/changelog.py --repo .
+```
+
+## What It Does
+
+- Finds commits since the latest git tag, or since a revision supplied with `--since`.
+- Groups commits into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a markdown `CHANGELOG.md` that is ready for review.
+
+## Good Review Checklist
+
+- Confirm the latest tag is the intended release boundary.
+- Rewrite terse commit messages into user-facing wording if needed.
+- Remove internal-only commits that should not appear in release notes.

--- a/skills/generate-changelog/changelog.py
+++ b/skills/generate-changelog/changelog.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Generate a Keep a Changelog-style file from git history."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    body: str = ""
+
+
+def run_git(repo: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def last_tag(repo: Path) -> str | None:
+    try:
+        tag = run_git(repo, ["describe", "--tags", "--abbrev=0"])
+    except subprocess.CalledProcessError:
+        return None
+    return tag or None
+
+
+def commit_range(repo: Path, since: str | None) -> str:
+    if since:
+        return f"{since}..HEAD"
+    tag = last_tag(repo)
+    return f"{tag}..HEAD" if tag else "HEAD"
+
+
+def load_commits(repo: Path, since: str | None = None) -> list[Commit]:
+    fmt = "%H%x1f%s%x1f%b%x1e"
+    output = run_git(repo, ["log", commit_range(repo, since), f"--pretty=format:{fmt}"])
+    commits: list[Commit] = []
+    for raw in output.split("\x1e"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        parts = raw.split("\x1f", 2)
+        if len(parts) < 2:
+            continue
+        sha, subject = parts[0], parts[1].strip()
+        body = parts[2].strip() if len(parts) == 3 else ""
+        commits.append(Commit(sha=sha, subject=subject, body=body))
+    return commits
+
+
+def clean_subject(subject: str) -> str:
+    subject = re.sub(r"^[a-zA-Z]+(?:\([^)]+\))?!?:\s*", "", subject).strip()
+    return subject[:1].upper() + subject[1:] if subject else "Update project"
+
+
+def categorize(subject: str, body: str = "") -> str:
+    text = f"{subject}\n{body}".lower()
+    prefix = subject.split(":", 1)[0].lower()
+
+    if any(word in text for word in ("remove", "removed", "delete", "deleted", "drop ", "deprecate")):
+        return "Removed"
+    if prefix.startswith("fix") or any(word in text for word in ("bug", "crash", "regression")):
+        return "Fixed"
+    if prefix.startswith("feat") or any(word in text for word in ("add ", "added", "implement", "introduce")):
+        return "Added"
+    return "Changed"
+
+
+def group_commits(commits: list[Commit]) -> dict[str, list[Commit]]:
+    grouped = {category: [] for category in CATEGORIES}
+    for commit in commits:
+        grouped[categorize(commit.subject, commit.body)].append(commit)
+    return grouped
+
+
+def render_changelog(commits: list[Commit], title: str = "Unreleased") -> str:
+    grouped = group_commits(commits)
+    lines = ["# Changelog", "", f"## {title}", ""]
+    if not commits:
+        lines.extend(["No changes found.", ""])
+        return "\n".join(lines)
+
+    for category in CATEGORIES:
+        entries = grouped[category]
+        if not entries:
+            continue
+        lines.extend([f"### {category}", ""])
+        for commit in entries:
+            lines.append(f"- {clean_subject(commit.subject)} ({commit.sha[:7]})")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git commits.")
+    parser.add_argument("--repo", default=".", help="Repository path. Defaults to current directory.")
+    parser.add_argument("--since", help="Git revision or tag to start after. Defaults to the last tag.")
+    parser.add_argument("--output", default="CHANGELOG.md", help="Output file path.")
+    parser.add_argument("--title", default="Unreleased", help="Heading for the generated release section.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = Path(args.repo).resolve()
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = repo / output
+
+    commits = load_commits(repo, args.since)
+    output.write_text(render_changelog(commits, args.title), encoding="utf-8")
+    print(f"Wrote {output} with {len(commits)} commits.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/generate-changelog/examples/CHANGELOG.sample.md
+++ b/skills/generate-changelog/examples/CHANGELOG.sample.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Sample Output
+
+### Added
+
+- Initial README with bounty board (1aeae2a)
+
+### Changed
+
+- Initial commit (a80a580)

--- a/templates/next-sqlite/CLAUDE.md
+++ b/templates/next-sqlite/CLAUDE.md
@@ -1,0 +1,91 @@
+# Next.js 15 + SQLite SaaS Project Guide
+
+## Stack And Versions
+
+- Use Next.js 15 with the App Router, React Server Components by default, and Server Actions only for mutations that benefit from colocated form handling.
+- Use TypeScript in strict mode. Avoid `any`; use `unknown` at boundaries and narrow explicitly.
+- Use SQLite for local development and small deployments. Prefer `better-sqlite3` for embedded deployments and Turso/libSQL when remote access, replication, or edge-adjacent reads are needed.
+- Use a thin validation layer with Zod at all request, form, webhook, and environment-variable boundaries.
+
+## Folder Structure
+
+- `app/`: Route segments, layouts, loading states, and server-only page composition.
+- `app/(marketing)/`: Public pages with no authenticated data requirements.
+- `app/(app)/`: Authenticated product pages and account-level navigation.
+- `components/`: Reusable presentational components that do not access the database directly.
+- `features/<feature>/`: Feature-owned UI, actions, queries, schemas, and tests.
+- `lib/db/`: Database connection, migrations, query helpers, and transaction utilities.
+- `lib/auth/`: Session resolution, role checks, and auth provider adapters.
+- `lib/env.ts`: Single parsed environment contract. Nothing reads `process.env` directly outside this file.
+- `tests/`: Unit and integration tests that are not colocated with feature code.
+
+Reason: route files stay small, feature code remains discoverable, and database access is kept out of generic UI.
+
+## Naming Conventions
+
+- Use `getX` for read-only data loaders and `createX`, `updateX`, `deleteX` for mutations.
+- Use `requireUser()` when missing auth is exceptional and `getUser()` when anonymous access is valid.
+- Name Server Actions with an `Action` suffix, for example `updateWorkspaceAction`.
+- Name database tables in snake_case and TypeScript types in PascalCase.
+- Name files by role: `queries.ts`, `actions.ts`, `schema.ts`, `permissions.ts`, `page.tsx`.
+
+Reason: predictable names reduce context hunting and make access patterns obvious.
+
+## SQL And Migration Conventions
+
+- Every schema change must be represented by a migration file committed with the feature.
+- Migrations are append-only. Never edit a migration that has reached `main`.
+- Wrap multi-step writes in a transaction and keep transaction scope small.
+- Use explicit column lists in inserts and selects. Avoid `SELECT *`.
+- Add indexes with the query that needs them, and document the access pattern in the migration.
+- Store timestamps as UTC ISO strings or integer epoch milliseconds. Pick one per project and do not mix.
+- Use foreign keys and `ON DELETE` rules intentionally. Do not rely on application code for referential cleanup.
+
+Reason: SQLite is reliable when schema history is boring, explicit, and easy to replay.
+
+## Component Patterns
+
+- Default to Server Components for data loading and page assembly.
+- Use Client Components only for browser state, event handlers, optimistic UI, or client-only APIs.
+- Keep forms small: validation schema, action call, pending state, and error display should be visible in one place.
+- Pass plain serializable props from server to client. Do not pass database rows with unused fields.
+- Prefer composition over global state. Start with URL state for filters and tabs.
+
+Reason: the App Router works best when server and client responsibilities are deliberately separated.
+
+## Data Access Rules
+
+- Pages call feature-level query functions; they do not write SQL inline.
+- Query functions accept typed input objects, not loose positional arguments.
+- Authorization checks happen before database mutations and again inside shared mutation helpers when reused.
+- Return view models from feature queries instead of leaking raw persistence details into UI.
+- Log mutation failures with stable operation names, not user-provided text.
+
+Reason: data ownership stays local to the feature while auth and logging remain consistent.
+
+## Dev Commands
+
+- `npm run dev`: Start the app.
+- `npm run lint`: Run linting and type-aware checks.
+- `npm run test`: Run unit tests.
+- `npm run db:migrate`: Apply local migrations.
+- `npm run db:studio`: Inspect the local database if the project provides a studio tool.
+
+If a command does not exist yet, add it before depending on it in documentation or automation.
+
+## What We Do Not Do
+
+- Do not put secrets in `.env.example`; use safe placeholders only.
+- Do not call third-party services directly from Client Components.
+- Do not add a global state library for server data that can be represented by URL state or server queries.
+- Do not create generic `utils.ts` dumping grounds. Put helpers beside the feature or in a named `lib` module.
+- Do not hide database writes behind ambiguous names like `handleSubmit` or `processData`.
+- Do not weaken TypeScript to move faster. A failing type is usually the cheapest bug report.
+
+## Review Checklist
+
+- Does every mutation have validation, authorization, and a transaction if multiple tables are touched?
+- Does every new table or query have the index it needs?
+- Are Client Components limited to interactive boundaries?
+- Can a new contributor find the feature's queries, actions, and schema without searching the whole repo?
+- Can the app boot from a clean checkout using only the documented commands?

--- a/templates/next-sqlite/README.md
+++ b/templates/next-sqlite/README.md
@@ -1,0 +1,21 @@
+# Next.js + SQLite Template
+
+This directory contains an opinionated `CLAUDE.md` for a greenfield SaaS app using Next.js 15 App Router and SQLite.
+
+## Setup
+
+1. Create a new Next.js 15 project.
+2. Copy `templates/next-sqlite/CLAUDE.md` into the project root.
+3. Use it as the project context file before implementing features.
+
+## Smoke Check
+
+The template was reviewed against the issue criteria for:
+
+- Stack and version guidance
+- Folder structure
+- SQL and migration conventions
+- Component patterns
+- Explicit anti-patterns with reasons
+
+It is designed to be usable without modification for a new Next.js + SQLite SaaS project.

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,40 @@
+import unittest
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "skills" / "generate-changelog" / "changelog.py"
+SPEC = importlib.util.spec_from_file_location("changelog", MODULE_PATH)
+changelog = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = changelog
+SPEC.loader.exec_module(changelog)
+
+Commit = changelog.Commit
+categorize = changelog.categorize
+render_changelog = changelog.render_changelog
+
+
+class ChangelogTests(unittest.TestCase):
+    def test_categorizes_common_commit_shapes(self):
+        self.assertEqual(categorize("feat: add export button"), "Added")
+        self.assertEqual(categorize("fix: prevent crash"), "Fixed")
+        self.assertEqual(categorize("remove deprecated option"), "Removed")
+        self.assertEqual(categorize("docs: update setup"), "Changed")
+
+    def test_renders_grouped_changelog(self):
+        markdown = render_changelog(
+            [
+                Commit("abc123456", "feat: add export button"),
+                Commit("def123456", "fix: prevent crash"),
+            ]
+        )
+        self.assertIn("### Added", markdown)
+        self.assertIn("- Add export button (abc1234)", markdown)
+        self.assertIn("### Fixed", markdown)
+        self.assertIn("- Prevent crash (def1234)", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,0 +1,30 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "hooks" / "block-destructive-bash" / "block_destructive_bash.py"
+SPEC = importlib.util.spec_from_file_location("block_destructive_bash", MODULE_PATH)
+hook = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(hook)
+
+block_reason = hook.block_reason
+
+
+class HookTests(unittest.TestCase):
+    def test_blocks_required_patterns(self):
+        self.assertIsNotNone(block_reason("rm -rf /tmp/example"))
+        self.assertIsNotNone(block_reason("DROP TABLE users"))
+        self.assertIsNotNone(block_reason("TRUNCATE audit_log"))
+        self.assertIsNotNone(block_reason("git push origin main --force"))
+        self.assertIsNotNone(block_reason("DELETE FROM users"))
+
+    def test_allows_normal_commands(self):
+        self.assertIsNone(block_reason("git status --short"))
+        self.assertIsNone(block_reason("DELETE FROM users WHERE id = 1"))
+        self.assertIsNone(block_reason("rm -r build-output"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -1,0 +1,48 @@
+import unittest
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "agents" / "pr-reviewer" / "claude_review.py"
+SPEC = importlib.util.spec_from_file_location("claude_review", MODULE_PATH)
+claude_review = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = claude_review
+SPEC.loader.exec_module(claude_review)
+
+confidence = claude_review.confidence
+parse_diff = claude_review.parse_diff
+render_review = claude_review.render_review
+
+
+SAMPLE_DIFF = """diff --git a/app/page.tsx b/app/page.tsx
+index 1111111..2222222 100644
+--- a/app/page.tsx
++++ b/app/page.tsx
+@@ -1,2 +1,3 @@
+ export default function Page() {
+-  return null
++  return <main>Hello</main>
+ }
+"""
+
+
+class PrReviewerTests(unittest.TestCase):
+    def test_parses_basic_diff_stats(self):
+        stats = parse_diff(SAMPLE_DIFF)
+        self.assertEqual(stats.files, ["app/page.tsx"])
+        self.assertEqual(stats.additions, 1)
+        self.assertEqual(stats.deletions, 1)
+        self.assertEqual(confidence(stats), "High")
+
+    def test_renders_required_sections(self):
+        review = render_review("https://github.com/example/repo/pull/1", SAMPLE_DIFF)
+        self.assertIn("## Summary", review)
+        self.assertIn("## Identified Risks", review)
+        self.assertIn("## Improvement Suggestions", review)
+        self.assertIn("## Confidence", review)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a changelog skill and script with a sample changelog.
- Add a Next.js + SQLite project context template with setup notes.
- Add a destructive-command hook and PR review CLI/agent with sample outputs.

## Tests
- python -m unittest discover -s tests
- python -m compileall agents hooks skills tests

Resolves #1
Resolves #2
Resolves #3
Resolves #4