### PR TITLE
feat: add changelog generator skill

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,18 @@
+---
+description: Generate a structured CHANGELOG.md from git history
+---
+
+Run the repository changelog generator:
+
+```bash
+bash changelog.sh
+```
+
+If the user provides an output path, pass it as the first argument:
+
+```bash
+bash changelog.sh "$ARGUMENTS"
+```
+
+After generation, summarize which commit range was used and where the changelog
+was written.

--- a/.claude/skills/generate-changelog/SKILL.md
+++ b/.claude/skills/generate-changelog/SKILL.md
@@ -1,0 +1,35 @@
+# Generate Changelog
+
+Use this skill when the user asks for `/generate-changelog`, asks to create a
+`CHANGELOG.md`, or wants release notes generated from git history.
+
+## Command
+
+Run the changelog generator from the repository root:
+
+```bash
+bash changelog.sh
+```
+
+To write to a custom path:
+
+```bash
+bash changelog.sh docs/CHANGELOG.md
+```
+
+## What It Does
+
+- Detects the latest git tag and reads commits from that tag through `HEAD`.
+- Falls back to all commits when the repository has no tags.
+- Categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a Markdown `CHANGELOG.md` with an `Unreleased` section.
+
+## Verification
+
+After running the script, inspect the generated file and confirm the sections
+match the recent commit history:
+
+```bash
+git log --oneline --decorate --max-count=20
+sed -n '1,120p' CHANGELOG.md
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ You're in the right place.
 
 ---
 
+## Generate Changelog
+
+This repository includes a solution for bounty [#1](../../issues/1): a portable
+changelog generator that reads git history and writes a structured
+`CHANGELOG.md`.
+
+Setup and usage:
+
+1. Run `bash changelog.sh` from any git repository root.
+2. Optionally pass an output path, for example `bash changelog.sh docs/CHANGELOG.md`.
+3. Review the generated `Added`, `Fixed`, `Changed`, and `Removed` sections.
+
+Claude Code users can invoke `/generate-changelog` from
+`.claude/commands/generate-changelog.md` or install the skill from
+`.claude/skills/generate-changelog/SKILL.md`. See `examples/sample-output.md` for
+output generated against this GitHub repo.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FILE="${1:-CHANGELOG.md}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "Error: changelog.sh must be run inside a git repository." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$LATEST_TAG" ]]; then
+  RANGE="${LATEST_TAG}..HEAD"
+  RANGE_LABEL="since ${LATEST_TAG}"
+else
+  RANGE="HEAD"
+  RANGE_LABEL="from the first commit"
+fi
+
+if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo "Error: no commits found in this repository." >&2
+  exit 1
+fi
+
+declare -a ADDED=()
+declare -a FIXED=()
+declare -a CHANGED=()
+declare -a REMOVED=()
+
+categorize_commit() {
+  local subject="$1"
+  local lower
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$lower" in
+    feat:*|feat\(*\):*|feature:*|feature\(*\):*|add:*|add\(*\):*|added:*|*' add '*|*' adds '*)
+      ADDED+=("$subject")
+      ;;
+    fix:*|fix\(*\):*|bug:*|bug\(*\):*|bugfix:*|bugfix\(*\):*|hotfix:*|hotfix\(*\):*|*' fix '*|*' fixes '*|*' fixed '*)
+      FIXED+=("$subject")
+      ;;
+    remove:*|remove\(*\):*|removed:*|delete:*|delete\(*\):*|deleted:*|deprecate:*|deprecate\(*\):*|deprecated:*|*' remove '*|*' removes '*|*' delete '*)
+      REMOVED+=("$subject")
+      ;;
+    change:*|change\(*\):*|changed:*|update:*|update\(*\):*|updated:*|refactor:*|refactor\(*\):*|docs:*|docs\(*\):*|test:*|test\(*\):*|style:*|style\(*\):*|chore:*|chore\(*\):*|build:*|build\(*\):*|ci:*|ci\(*\):*|perf:*|perf\(*\):*)
+      CHANGED+=("$subject")
+      ;;
+    *)
+      CHANGED+=("$subject")
+      ;;
+  esac
+}
+
+while IFS= read -r subject || [[ -n "$subject" ]]; do
+  [[ -z "$subject" ]] && continue
+  categorize_commit "$subject"
+done < <(git log "$RANGE" --reverse --pretty=format:'%s')
+
+SECTIONS_WRITTEN=0
+
+write_section() {
+  local title="$1"
+  shift
+  local entries=("$@")
+
+  if [[ "$SECTIONS_WRITTEN" -gt 0 ]]; then
+    echo >> "$OUTPUT_FILE"
+  fi
+
+  {
+    echo "### ${title}"
+    echo
+    if [[ "${#entries[@]}" -eq 0 ]]; then
+      echo "- Nothing notable."
+    else
+      for entry in "${entries[@]}"; do
+        echo "- ${entry}"
+      done
+    fi
+  } >> "$OUTPUT_FILE"
+
+  SECTIONS_WRITTEN=$((SECTIONS_WRITTEN + 1))
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "Generated on $(date -u +%Y-%m-%d) for changes ${RANGE_LABEL}."
+  echo
+  echo "## Unreleased"
+  echo
+} > "$OUTPUT_FILE"
+
+write_section "Added" "${ADDED[@]}"
+write_section "Fixed" "${FIXED[@]}"
+write_section "Changed" "${CHANGED[@]}"
+write_section "Removed" "${REMOVED[@]}"
+
+echo "Wrote ${OUTPUT_FILE}"

--- a/examples/sample-output.md
+++ b/examples/sample-output.md
@@ -1,0 +1,22 @@
+# Changelog
+
+Generated on 2026-05-12 for changes from the first commit.
+
+## Unreleased
+
+### Added
+
+- feat: initial README with bounty board
+- feat: add changelog generator skill
+
+### Fixed
+
+- Nothing notable.
+
+### Changed
+
+- Nothing notable.
+
+### Removed
+
+- Nothing notable.


### PR DESCRIPTION
## Summary
- add a portable `changelog.sh` generator that writes a structured `CHANGELOG.md` from git history
- add a Claude Code `/generate-changelog` command and skill wrapper
- document setup in three steps and include sample output from this repo

## Acceptance criteria
- [x] Works via `/generate-changelog` command or `bash changelog.sh`
- [x] Fetches commits since the last git tag, with all-history fallback for untagged repos
- [x] Auto-categorizes into Added, Fixed, Changed, and Removed
- [x] Outputs a properly formatted Markdown changelog
- [x] Includes sample output generated from this GitHub repo
- [x] README setup instructions are 3 steps

## Verification
- `bash changelog.sh examples/sample-output.md`
- synthetic tagged repo: categorized `feat(ui):` under Added
- synthetic tagged repo: categorized `fix(ui):` under Fixed and `remove(api):` under Removed

Closes #1