### PR TITLE
feat: add structured PR review agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,48 @@ You're in the right place.
 
 ---
 
+## Claude PR Review Agent
+
+This repository includes a small PR review agent for bounty [#4](../../issues/4). It fetches a GitHub pull request, inspects the diff metadata, and prints a structured Markdown review with the required sections:
+
+- Summary
+- Risks
+- Suggestions
+- Confidence score
+
+### Setup
+
+1. Install the GitHub CLI (`gh`) or set `GITHUB_TOKEN` for API access. If `gh` is not on `PATH`, set `GH_BIN=/path/to/gh`.
+2. Make the script executable: `chmod +x claude-review`.
+3. Run it against a public PR:
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Optional file output:
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+### Sample Outputs
+
+Two sample reviews from real GitHub PRs are included:
+
+- [`samples/review-1033.md`](samples/review-1033.md)
+- [`samples/review-1356.md`](samples/review-1356.md)
+
+### Verification
+
+```bash
+python3 -m unittest discover -s tests
+./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/1033 --output /tmp/review-1033.md
+./claude-review --pr https://github.com/moleculerjs/moleculer/pull/1356 --output /tmp/review-1356.md
+```
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Optional file output:
 ./claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
 ```
 
+Post the review as a PR comment:
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+The repository also includes `workflows/claude-review.yml`, a ready-to-copy GitHub Actions workflow that runs the same agent on pull requests or through `workflow_dispatch`.
+
 ### Sample Outputs
 
 Two sample reviews from real GitHub PRs are included:
@@ -72,6 +80,7 @@ Two sample reviews from real GitHub PRs are included:
 python3 -m unittest discover -s tests
 ./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/1033 --output /tmp/review-1033.md
 ./claude-review --pr https://github.com/moleculerjs/moleculer/pull/1356 --output /tmp/review-1356.md
+./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/1033 --post-comment
 ```
 
 ---

--- a/claude-review
+++ b/claude-review
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Review a GitHub pull request and print a structured Markdown report."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+PR_RE = re.compile(r"^/([^/]+)/([^/]+)/pull/(\d+)$")
+PATCH_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$", re.MULTILINE)
+ADDED_LINE_RE = re.compile(r"^\+(?!\+\+)(.*)$", re.MULTILINE)
+REMOVED_LINE_RE = re.compile(r"^-(?!--)(.*)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    owner: str
+    repo: str
+    number: str
+    url: str
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    pr: PullRequest
+    title: str
+    author: str
+    changed_files: list[str]
+    additions: int
+    deletions: int
+    patch: str
+
+
+def parse_pr_url(value: str) -> PullRequest:
+    parsed = urlparse(value)
+    match = PR_RE.match(parsed.path)
+    if parsed.netloc != "github.com" or not match:
+        raise SystemExit("Expected a GitHub pull request URL like https://github.com/owner/repo/pull/123")
+    owner, repo, number = match.groups()
+    return PullRequest(owner=owner, repo=repo, number=number, url=value)
+
+
+def find_gh() -> str | None:
+    configured = os.environ.get("GH_BIN")
+    if configured:
+        return configured
+    return shutil.which("gh")
+
+
+def run_gh(args: list[str]) -> str:
+    gh_bin = find_gh()
+    if not gh_bin:
+        raise FileNotFoundError("gh")
+    completed = subprocess.run([gh_bin, *args], check=True, text=True, capture_output=True)
+    return completed.stdout
+
+
+def http_get(url: str, token: str | None = None, accept: str = "application/vnd.github+json") -> str:
+    headers = {
+        "Accept": accept,
+        "User-Agent": "claude-review-agent",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def fetch_with_gh(pr: PullRequest) -> ReviewContext:
+    repo = f"{pr.owner}/{pr.repo}"
+    raw = run_gh([
+        "pr",
+        "view",
+        pr.number,
+        "--repo",
+        repo,
+        "--json",
+        "title,author,files,additions,deletions",
+    ])
+    data = json.loads(raw)
+    patch = run_gh(["pr", "diff", pr.number, "--repo", repo, "--patch"])
+    files = [item["path"] for item in data.get("files", [])]
+    return ReviewContext(
+        pr=pr,
+        title=data.get("title") or f"PR #{pr.number}",
+        author=(data.get("author") or {}).get("login", "unknown"),
+        changed_files=files,
+        additions=int(data.get("additions") or 0),
+        deletions=int(data.get("deletions") or 0),
+        patch=patch,
+    )
+
+
+def fetch_with_http(pr: PullRequest) -> ReviewContext:
+    token = os.environ.get("GITHUB_TOKEN")
+    api_base = f"https://api.github.com/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}"
+    data = json.loads(http_get(api_base, token))
+    patch = http_get(data["patch_url"], token, "application/vnd.github.patch")
+    files_data = json.loads(http_get(f"{api_base}/files?per_page=100", token))
+    files = [item["filename"] for item in files_data]
+    return ReviewContext(
+        pr=pr,
+        title=data.get("title") or f"PR #{pr.number}",
+        author=(data.get("user") or {}).get("login", "unknown"),
+        changed_files=files,
+        additions=int(data.get("additions") or 0),
+        deletions=int(data.get("deletions") or 0),
+        patch=patch,
+    )
+
+
+def fetch_context(pr: PullRequest) -> ReviewContext:
+    try:
+        return fetch_with_gh(pr)
+    except (FileNotFoundError, subprocess.CalledProcessError, json.JSONDecodeError):
+        try:
+            return fetch_with_http(pr)
+        except (HTTPError, URLError, TimeoutError, KeyError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"Unable to fetch pull request data: {exc}") from exc
+
+
+def risk_for_file(path: str) -> list[str]:
+    lower = path.lower()
+    risks: list[str] = []
+    if any(part in lower for part in ("auth", "login", "permission", "rbac", "token", "secret")):
+        risks.append(f"`{path}` touches authentication or authorization-sensitive code.")
+    if any(part in lower for part in ("migration", "schema", "database", "sql", "prisma")):
+        risks.append(f"`{path}` may affect persisted data or schema behavior.")
+    if any(part in lower for part in ("workflow", ".github/", "ci", "deploy")):
+        risks.append(f"`{path}` changes automation or deployment behavior.")
+    if lower.endswith((".md", ".mdx", ".rst")):
+        risks.append(f"`{path}` is documentation-only unless paired with implementation changes.")
+    return risks
+
+
+def patch_risks(patch: str, changed_files: list[str]) -> list[str]:
+    risks: list[str] = []
+    added = "\n".join(ADDED_LINE_RE.findall(patch)).lower()
+    removed = "\n".join(REMOVED_LINE_RE.findall(patch)).lower()
+    if any(term in added for term in ("eval(", "exec(", "shell=true", "child_process", "subprocess")):
+        risks.append("New command execution or dynamic evaluation appears in the diff.")
+    if any(term in added for term in ("todo", "fixme", "hack")):
+        risks.append("The diff introduces TODO/FIXME/HACK markers that may indicate unfinished work.")
+    has_test_file = any(re.search(r"(^|/)(test|tests|__tests__|spec)\b|\.(test|spec)\.", path) for path in changed_files)
+    if not has_test_file and "test" not in added and "spec" not in added and "tests/" not in patch:
+        risks.append("No obvious test additions were detected in the patch.")
+    if any(term in removed for term in ("test(", "it(", "describe(", "assert", "expect(")):
+        risks.append("The patch removes test/assertion code; confirm coverage did not regress.")
+    return risks
+
+
+def suggestions(context: ReviewContext, risks: list[str]) -> list[str]:
+    output: list[str] = []
+    files = context.changed_files
+    has_tests = any(re.search(r"(^|/)(test|tests|__tests__|spec)\b|\\.(test|spec)\\.", path) for path in files)
+    material_risks = [risk for risk in risks if not risk.startswith("No obvious structural risks")]
+    if not has_tests:
+        output.append("Add or update focused tests that cover the changed behavior.")
+    if context.additions + context.deletions > 600:
+        output.append("Consider splitting the change or adding a short design note because the diff is large.")
+    if material_risks:
+        output.append("Call out the highest-risk behavior in the PR description with exact verification steps.")
+    if any(path.lower().endswith((".md", ".mdx")) for path in files):
+        output.append("Preview the rendered documentation to catch broken links, formatting, and headings.")
+    if not output:
+        output.append("Keep the PR description concise and include the exact validation commands used.")
+    return output
+
+
+def confidence(context: ReviewContext, risks: list[str]) -> str:
+    file_count = len(context.changed_files)
+    diff_size = context.additions + context.deletions
+    material_risks = [risk for risk in risks if not risk.startswith("No obvious structural risks")]
+    if diff_size > 800 or len(material_risks) >= 4 or file_count > 20:
+        return "Low"
+    if diff_size > 250 or material_risks or file_count > 8:
+        return "Medium"
+    return "High"
+
+
+def summarize(context: ReviewContext) -> str:
+    files = ", ".join(f"`{path}`" for path in context.changed_files[:5])
+    if len(context.changed_files) > 5:
+        files += f", and {len(context.changed_files) - 5} more"
+    if not files:
+        files = "no files reported by GitHub"
+    return (
+        f"This PR changes {len(context.changed_files)} file(s), with "
+        f"{context.additions} additions and {context.deletions} deletions. "
+        f"The main touched paths are {files}."
+    )
+
+
+def build_review(context: ReviewContext) -> str:
+    risks = []
+    for path in context.changed_files:
+        risks.extend(risk_for_file(path))
+    risks.extend(patch_risks(context.patch, context.changed_files))
+    deduped_risks = list(dict.fromkeys(risks)) or ["No obvious structural risks were detected from the diff metadata."]
+    improvement_suggestions = suggestions(context, deduped_risks)
+    confidence_score = confidence(context, deduped_risks)
+    return "\n".join([
+        "## Summary",
+        summarize(context),
+        f"The change is submitted by `@{context.author}` in `{context.pr.owner}/{context.pr.repo}` PR #{context.pr.number}: {context.title}.",
+        "",
+        "## Risks",
+        *[f"- {risk}" for risk in deduped_risks],
+        "",
+        "## Suggestions",
+        *[f"- {item}" for item in improvement_suggestions],
+        "",
+        f"## Confidence: {confidence_score}",
+    ])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Review a GitHub pull request and print structured Markdown.")
+    parser.add_argument("--pr", required=True, help="GitHub pull request URL")
+    parser.add_argument("--output", help="Optional file path for the Markdown review")
+    args = parser.parse_args()
+
+    context = fetch_context(parse_pr_url(args.pr))
+    review = build_review(context)
+    if args.output:
+        Path(args.output).write_text(review + "\n", encoding="utf-8")
+    print(review)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-review
+++ b/claude-review
@@ -79,6 +79,21 @@ def http_get(url: str, token: str | None = None, accept: str = "application/vnd.
         return response.read().decode("utf-8")
 
 
+def http_post(url: str, payload: dict[str, str], token: str | None = None) -> str:
+    if not token:
+        raise SystemExit("Posting a review via HTTP fallback requires GITHUB_TOKEN.")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "claude-review-agent",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    request = Request(url, data=json.dumps(payload).encode("utf-8"), headers=headers, method="POST")
+    with urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
 def fetch_with_gh(pr: PullRequest) -> ReviewContext:
     repo = f"{pr.owner}/{pr.repo}"
     raw = run_gh([
@@ -130,6 +145,31 @@ def fetch_context(pr: PullRequest) -> ReviewContext:
             return fetch_with_http(pr)
         except (HTTPError, URLError, TimeoutError, KeyError, json.JSONDecodeError) as exc:
             raise SystemExit(f"Unable to fetch pull request data: {exc}") from exc
+
+
+def format_comment_body(review: str) -> str:
+    return f"## Claude Review Agent\n\n{review.strip()}\n"
+
+
+def post_comment_with_gh(pr: PullRequest, body: str) -> None:
+    run_gh(["pr", "comment", pr.number, "--repo", f"{pr.owner}/{pr.repo}", "--body", body])
+
+
+def post_comment_with_http(pr: PullRequest, body: str) -> None:
+    token = os.environ.get("GITHUB_TOKEN")
+    url = f"https://api.github.com/repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments"
+    http_post(url, {"body": body}, token)
+
+
+def post_review_comment(pr: PullRequest, review: str) -> None:
+    body = format_comment_body(review)
+    try:
+        post_comment_with_gh(pr, body)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        try:
+            post_comment_with_http(pr, body)
+        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"Unable to post review comment: {exc}") from exc
 
 
 def risk_for_file(path: str) -> list[str]:
@@ -231,13 +271,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Review a GitHub pull request and print structured Markdown.")
     parser.add_argument("--pr", required=True, help="GitHub pull request URL")
     parser.add_argument("--output", help="Optional file path for the Markdown review")
+    parser.add_argument("--post-comment", action="store_true", help="Post the structured review as a PR comment")
     args = parser.parse_args()
 
-    context = fetch_context(parse_pr_url(args.pr))
+    pr = parse_pr_url(args.pr)
+    context = fetch_context(pr)
     review = build_review(context)
     if args.output:
         Path(args.output).write_text(review + "\n", encoding="utf-8")
     print(review)
+    if args.post_comment:
+        post_review_comment(pr, review)
     return 0
 
 

--- a/samples/review-1033.md
+++ b/samples/review-1033.md
@@ -1,0 +1,14 @@
+## Summary
+This PR changes 4 file(s), with 589 additions and 0 deletions. The main touched paths are `README.md`, `hooks/block_destructive_bash.py`, `scripts/install_block_destructive_bash_hook.py`, `tests/test_block_destructive_bash.py`.
+The change is submitted by `@Treasure520520` in `claude-builders-bounty/claude-builders-bounty` PR #1033: feat: add destructive bash command blocker hook.
+
+## Risks
+- `README.md` is documentation-only unless paired with implementation changes.
+- New command execution or dynamic evaluation appears in the diff.
+- The patch removes test/assertion code; confirm coverage did not regress.
+
+## Suggestions
+- Call out the highest-risk behavior in the PR description with exact verification steps.
+- Preview the rendered documentation to catch broken links, formatting, and headings.
+
+## Confidence: Medium

--- a/samples/review-1356.md
+++ b/samples/review-1356.md
@@ -1,0 +1,11 @@
+## Summary
+This PR changes 8 file(s), with 375 additions and 0 deletions. The main touched paths are `index.d.ts`, `index.js`, `index.mjs`, `src/testing/event-catcher.js`, `src/testing/index.d.ts`, and 3 more.
+The change is submitted by `@Treasure520520` in `moleculerjs/moleculer` PR #1356: feat(testing): add Moleculer testing helpers.
+
+## Risks
+- No obvious structural risks were detected from the diff metadata.
+
+## Suggestions
+- Keep the PR description concise and include the exact validation commands used.
+
+## Confidence: Medium

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -53,6 +53,12 @@ class ClaudeReviewTests(unittest.TestCase):
         )
         self.assertIn("## Confidence: High", claude_review.build_review(context))
 
+    def test_format_comment_body_wraps_review(self):
+        body = claude_review.format_comment_body("## Summary\nLooks good.")
+        self.assertTrue(body.startswith("## Claude Review Agent"))
+        self.assertIn("## Summary", body)
+        self.assertTrue(body.endswith("\n"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,0 +1,58 @@
+import importlib.util
+import importlib.machinery
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+LOADER = importlib.machinery.SourceFileLoader("claude_review", str(ROOT / "claude-review"))
+SPEC = importlib.util.spec_from_loader("claude_review", LOADER)
+claude_review = importlib.util.module_from_spec(SPEC)
+sys.modules["claude_review"] = claude_review
+SPEC.loader.exec_module(claude_review)
+
+
+class ClaudeReviewTests(unittest.TestCase):
+    def test_parse_pr_url(self):
+        pr = claude_review.parse_pr_url("https://github.com/octocat/Hello-World/pull/42")
+        self.assertEqual(pr.owner, "octocat")
+        self.assertEqual(pr.repo, "Hello-World")
+        self.assertEqual(pr.number, "42")
+
+    def test_rejects_non_pr_url(self):
+        with self.assertRaises(SystemExit):
+            claude_review.parse_pr_url("https://github.com/octocat/Hello-World/issues/42")
+
+    def test_build_review_contains_required_sections(self):
+        context = claude_review.ReviewContext(
+            pr=claude_review.PullRequest("owner", "repo", "7", "https://github.com/owner/repo/pull/7"),
+            title="Add auth middleware",
+            author="alice",
+            changed_files=["src/auth.ts", "README.md"],
+            additions=40,
+            deletions=5,
+            patch="+const token = request.headers.authorization\n+// TODO: add tests\n",
+        )
+        review = claude_review.build_review(context)
+        self.assertIn("## Summary", review)
+        self.assertIn("## Risks", review)
+        self.assertIn("## Suggestions", review)
+        self.assertIn("## Confidence:", review)
+        self.assertIn("authentication or authorization-sensitive", review)
+
+    def test_low_risk_review_gets_high_confidence(self):
+        context = claude_review.ReviewContext(
+            pr=claude_review.PullRequest("owner", "repo", "8", "https://github.com/owner/repo/pull/8"),
+            title="Tighten copy",
+            author="bob",
+            changed_files=["src/copy.test.ts"],
+            additions=8,
+            deletions=3,
+            patch="+expect(title).toContain('Hello')\n",
+        )
+        self.assertIn("## Confidence: High", claude_review.build_review(context))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflows/claude-review.yml
+++ b/workflows/claude-review.yml
@@ -1,0 +1,36 @@
+name: Claude Review Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: Pull request URL to review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run PR review agent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_url || github.event.pull_request.html_url }}
+        run: |
+          python3 claude-review --pr "$PR_URL" --output review.md --post-comment
+
+      - name: Upload review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review
+          path: review.md


### PR DESCRIPTION
/claim #4

## Summary
- Added `claude-review`, a dependency-free Python CLI that reviews a GitHub PR URL and emits structured Markdown.
- Fetches PR metadata and patches through `gh` when available, with a `GITHUB_TOKEN` HTTP fallback.
- Produces the required sections: Summary, Risks, Suggestions, and Confidence.
- Added sample review outputs for two real PRs and unit tests for URL parsing and review generation.

## Sample outputs
- `samples/review-1033.md`
- `samples/review-1356.md`

## Verification
```bash
python3 -m unittest discover -s tests
GH_BIN=/Users/treasure/Documents/Codex/2026-05-12/goal-100-paypal-puresenses2021-gmail-com/tools/gh_2.92.0_macOS_arm64/bin/gh ./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/1033 --output samples/review-1033.md
GH_BIN=/Users/treasure/Documents/Codex/2026-05-12/goal-100-paypal-puresenses2021-gmail-com/tools/gh_2.92.0_macOS_arm64/bin/gh ./claude-review --pr https://github.com/moleculerjs/moleculer/pull/1356 --output samples/review-1356.md
git diff --check
```

Note: `GH_BIN` is only needed in my local environment because `gh` is installed in a local tool directory; normal users can run it with `gh` on PATH or use `GITHUB_TOKEN`.
