### PR TITLE
feat: add n8n weekly dev summary workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository includes an importable n8n workflow for bounty #5:
 - Workflow JSON: `workflows/weekly-dev-summary-n8n.json`
 - Setup guide: `docs/n8n-weekly-dev-summary.md`
 - Sample output: `samples/weekly-dev-summary-sample-output.md`
+- Static validator: `tests/validate_weekly_dev_summary_workflow.py`
 
 The workflow runs every Friday at 17:00, fetches weekly GitHub commits, closed issues, and merged PRs, sends the activity to `claude-sonnet-4-20250514`, and delivers the narrative summary to Slack via webhook.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ You're in the right place.
 
 ---
 
+## Bounty #5: n8n + Claude Weekly Development Summary
+
+This repository includes an importable n8n workflow for bounty #5:
+
+- Workflow JSON: `workflows/weekly-dev-summary-n8n.json`
+- Setup guide: `docs/n8n-weekly-dev-summary.md`
+- Sample output: `samples/weekly-dev-summary-sample-output.md`
+
+The workflow runs every Friday at 17:00, fetches weekly GitHub commits, closed issues, and merged PRs, sends the activity to `claude-sonnet-4-20250514`, and delivers the narrative summary to Slack via webhook.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/docs/n8n-weekly-dev-summary.md
+++ b/docs/n8n-weekly-dev-summary.md
@@ -43,5 +43,9 @@ This workflow generates a weekly narrative summary of a GitHub repository's acti
   - GitHub activity fetch code node
   - Claude API HTTP request node using `claude-sonnet-4-20250514`
   - Slack webhook delivery node
+- Repeatable validator included at `tests/validate_weekly_dev_summary_workflow.py`:
+  ```bash
+  python tests/validate_weekly_dev_summary_workflow.py
+  ```
 
 A real n8n execution still requires live `ANTHROPIC_API_KEY` and `SLACK_WEBHOOK_URL` values in the target n8n instance.

--- a/docs/n8n-weekly-dev-summary.md
+++ b/docs/n8n-weekly-dev-summary.md
@@ -1,0 +1,47 @@
+# n8n + Claude Weekly Development Summary
+
+This workflow generates a weekly narrative summary of a GitHub repository's activity with Claude and posts it to Slack.
+
+## Setup in 5 steps
+
+1. Import `workflows/weekly-dev-summary-n8n.json` into n8n.
+2. Set these n8n environment variables or replace the values in the **Config** node:
+   - `GITHUB_REPO` — repository slug, for example `owner/repo`
+   - `GITHUB_TOKEN` — optional GitHub token for higher rate limits/private repos
+   - `ANTHROPIC_API_KEY` — Claude API key
+   - `SLACK_WEBHOOK_URL` — destination Slack incoming webhook URL
+   - `SUMMARY_LANGUAGE` — `EN` or `FR`
+3. Open the workflow and run **Manual Trigger** once to verify the configuration.
+4. Check the Slack destination for the generated summary.
+5. Activate the workflow. The **Weekly Friday 5pm Trigger** runs every Friday at 17:00.
+
+## What it does
+
+- Computes a one-week reporting window.
+- Fetches from the GitHub API:
+  - commits for the week
+  - closed issues updated during the week
+  - merged pull requests updated during the week
+- Calls Anthropic Messages API with `claude-sonnet-4-20250514`.
+- Posts the generated narrative summary to Slack.
+
+## Configurable variables
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `GITHUB_REPO` | GitHub repository to summarize | `n8n-io/n8n` |
+| `GITHUB_TOKEN` | Optional GitHub token | `github_pat_...` |
+| `ANTHROPIC_API_KEY` | Claude API key | `sk-ant-...` |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook destination | `https://hooks.slack.com/services/...` |
+| `SUMMARY_LANGUAGE` | Output language | `EN` or `FR` |
+
+## Validation performed for this PR
+
+- JSON syntax validation with Python `json.load`.
+- Static workflow inspection to verify required nodes exist:
+  - weekly cron trigger
+  - GitHub activity fetch code node
+  - Claude API HTTP request node using `claude-sonnet-4-20250514`
+  - Slack webhook delivery node
+
+A real n8n execution still requires live `ANTHROPIC_API_KEY` and `SLACK_WEBHOOK_URL` values in the target n8n instance.

--- a/samples/weekly-dev-summary-sample-output.md
+++ b/samples/weekly-dev-summary-sample-output.md
@@ -1,0 +1,20 @@
+# Sample weekly development summary
+
+This is an example of the Slack message produced by `workflows/weekly-dev-summary-n8n.json` after Claude receives GitHub activity for the configured repository.
+
+## Highlights
+The repository had steady maintenance activity this week, with several dependency and bug-fix pull requests merged. Most changes were low-risk and focused on incremental reliability rather than large feature launches.
+
+## Merged PRs
+- #13393 fixed Copilot command guidance when direct execution fails.
+- #13396 updated a Go terminal dependency.
+
+## Closed Issues
+- No major user-facing issues were closed in the sampled window.
+
+## Notable Commits
+- Dependency bumps and small command-handling fixes dominated the week.
+
+## Risks / Follow-ups
+- Dependency changes should be monitored for CLI compatibility regressions.
+- Any Copilot command-path changes should be covered by integration tests where possible.

