### PR TITLE
feat: add n8n weekly GitHub summary workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ You're in the right place.
 
 ---
 
+## n8n Weekly Dev Summary Workflow
+
+The bounty [#5](../../issues/5) workflow lives in [`workflows/github-weekly-summary.workflow.json`](workflows/github-weekly-summary.workflow.json).
+
+It runs weekly, gathers GitHub commits, closed issues, and merged PRs, asks Claude Sonnet 4 for a narrative summary, and posts the result to Discord. Setup is documented in [`workflows/README.md`](workflows/README.md).
+
+Validation:
+
+```bash
+python3 tests/validate_n8n_workflow.py
+```
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/tests/validate_n8n_workflow.py
+++ b/tests/validate_n8n_workflow.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / "workflows" / "github-weekly-summary.workflow.json"
+
+
+def main() -> int:
+    data = json.loads(WORKFLOW.read_text(encoding="utf-8"))
+    nodes = {node["name"]: node for node in data["nodes"]}
+    required_nodes = [
+        "Weekly Trigger",
+        "Configuration",
+        "Normalize Config",
+        "Fetch Commits",
+        "Fetch Closed Issues",
+        "Fetch Merged PRs",
+        "Build Claude Prompt",
+        "Call Claude API",
+        "Format Discord Payload",
+        "Send to Discord",
+    ]
+    missing = [name for name in required_nodes if name not in nodes]
+    assert not missing, f"Missing nodes: {missing}"
+
+    trigger = nodes["Weekly Trigger"]
+    cron = trigger["parameters"]["rule"]["interval"][0]["expression"]
+    assert cron == "0 17 * * 5", f"Unexpected cron: {cron}"
+
+    claude_body = nodes["Call Claude API"]["parameters"]["jsonBody"]
+    assert "claude-sonnet-4-20250514" in claude_body
+
+    config_text = json.dumps(nodes["Configuration"])
+    for key in ["GITHUB_REPO", "GITHUB_TOKEN", "ANTHROPIC_API_KEY", "DISCORD_WEBHOOK_URL", "SUMMARY_LANGUAGE"]:
+        assert key in config_text, f"Missing configurable variable {key}"
+
+    github_urls = "\n".join(
+        node["parameters"].get("url", "")
+        for node in data["nodes"]
+        if node["type"] == "n8n-nodes-base.httpRequest"
+    )
+    for path in ["/commits", "/issues", "/pulls"]:
+        assert path in github_urls, f"Missing GitHub API path {path}"
+
+    connections = data["connections"]
+    for source in required_nodes[:-1]:
+        assert source in connections, f"Missing connection from {source}"
+
+    print(f"Validated {WORKFLOW}: {len(data['nodes'])} nodes, cron {cron}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,31 @@
+# GitHub Weekly Narrative Summary
+
+This n8n workflow generates a weekly narrative summary for a GitHub repository with Claude Sonnet 4 and posts it to Discord.
+
+## Setup
+
+1. Import `github-weekly-summary.workflow.json` into n8n.
+2. Set environment variables: `GITHUB_REPO=owner/repo`, `GITHUB_TOKEN=...`, `ANTHROPIC_API_KEY=...`, `DISCORD_WEBHOOK_URL=...`, and `SUMMARY_LANGUAGE=EN` or `FR`.
+3. Open the workflow and confirm the **Weekly Trigger** cron is `0 17 * * 5` for Friday 5pm.
+4. Run **Execute workflow** once to verify GitHub fetch, Claude summary generation, and Discord delivery.
+5. Activate the workflow.
+
+## What It Does
+
+- Runs every Friday at 5pm.
+- Fetches commits, closed issues, and merged pull requests from the GitHub API for the last seven days.
+- Calls Claude with `claude-sonnet-4-20250514`.
+- Delivers the generated narrative summary to Discord.
+- Supports English and French output through `SUMMARY_LANGUAGE`.
+
+## Validation
+
+The workflow structure can be checked locally without secrets:
+
+```bash
+python3 tests/validate_n8n_workflow.py
+```
+
+The workflow was also imported with the n8n CLI; see [`VALIDATION.md`](VALIDATION.md).
+
+Live execution requires real `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_URL` values in an n8n instance.

--- a/workflows/VALIDATION.md
+++ b/workflows/VALIDATION.md
@@ -1,0 +1,36 @@
+# Validation Notes
+
+Validated locally on 2026-05-13.
+
+## Static Workflow Validation
+
+```bash
+python3 tests/validate_n8n_workflow.py
+```
+
+Result:
+
+```text
+Validated workflows/github-weekly-summary.workflow.json: 10 nodes, cron 0 17 * * 5
+```
+
+This checks:
+
+- Importable JSON syntax
+- Required n8n nodes
+- Friday 5pm weekly cron
+- GitHub commits, issues, and pulls API paths
+- Claude model `claude-sonnet-4-20250514`
+- Configurable `GITHUB_REPO`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `DISCORD_WEBHOOK_URL`, and `SUMMARY_LANGUAGE`
+
+## n8n CLI Import
+
+```bash
+N8N_USER_FOLDER=/tmp/n8n-claude-builders-5 \
+  npx --yes n8n@latest import:workflow \
+  --input=workflows/github-weekly-summary.workflow.json
+```
+
+Result: command completed with exit code `0`.
+
+Live end-to-end execution requires real GitHub, Anthropic, and Discord credentials. The workflow is configured to run manually in n8n for that final smoke test before activation.

--- a/workflows/github-weekly-summary.workflow.json
+++ b/workflows/github-weekly-summary.workflow.json
@@ -1,0 +1,399 @@
+{
+  "name": "GitHub Weekly Narrative Summary with Claude",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 17 * * 5"
+            }
+          ]
+        }
+      },
+      "id": "weekly-friday-trigger",
+      "name": "Weekly Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [160, 320]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "repo",
+              "name": "repo",
+              "type": "string",
+              "value": "={{ $env.GITHUB_REPO || 'owner/repo' }}"
+            },
+            {
+              "id": "language",
+              "name": "language",
+              "type": "string",
+              "value": "={{ ($env.SUMMARY_LANGUAGE || 'EN').toUpperCase() }}"
+            },
+            {
+              "id": "destination",
+              "name": "destinationWebhookUrl",
+              "type": "string",
+              "value": "={{ $env.DISCORD_WEBHOOK_URL || 'https://discord.com/api/webhooks/replace/me' }}"
+            },
+            {
+              "id": "github-token",
+              "name": "githubToken",
+              "type": "string",
+              "value": "={{ $env.GITHUB_TOKEN || '' }}"
+            },
+            {
+              "id": "anthropic-key",
+              "name": "anthropicApiKey",
+              "type": "string",
+              "value": "={{ $env.ANTHROPIC_API_KEY || '' }}"
+            },
+            {
+              "id": "since",
+              "name": "since",
+              "type": "string",
+              "value": "={{ $now.minus({ days: 7 }).toISO() }}"
+            },
+            {
+              "id": "until",
+              "name": "until",
+              "type": "string",
+              "value": "={{ $now.toISO() }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "configuration",
+      "name": "Configuration",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [400, 320]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $input.first().json;\nconst [owner, repo] = config.repo.split('/');\nif (!owner || !repo) {\n  throw new Error('GITHUB_REPO must use owner/repo format');\n}\nreturn [{ json: { ...config, owner, repo } }];"
+      },
+      "id": "normalize-config",
+      "name": "Normalize Config",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [640, 320]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $json.owner }}/{{ $json.repo }}/commits",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.githubToken }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "since",
+              "value": "={{ $json.since }}"
+            },
+            {
+              "name": "until",
+              "value": "={{ $json.until }}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-commits",
+      "name": "Fetch Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [880, 160]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Normalize Config').item.json.owner }}/{{ $('Normalize Config').item.json.repo }}/issues",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Normalize Config').item.json.githubToken }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "since",
+              "value": "={{ $('Normalize Config').item.json.since }}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-closed-issues",
+      "name": "Fetch Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 320]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Normalize Config').item.json.owner }}/{{ $('Normalize Config').item.json.repo }}/pulls",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Normalize Config').item.json.githubToken }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "sort",
+              "value": "updated"
+            },
+            {
+              "name": "direction",
+              "value": "desc"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-merged-prs",
+      "name": "Fetch Merged PRs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1360, 320]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $('Normalize Config').first().json;\nconst commits = $('Fetch Commits').all().map(item => item.json);\nconst issues = $('Fetch Closed Issues').all().map(item => item.json).filter(issue => !issue.pull_request);\nconst since = new Date(config.since);\nconst prs = $('Fetch Merged PRs').all().map(item => item.json).filter(pr => pr.merged_at && new Date(pr.merged_at) >= since);\n\nconst commitList = commits.slice(0, 30).map(commit => {\n  const message = commit.commit?.message?.split('\\n')[0] || 'Untitled commit';\n  const author = commit.author?.login || commit.commit?.author?.name || 'unknown';\n  return `- ${message} (@${author})`;\n}).join('\\n') || '- None';\n\nconst issueList = issues.slice(0, 20).map(issue => `- #${issue.number}: ${issue.title}`).join('\\n') || '- None';\nconst prList = prs.slice(0, 20).map(pr => `- #${pr.number}: ${pr.title} (@${pr.user?.login || 'unknown'})`).join('\\n') || '- None';\nconst languageInstruction = config.language === 'FR' ? 'Respond entirely in French.' : 'Respond entirely in English.';\n\nconst prompt = `You are a technical writer creating a weekly narrative summary for a GitHub repository.\\n${languageInstruction}\\n\\nRepository: ${config.owner}/${config.repo}\\nPeriod: ${config.since.slice(0, 10)} to ${config.until.slice(0, 10)}\\n\\nCommits (${commits.length}):\\n${commitList}\\n\\nClosed issues (${issues.length}):\\n${issueList}\\n\\nMerged pull requests (${prs.length}):\\n${prList}\\n\\nWrite a concise 300-500 word Markdown summary with these sections:\\n## Overview\\n## Shipped Work\\n## Issues Resolved\\n## Contributors\\n## Momentum\\n\\nMention concrete PR and issue numbers when useful.`;\n\nreturn [{ json: { ...config, prompt, stats: { commits: commits.length, closedIssues: issues.length, mergedPullRequests: prs.length } } }];"
+      },
+      "id": "build-claude-prompt",
+      "name": "Build Claude Prompt",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1600, 320]
+    },
+    {
+      "parameters": {
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropicApiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 1200,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": {{ JSON.stringify($json.prompt) }}\n    }\n  ]\n}",
+        "options": {}
+      },
+      "id": "call-claude",
+      "name": "Call Claude API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1840, 320]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $('Build Claude Prompt').first().json;\nconst response = $input.first().json;\nconst summary = response.content?.[0]?.text || 'Claude did not return summary text.';\nconst payload = {\n  username: 'GitHub Weekly Summary',\n  embeds: [\n    {\n      title: `Weekly summary: ${config.repo}`,\n      description: summary.slice(0, 4096),\n      color: 5814783,\n      footer: {\n        text: `${config.stats.commits} commits • ${config.stats.closedIssues} issues closed • ${config.stats.mergedPullRequests} PRs merged`\n      }\n    }\n  ]\n};\nreturn [{ json: { ...config, summary, discordPayload: payload } }];"
+      },
+      "id": "format-discord-payload",
+      "name": "Format Discord Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2080, 320]
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.destinationWebhookUrl }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.discordPayload) }}",
+        "options": {}
+      },
+      "id": "send-to-discord",
+      "name": "Send to Discord",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2320, 320]
+    }
+  ],
+  "connections": {
+    "Weekly Trigger": {
+      "main": [
+        [
+          {
+            "node": "Configuration",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Configuration": {
+      "main": [
+        [
+          {
+            "node": "Normalize Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Config": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits": {
+      "main": [
+        [
+          {
+            "node": "Fetch Closed Issues",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed Issues": {
+      "main": [
+        [
+          {
+            "node": "Fetch Merged PRs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Merged PRs": {
+      "main": [
+        [
+          {
+            "node": "Build Claude Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Claude Prompt": {
+      "main": [
+        [
+          {
+            "node": "Call Claude API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Claude API": {
+      "main": [
+        [
+          {
+            "node": "Format Discord Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Discord Payload": {
+      "main": [
+        [
+          {
+            "node": "Send to Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "saveExecutionProgress": true
+  },
+  "pinData": {},
+  "staticData": null,
+  "tags": [],
+  "versionId": "1.0.0"
+}


### PR DESCRIPTION
/claim #5

## Summary
- Added an importable n8n workflow JSON for weekly GitHub repo summaries.
- Workflow runs every Friday at 5pm, fetches commits, closed issues, and merged PRs from GitHub, calls Claude Sonnet 4 (`claude-sonnet-4-20250514`), and posts a narrative summary to Discord.
- Added configurable variables for repo, GitHub token, Anthropic key, Discord webhook, and EN/FR language selection.
- Added a 5-step setup README plus validation notes.

## Files
- `workflows/github-weekly-summary.workflow.json`
- `workflows/README.md`
- `workflows/VALIDATION.md`
- `tests/validate_n8n_workflow.py`

## Verification
```bash
python3 tests/validate_n8n_workflow.py
python3 -m json.tool workflows/github-weekly-summary.workflow.json >/tmp/github-weekly-summary.pretty.json
git diff --check
N8N_USER_FOLDER=/tmp/n8n-claude-builders-5 npx --yes n8n@latest import:workflow --input=workflows/github-weekly-summary.workflow.json
```

The n8n CLI import command completed with exit code `0`. Live end-to-end execution still requires real `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_URL` values in an n8n instance; I documented that in `workflows/VALIDATION.md` rather than fabricating a screenshot.
