### PR TITLE
feat: PreToolUse hook blocking destructive bash commands (bounty #3)

### DIFF
--- a/hooks/destructive-bash-guard/README.md
+++ b/hooks/destructive-bash-guard/README.md
@@ -1,0 +1,55 @@
+# 🛡️ Destructive Bash Guard — Claude Code PreToolUse Hook
+
+A Claude Code `PreToolUse` hook that intercepts dangerous bash commands before execution.
+
+## Blocked Patterns
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf` | Recursive force delete — irreversible filesystem destruction |
+| `rm --no-preserve-root` | Dangerous root-level deletion |
+| `DROP TABLE / DROP DATABASE` | Irreversible database object removal |
+| `TRUNCATE` | Wipes all rows from a table |
+| `DELETE FROM` (without `WHERE`) | Deletes every row in a table |
+| `git push --force / -f` | Overwrites remote history |
+
+## Installation (2 commands)
+
+```bash
+git clone https://github.com/oceanzhang1204/claude-builders-bounty.git
+bash claude-builders-bounty/hooks/destructive-bash-guard/install.sh
+```
+
+That's it. The install script:
+1. Deploys `pre_tool_use.py` to `~/.claude/hooks/`
+2. Registers the hook in `~/.claude/settings.json` (merges with existing config)
+
+## How It Works
+
+The hook follows the [Claude Code hooks protocol](https://docs.anthropic.com/claude-code/hooks):
+
+1. **Receives** a JSON payload on stdin with the tool name and command
+2. **Checks** the command against blocked patterns (only for `Bash` tool calls)
+3. **If dangerous**: outputs `{"hookSpecificOutput": {"permissionDecision": "deny", ...}}` and exits with code `2` → **blocks execution**
+4. **If safe**: exits with code `0` → **allows execution** (zero overhead)
+
+## Logging
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-05-12T10:02:30Z] project='/my-project' | reason='rm with -f flag (destructive delete)' | command='rm -rf /tmp/old'
+[2026-05-12T10:02:31Z] project='/my-project' | reason='DELETE FROM without WHERE (deletes all rows)' | command='sqlite3 db.sqlite "DELETE FROM logs"'
+```
+
+## Testing
+
+```bash
+python3 -m unittest test_hook -v
+```
+
+25 test cases covering all blocked patterns, safe command pass-through, logging, and the full stdin→stdout pipeline.
+
+## Uninstall
+
+Remove the hook entry from `~/.claude/settings.json` under `hooks.PreToolUse`, then delete `~/.claude/hooks/pre_tool_use.py`.

--- a/hooks/destructive-bash-guard/install.sh
+++ b/hooks/destructive-bash-guard/install.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# install.sh — Deploy the destructive-bash-guard hook for Claude Code
+#
+# Usage:
+#   bash install.sh
+#
+# This script:
+#   1. Copies pre_tool_use.py to ~/.claude/hooks/
+#   2. Registers the hook in ~/.claude/settings.json (merges, does not overwrite)
+
+set -euo pipefail
+
+HOOK_DIR="$HOME/.claude/hooks"
+HOOK_SCRIPT="pre_tool_use.py"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+# --- Step 1: Deploy the hook script ---
+mkdir -p "$HOOK_DIR"
+cp "$HOOK_SCRIPT" "$HOOK_DIR/$HOOK_SCRIPT"
+chmod +x "$HOOK_DIR/$HOOK_SCRIPT"
+echo "✅ Hook script deployed to $HOOK_DIR/$HOOK_SCRIPT"
+
+# --- Step 2: Register in settings.json ---
+# Ensure settings.json exists
+if [ ! -f "$SETTINGS_FILE" ]; then
+    mkdir -p "$(dirname "$SETTINGS_FILE")"
+    echo '{}' > "$SETTINGS_FILE"
+fi
+
+# Use python to safely merge the hook config into settings.json
+python3 -c "
+import json, sys
+
+settings_path = '$SETTINGS_FILE'
+hook_command = '$HOOK_DIR/$HOOK_SCRIPT'
+
+with open(settings_path, 'r') as f:
+    settings = json.load(f)
+
+# Ensure hooks structure exists
+if 'hooks' not in settings:
+    settings['hooks'] = {}
+
+if 'PreToolUse' not in settings['hooks']:
+    settings['hooks']['PreToolUse'] = []
+
+# Check if our hook is already registered
+existing = settings['hooks']['PreToolUse']
+already_registered = any(
+    h.get('hooks', [{}])[0].get('command', '').endswith('pre_tool_use.py')
+    for h in existing
+    if h.get('matcher') == 'Bash'
+)
+
+if already_registered:
+    print('⚠️  Hook already registered in settings.json — skipping')
+else:
+    # Add our hook entry
+    new_entry = {
+        'matcher': 'Bash',
+        'hooks': [
+            {
+                'type': 'command',
+                'command': f'python3 {hook_command}',
+                'timeout': 10
+            }
+        ]
+    }
+    settings['hooks']['PreToolUse'].append(new_entry)
+
+    with open(settings_path, 'w') as f:
+        json.dump(settings, f, indent=2)
+
+    print('✅ Hook registered in $SETTINGS_FILE')
+"
+
+echo ""
+echo "🛡️  Destructive Bash Guard is now active!"
+echo "   Blocked patterns: rm -rf, DROP TABLE, git push --force, TRUNCATE, DELETE FROM without WHERE"
+echo "   Blocked attempts logged to: $HOOK_DIR/blocked.log"

--- a/hooks/destructive-bash-guard/pre_tool_use.py
+++ b/hooks/destructive-bash-guard/pre_tool_use.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse Hook — Destructive Bash Command Guard
+
+Blocks dangerous bash commands before Claude Code executes them.
+Follows the Claude Code hooks protocol (stdin JSON → stdout JSON + exit code).
+
+Blocked patterns:
+  - rm -rf / rm --no-preserve-root
+  - DROP TABLE / DROP DATABASE
+  - TRUNCATE (SQL)
+  - DELETE FROM without WHERE
+  - git push --force / git push -f
+
+Logs every blocked attempt to ~/.claude/hooks/blocked.log
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Pattern definitions: (compiled_regex, reason_string)
+# ---------------------------------------------------------------------------
+BLOCKED_PATTERNS = [
+    # rm -rf / rm --no-preserve-root
+    (re.compile(r"\brm\s+.*-[a-zA-Z]*f.*\b", re.IGNORECASE),
+     "rm with -f flag (destructive delete)"),
+
+    (re.compile(r"\brm\s+.*--no-preserve-root\b", re.IGNORECASE),
+     "rm --no-preserve-root (dangerous root deletion)"),
+
+    # SQL: DROP TABLE / DROP DATABASE
+    (re.compile(r"\bDROP\s+(TABLE|DATABASE|SCHEMA)\b", re.IGNORECASE),
+     "DROP TABLE/DATABASE/SCHEMA (irreversible database operation)"),
+
+    # SQL: TRUNCATE
+    (re.compile(r"\bTRUNCATE\s+(TABLE\s+)?", re.IGNORECASE),
+     "TRUNCATE (wipes all table rows)"),
+
+    # SQL: DELETE FROM without WHERE
+    (re.compile(r"\bDELETE\s+FROM\b(?!.*\bWHERE\b)", re.IGNORECASE),
+     "DELETE FROM without WHERE (deletes all rows)"),
+
+    # git push --force / git push -f
+    (re.compile(r"\bgit\s+push\b.*--force\b", re.IGNORECASE),
+     "git push --force (overwrites remote history)"),
+
+    (re.compile(r"\bgit\s+push\b.*\s-f\b", re.IGNORECASE),
+     "git push -f (overwrites remote history)"),
+]
+
+# Allowed pattern overrides (e.g., "rm -rf" in a docker/container context)
+# Not currently used, but can be extended.
+ALLOWED_OVERRIDES = []
+
+LOG_DIR = os.path.join(os.path.expanduser("~"), ".claude", "hooks")
+LOG_FILE = os.path.join(LOG_DIR, "blocked.log")
+
+
+def log_blocked(command: str, reason: str, project_path: str) -> None:
+    """Append a blocked-attempt record to the log file."""
+    os.makedirs(LOG_DIR, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    entry = (
+        f"[{timestamp}] project='{project_path}' | "
+        f"reason='{reason}' | command='{command}'\n"
+    )
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(entry)
+
+
+def check_command(command: str) -> list[str]:
+    """Return a list of reasons the command should be blocked. Empty = safe."""
+    reasons = []
+    for pattern, reason in BLOCKED_PATTERNS:
+        if pattern.search(command):
+            # Check if any override applies
+            overridden = False
+            for override in ALLOWED_OVERRIDES:
+                if override.search(command):
+                    overridden = True
+                    break
+            if not overridden:
+                reasons.append(reason)
+    return reasons
+
+
+def main() -> None:
+    # 1. Read stdin JSON from Claude Code
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            # No input — pass through
+            sys.exit(0)
+        data = json.loads(raw)
+    except (json.JSONDecodeError, Exception):
+        # Malformed input — fail safe, allow through
+        sys.exit(0)
+
+    # 2. Only intercept Bash tool calls
+    tool_name = data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {})
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    project_path = data.get("cwd", os.getcwd())
+
+    # 3. Check against blocked patterns
+    reasons = check_command(command)
+
+    if not reasons:
+        # Safe command — allow through (exit 0, no output)
+        sys.exit(0)
+
+    # 4. Log the blocked attempt
+    log_blocked(command, "; ".join(reasons), project_path)
+
+    # 5. Output deny decision + exit code 2 to block execution
+    reason_text = "Blocked: " + "; ".join(reasons)
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason_text,
+        }
+    }
+
+    # Print JSON to stdout (Claude Code reads this)
+    json.dump(output, sys.stdout)
+    sys.stdout.write("\n")
+
+    # Also write human-readable reason to stderr (shown to model)
+    print(
+        f"⛔ Destructive command blocked: {reason_text}\n"
+        f"   Command: {command}\n"
+        f"   Logged to: {LOG_FILE}",
+        file=sys.stderr,
+    )
+
+    # Exit code 2 = block tool execution + send stderr to model
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/destructive-bash-guard/test_hook.py
+++ b/hooks/destructive-bash-guard/test_hook.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Unit tests for pre_tool_use.py hook — validates all blocked patterns and pass-through."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+# Add parent dir to path so we can import the hook
+sys.path.insert(0, os.path.dirname(__file__))
+from pre_tool_use import check_command, log_blocked
+
+
+class TestBlockedPatterns(unittest.TestCase):
+    """Test that all required destructive patterns are blocked."""
+
+    # --- rm -rf ---
+    def test_rm_rf(self):
+        reasons = check_command("rm -rf /tmp/old-project")
+        self.assertTrue(any("rm" in r for r in reasons))
+
+    def test_rm_force_recursive(self):
+        reasons = check_command("rm -r -f node_modules")
+        self.assertTrue(any("rm" in r for r in reasons))
+
+    def test_rm_no_preserve_root(self):
+        reasons = check_command("rm --no-preserve-root -rf /")
+        self.assertTrue(any("no-preserve-root" in r for r in reasons))
+
+    # --- DROP TABLE ---
+    def test_drop_table(self):
+        reasons = check_command('psql -c "DROP TABLE users"')
+        self.assertTrue(any("DROP" in r for r in reasons))
+
+    def test_drop_database(self):
+        reasons = check_command('mysql -e "DROP DATABASE production"')
+        self.assertTrue(any("DROP" in r for r in reasons))
+
+    # --- TRUNCATE ---
+    def test_truncate(self):
+        reasons = check_command('psql -c "TRUNCATE TABLE logs"')
+        self.assertTrue(any("TRUNCATE" in r for r in reasons))
+
+    def test_truncate_no_table_keyword(self):
+        reasons = check_command('sqlite3 db.sqlite "TRUNCATE sessions"')
+        self.assertTrue(any("TRUNCATE" in r for r in reasons))
+
+    # --- DELETE FROM without WHERE ---
+    def test_delete_from_no_where(self):
+        reasons = check_command('mysql -e "DELETE FROM logs"')
+        self.assertTrue(any("DELETE FROM" in r for r in reasons))
+
+    def test_delete_from_with_where_allowed(self):
+        reasons = check_command('mysql -e "DELETE FROM logs WHERE id < 100"')
+        self.assertEqual(len(reasons), 0)
+
+    # --- git push --force ---
+    def test_git_push_force(self):
+        reasons = check_command("git push origin main --force")
+        self.assertTrue(any("force" in r.lower() for r in reasons))
+
+    def test_git_push_f(self):
+        reasons = check_command("git push -f origin main")
+        self.assertTrue(any("force" in r.lower() or "-f" in r for r in reasons))
+
+
+class TestSafeCommands(unittest.TestCase):
+    """Test that normal commands pass through without blocking."""
+
+    def test_ls(self):
+        reasons = check_command("ls -la")
+        self.assertEqual(len(reasons), 0)
+
+    def test_git_push_normal(self):
+        reasons = check_command("git push origin main")
+        self.assertEqual(len(reasons), 0)
+
+    def test_rm_single_file(self):
+        reasons = check_command("rm temp.txt")
+        self.assertEqual(len(reasons), 0)
+
+    def test_pip_install(self):
+        reasons = check_command("pip install requests")
+        self.assertEqual(len(reasons), 0)
+
+    def test_git_commit(self):
+        reasons = check_command("git commit -m 'fix bug'")
+        self.assertEqual(len(reasons), 0)
+
+    def test_mkdir(self):
+        reasons = check_command("mkdir -p src/components")
+        self.assertEqual(len(reasons), 0)
+
+    def test_delete_from_with_where_complex(self):
+        reasons = check_command("DELETE FROM users WHERE active = false AND last_login < '2024-01-01'")
+        self.assertEqual(len(reasons), 0)
+
+    def test_curl(self):
+        reasons = check_command("curl -s https://api.example.com/data")
+        self.assertEqual(len(reasons), 0)
+
+
+class TestLogging(unittest.TestCase):
+    """Test that blocked attempts are logged correctly."""
+
+    def test_log_creates_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "blocked.log")
+            with patch("pre_tool_use.LOG_FILE", log_file), \
+                 patch("pre_tool_use.LOG_DIR", tmpdir):
+                log_blocked("rm -rf /", "rm with -f flag", "/project")
+                self.assertTrue(os.path.exists(log_file))
+                with open(log_file) as f:
+                    content = f.read()
+                self.assertIn("rm -rf /", content)
+                self.assertIn("rm with -f flag", content)
+                self.assertIn("/project", content)
+
+    def test_log_appends(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "blocked.log")
+            with patch("pre_tool_use.LOG_FILE", log_file), \
+                 patch("pre_tool_use.LOG_DIR", tmpdir):
+                log_blocked("rm -rf /", "reason1", "/project1")
+                log_blocked("DROP TABLE x", "reason2", "/project2")
+                with open(log_file) as f:
+                    lines = f.readlines()
+                self.assertEqual(len(lines), 2)
+
+
+class TestHookIntegration(unittest.TestCase):
+    """Test the full stdin→stdout pipeline."""
+
+    def _run_hook(self, tool_name: str, command: str) -> tuple[dict, int]:
+        """Run the hook with mocked stdin, capture stdout and exit code."""
+        input_data = {
+            "hook_event_name": "PreToolUse",
+            "session_id": "test-session",
+            "cwd": "/test/project",
+            "tool_name": tool_name,
+            "tool_input": {"command": command},
+        }
+        stdin_json = json.dumps(input_data)
+
+        with patch("sys.stdin", new_callable=lambda: type("S", (), {"read": lambda self: stdin_json})):
+            import importlib
+            import pre_tool_use
+            importlib.reload(pre_tool_use)
+
+            stdout_capture = []
+            exit_code = 0
+
+            with patch("sys.stdout") as mock_stdout, \
+                 patch("sys.stderr"):
+                mock_stdout.write.side_effect = lambda s: stdout_capture.append(s)
+
+                try:
+                    pre_tool_use.main()
+                except SystemExit as e:
+                    exit_code = e.code
+
+        return stdout_capture, exit_code
+
+    def test_bash_rm_rf_blocked(self):
+        """rm -rf should be blocked with exit code 2."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__), "pre_tool_use.py")],
+            input=json.dumps({
+                "hook_event_name": "PreToolUse",
+                "session_id": "test",
+                "cwd": "/test",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /tmp/test"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 2)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("rm", output["hookSpecificOutput"]["permissionDecisionReason"].lower())
+
+    def test_bash_safe_command_passes(self):
+        """Safe commands should pass with exit code 0."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__), "pre_tool_use.py")],
+            input=json.dumps({
+                "hook_event_name": "PreToolUse",
+                "session_id": "test",
+                "cwd": "/test",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls -la"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_non_bash_tool_passes(self):
+        """Non-Bash tool calls should pass through."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__), "pre_tool_use.py")],
+            input=json.dumps({
+                "hook_event_name": "PreToolUse",
+                "session_id": "test",
+                "cwd": "/test",
+                "tool_name": "Write",
+                "tool_input": {"file_path": "test.txt", "content": "hello"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_empty_input_passes(self):
+        """Empty stdin should not crash, just pass through."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__), "pre_tool_use.py")],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A Claude Code `PreToolUse` hook that intercepts dangerous bash commands before execution, following the official hooks protocol.

## What it blocks

| Pattern | Reason |
|---------|--------|
| `rm -rf` | Recursive force delete — irreversible filesystem destruction |
| `rm --no-preserve-root` | Dangerous root-level deletion |
| `DROP TABLE / DROP DATABASE / DROP SCHEMA` | Irreversible database object removal |
| `TRUNCATE` | Wipes all rows from a table |
| `DELETE FROM` without `WHERE` | Deletes every row in a table |
| `git push --force / -f` | Overwrites remote history |

## Acceptance Criteria Checklist

- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks all required patterns: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path
- [x] Displays clear message to Claude explaining why the command was blocked
- [x] Does not interfere with normal bash commands
- [x] README with installation in 2 commands or fewer

## Test Results

```
25 tests in 0.179s — ALL PASSED
```

## Installation (2 commands)

```bash
git clone https://github.com/oceanzhang1204/claude-builders-bounty.git
bash claude-builders-bounty/hooks/destructive-bash-guard/install.sh
```

Closes #3