--- a/tests/validate_weekly_dev_summary_workflow.py
+++ b/tests/validate_weekly_dev_summary_workflow.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Static validator for the n8n weekly GitHub dev summary workflow.
+
+This keeps the bounty deliverable reviewable without requiring live n8n,
+GitHub, Anthropic, or Slack credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / "workflows" / "weekly-dev-summary-n8n.json"
+
+
+def load_workflow() -> dict:
+    with WORKFLOW.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def node_by_name(workflow: dict, name: str) -> dict:
+    for node in workflow.get("nodes", []):
+        if node.get("name") == name:
+            return node
+    raise AssertionError(f"Missing node: {name}")
+
+
+def assert_contains(value: object, expected: str, context: str) -> None:
+    text = json.dumps(value, sort_keys=True)
+    assert expected in text, f"{context} must contain {expected!r}"
+
+
+def main() -> int:
+    workflow = load_workflow()
+
+    assert workflow.get("name"), "Workflow must have a name"
+    assert isinstance(workflow.get("nodes"), list) and workflow["nodes"], "Workflow must define nodes"
+    assert workflow.get("connections"), "Workflow must define node connections"
+
+    manual = node_by_name(workflow, "Manual Trigger")
+    assert manual["type"] == "n8n-nodes-base.manualTrigger"
+
+    schedule = node_by_name(workflow, "Weekly Friday 5pm Trigger")
+    assert schedule["type"] == "n8n-nodes-base.scheduleTrigger"
+    assert_contains(schedule, "0 17 * * 5", "Weekly trigger")
+
+    config = node_by_name(workflow, "Config")
+    for field in (
+        "githubRepo",
+        "githubToken",
+        "anthropicApiKey",
+        "slackWebhookUrl",
+        "language",
+    ):
+        assert_contains(config, field, "Config node")
+
+    fetch = node_by_name(workflow, "Fetch GitHub Activity")
+    assert fetch["type"] == "n8n-nodes-base.code"
+    for required in (
+        "/commits?since=",
+        "/issues?state=closed",
+        "/pulls?state=closed",
+        "merged_at",
+        "closedIssues",
+        "mergedPulls",
+    ):
+        assert_contains(fetch, required, "GitHub activity fetch node")
+
+    claude = node_by_name(workflow, "Generate Claude Summary")
+    assert claude["type"] == "n8n-nodes-base.httpRequest"
+    assert_contains(claude, "https://api.anthropic.com/v1/messages", "Claude API node")
+    assert_contains(claude, "claude-sonnet-4-20250514", "Claude API node")
+    assert_contains(claude, "anthropic-version", "Claude API node")
+    assert_contains(claude, "x-api-key", "Claude API node")
+
+    extract = node_by_name(workflow, "Extract Summary Text")
+    assert extract["type"] == "n8n-nodes-base.code"
+
+    slack = node_by_name(workflow, "Send Slack Webhook")
+    assert slack["type"] == "n8n-nodes-base.httpRequest"
+    assert_contains(slack, "slackWebhookUrl", "Slack delivery node")
+
+    print(
+        "OK: weekly dev summary workflow has schedule, config, GitHub activity fetch, "
+        "Claude generation, Slack delivery, and importable JSON structure."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/weekly-dev-summary-n8n.json
+++ b/workflows/weekly-dev-summary-n8n.json
@@ -1,0 +1,239 @@
+{
+  "name": "Weekly GitHub Dev Summary with Claude",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "81fff6dc-ed94-4d08-a15f-a33badd7184f",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -780,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 17 * * 5"
+            }
+          ]
+        }
+      },
+      "id": "e8700e73-82ad-441c-af43-329fc239e89b",
+      "name": "Weekly Friday 5pm Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -780,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "repo",
+              "name": "githubRepo",
+              "type": "string",
+              "value": "={{$env.GITHUB_REPO || 'owner/repo'}}"
+            },
+            {
+              "id": "gh_token",
+              "name": "githubToken",
+              "type": "string",
+              "value": "={{$env.GITHUB_TOKEN || ''}}"
+            },
+            {
+              "id": "anthropic",
+              "name": "anthropicApiKey",
+              "type": "string",
+              "value": "={{$env.ANTHROPIC_API_KEY}}"
+            },
+            {
+              "id": "slack",
+              "name": "slackWebhookUrl",
+              "type": "string",
+              "value": "={{$env.SLACK_WEBHOOK_URL}}"
+            },
+            {
+              "id": "lang",
+              "name": "language",
+              "type": "string",
+              "value": "={{$env.SUMMARY_LANGUAGE || 'EN'}}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "e9fe1fa4-8a33-4db5-adac-e778dcc28fe7",
+      "name": "Config",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -520,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const cfg = $input.first().json;\nconst [owner, repo] = cfg.githubRepo.split('/');\nconst since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();\nconst until = new Date().toISOString();\nconst headers = {\n  'Accept': 'application/vnd.github+json',\n  'User-Agent': 'n8n-weekly-dev-summary'\n};\nif (cfg.githubToken) headers.Authorization = `Bearer ${cfg.githubToken}`;\n\nasync function gh(path) {\n  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}${path}`, { headers });\n  if (!response.ok) throw new Error(`GitHub ${path} failed: ${response.status} ${await response.text()}`);\n  return response.json();\n}\n\nconst commits = await gh(`/commits?since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}&per_page=100`);\nconst issues = await gh(`/issues?state=closed&since=${encodeURIComponent(since)}&per_page=100`);\nconst pulls = await gh(`/pulls?state=closed&sort=updated&direction=desc&per_page=100`);\nconst mergedPulls = pulls.filter(pr => pr.merged_at && new Date(pr.merged_at) >= new Date(since));\n\nconst prompt = `Write a concise weekly development activity summary in ${cfg.language} for ${cfg.githubRepo}.\nPeriod: ${since} to ${until}.\nUse a narrative style with sections: Highlights, Merged PRs, Closed Issues, Notable Commits, Risks/Follow-ups.\n\nCommits:\n${commits.map(c => `- ${c.sha.slice(0, 7)} ${c.commit.message.split('\\n')[0]} by ${c.commit.author?.name || 'unknown'}`).join('\\n') || '- None'}\n\nClosed issues:\n${issues.filter(i => !i.pull_request).map(i => `- #${i.number} ${i.title}`).join('\\n') || '- None'}\n\nMerged PRs:\n${mergedPulls.map(pr => `- #${pr.number} ${pr.title}`).join('\\n') || '- None'}\n`;\n\nreturn [{ json: { ...cfg, since, until, counts: { commits: commits.length, closedIssues: issues.filter(i => !i.pull_request).length, mergedPulls: mergedPulls.length }, prompt } }];"
+      },
+      "id": "80a3f509-2326-41b6-a1d9-eda0fad22424",
+      "name": "Fetch GitHub Activity",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{$json.anthropicApiKey}}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 1200, messages: [{ role: 'user', content: $json.prompt }] }) }}",
+        "options": {}
+      },
+      "id": "20677095-ab57-44a9-bcd9-9f5c8dbaf7c2",
+      "name": "Generate Claude Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json;\nconst text = body.content?.map(part => part.text).join('\\n') || body.summary || JSON.stringify(body);\nreturn [{ json: { text } }];"
+      },
+      "id": "579590bb-083a-4d9a-99b4-912c49bb43ca",
+      "name": "Extract Summary Text",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{$node['Config'].json.slackWebhookUrl}}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ text: $json.text }) }}",
+        "options": {}
+      },
+      "id": "6e8c694d-79b3-425f-bf66-887387c56a12",
+      "name": "Send Slack Webhook",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        520,
+        0
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Weekly Friday 5pm Trigger": {
+      "main": [
+        [
+          {
+            "node": "Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Config": {
+      "main": [
+        [
+          {
+            "node": "Fetch GitHub Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch GitHub Activity": {
+      "main": [
+        [
+          {
+            "node": "Generate Claude Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Claude Summary": {
+      "main": [
+        [
+          {
+            "node": "Extract Summary Text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Summary Text": {
+      "main": [
+        [
+          {
+            "node": "Send Slack Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 2,
+  "updatedAt": "2026-05-12T00:00:00.000Z",
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary
- Adds an importable n8n workflow JSON for weekly GitHub development summaries.
- Fetches weekly commits, closed issues, and merged PRs from GitHub, sends the activity to `claude-sonnet-4-20250514`, and posts the generated summary to Slack via webhook.
- Includes a 5-step setup guide, sample output, and repeatable static validator.

## Test Plan
- `python -m json.tool workflows/weekly-dev-summary-n8n.json`
- `python tests/validate_weekly_dev_summary_workflow.py`
- Static validation confirms required nodes and values:
  - weekly cron expression `0 17 * * 5`
  - configurable repo/token/API key/webhook/language values
  - GitHub API fetch logic for commits, closed issues, and merged PRs
  - Claude API call using `claude-sonnet-4-20250514`
  - Slack webhook delivery node

## Note
A live n8n run requires real `ANTHROPIC_API_KEY` and `SLACK_WEBHOOK_URL` values in the target n8n instance.

Closes #5
