### PR TITLE
feat: add changelog generator skill

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,11 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from the current repository's git history.
+
+Run:
+
+```bash
+bash changelog.sh
+```
+
+The command detects the latest git tag, reads commits after that tag, categorizes them as `Added`, `Fixed`, `Changed`, or `Removed`, and writes `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ You're in the right place.
 
 ---
 
+## Generate a Changelog
+
+Create a structured `CHANGELOG.md` from commits since the latest git tag:
+
+1. Run `bash changelog.sh`.
+2. Optionally pass `--repo PATH` or `--output PATH`.
+3. Review the generated `Added`, `Fixed`, `Changed`, and `Removed` sections.
+
+Claude Code users can also run `/generate-changelog` from this repository.
+See [samples/CHANGELOG.sample.md](samples/CHANGELOG.sample.md) for output generated from real repository history.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="."
+output="CHANGELOG.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -r|--repo)
+      repo="${2:?Missing value for $1}"
+      shift 2
+      ;;
+    -o|--output)
+      output="${2:?Missing value for $1}"
+      shift 2
+      ;;
+    --stdout)
+      exec python3 "$(dirname "$0")/scripts/generate_changelog.py" --repo "$repo" --stdout
+      ;;
+    -h|--help)
+      exec python3 "$(dirname "$0")/scripts/generate_changelog.py" --help
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: bash changelog.sh [--repo PATH] [--output CHANGELOG.md] [--stdout]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+python3 "$(dirname "$0")/scripts/generate_changelog.py" --repo "$repo" --output "$output"

--- a/samples/CHANGELOG.sample.md
+++ b/samples/CHANGELOG.sample.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes are generated from git history.
+
+## Unreleased - 2026-05-13
+
+All commits in this repository because no git tag was found.
+
+### Added
+- feat: initial README with bounty board ([`1aeae2a`](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/1aeae2adc82d33f971fd7731644348dcdd24b5a6), 2026-03-27)
+
+### Fixed
+- No changes.
+
+### Changed
+- Initial commit ([`a80a580`](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/a80a580e34190a6bb8649a1b75a9fec8312bea5c), 2026-03-27)
+
+### Removed
+- No changes.

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SECTIONS = ("Added", "Fixed", "Changed", "Removed")
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    author: str
+    date: str
+
+
+def run_git(repo: Path, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=check,
+    )
+
+
+def resolve_repo(path: str) -> Path:
+    repo = Path(path).expanduser().resolve()
+    result = run_git(repo, ["rev-parse", "--show-toplevel"])
+    return Path(result.stdout.strip())
+
+
+def latest_tag(repo: Path) -> str | None:
+    result = run_git(repo, ["describe", "--tags", "--abbrev=0"], check=False)
+    if result.returncode != 0:
+        return None
+    tag = result.stdout.strip()
+    return tag or None
+
+
+def collect_commits(repo: Path, tag: str | None) -> list[Commit]:
+    revision_range = f"{tag}..HEAD" if tag else "HEAD"
+    pretty = "%H%x1f%s%x1f%an%x1f%ad%x1e"
+    result = run_git(repo, ["log", "--date=short", f"--pretty=format:{pretty}", revision_range])
+    commits: list[Commit] = []
+    for record in result.stdout.strip("\x1e\n").split("\x1e"):
+        if not record.strip():
+            continue
+        parts = record.strip().split("\x1f")
+        if len(parts) != 4:
+            continue
+        commits.append(Commit(*parts))
+    return commits
+
+
+def category_for(subject: str) -> str:
+    lowered = subject.lower()
+    prefix = lowered.split(":", 1)[0].split("(", 1)[0].strip()
+
+    if prefix in {"feat", "feature", "add"}:
+        return "Added"
+    if prefix in {"fix", "bugfix", "hotfix"}:
+        return "Fixed"
+    if prefix in {"remove", "removed", "delete", "deleted"}:
+        return "Removed"
+    if prefix in {"refactor", "perf", "docs", "doc", "style", "test", "tests", "build", "ci", "chore"}:
+        return "Changed"
+
+    removed_words = ("remove", "removed", "delete", "deleted", "drop", "dropped", "deprecate")
+    fixed_words = ("fix", "fixed", "bug", "crash", "regression", "repair", "resolve")
+    added_words = ("add", "added", "introduce", "create", "new", "support")
+
+    if any(word in lowered for word in removed_words):
+        return "Removed"
+    if any(word in lowered for word in fixed_words):
+        return "Fixed"
+    if any(word in lowered for word in added_words):
+        return "Added"
+    return "Changed"
+
+
+def commit_url(repo: Path, sha: str) -> str | None:
+    result = run_git(repo, ["remote", "get-url", "origin"], check=False)
+    if result.returncode != 0:
+        return None
+    remote = result.stdout.strip()
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+    if remote.startswith("git@github.com:"):
+        remote = "https://github.com/" + remote.removeprefix("git@github.com:")
+    if remote.startswith("https://github.com/"):
+        return f"{remote}/commit/{sha}"
+    return None
+
+
+def format_changelog(repo: Path, commits: list[Commit], tag: str | None) -> str:
+    today = dt.date.today().isoformat()
+    grouped: dict[str, list[Commit]] = {section: [] for section in SECTIONS}
+    for commit in commits:
+        grouped[category_for(commit.subject)].append(commit)
+
+    if tag:
+        source = f"Commits since `{tag}`."
+    else:
+        source = "All commits in this repository because no git tag was found."
+
+    lines = [
+        "# Changelog",
+        "",
+        "All notable changes are generated from git history.",
+        "",
+        f"## Unreleased - {today}",
+        "",
+        source,
+        "",
+    ]
+
+    base_commit_url = commit_url(repo, "")
+    for section in SECTIONS:
+        lines.append(f"### {section}")
+        if grouped[section]:
+            for commit in grouped[section]:
+                short_sha = commit.sha[:7]
+                if base_commit_url:
+                    link = f"[`{short_sha}`]({base_commit_url}{commit.sha})"
+                else:
+                    link = f"`{short_sha}`"
+                lines.append(f"- {commit.subject} ({link}, {commit.date})")
+        else:
+            lines.append("- No changes.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from commits since the latest git tag.")
+    parser.add_argument("-r", "--repo", default=".", help="Git repository path. Defaults to current directory.")
+    parser.add_argument("-o", "--output", default="CHANGELOG.md", help="Output markdown path. Defaults to CHANGELOG.md.")
+    parser.add_argument("--stdout", action="store_true", help="Print changelog instead of writing a file.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        repo = resolve_repo(args.repo)
+        tag = latest_tag(repo)
+        commits = collect_commits(repo, tag)
+        changelog = format_changelog(repo, commits, tag)
+        if args.stdout:
+            sys.stdout.write(changelog)
+            return 0
+
+        output = Path(args.output)
+        if not output.is_absolute():
+            output = Path(os.getcwd()) / output
+        output.write_text(changelog, encoding="utf-8")
+        print(f"Wrote {output}")
+        return 0
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stderr or str(error))
+        return error.returncode or 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from commits since the latest git tag.
+---
+
+# Generate Changelog
+
+Use this skill when a project needs a quick release changelog from git history.
+
+## Steps
+
+1. Run `bash changelog.sh` from the repository root.
+2. Review the generated `CHANGELOG.md` sections: `Added`, `Fixed`, `Changed`, and `Removed`.
+3. Edit wording only when a commit subject needs human cleanup before release.
+
+## Behavior
+
+- Finds the latest git tag with `git describe --tags --abbrev=0`.
+- Uses all commits when a repository has no tags.
+- Categorizes conventional commits first, then falls back to keyword matching.
+- Writes a Keep-a-Changelog-style markdown file.

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+git -C "$tmp" init -q
+git -C "$tmp" config user.email "test@example.com"
+git -C "$tmp" config user.name "Test User"
+
+printf 'initial\n' > "$tmp/app.txt"
+git -C "$tmp" add app.txt
+git -C "$tmp" commit -q -m "chore: initial release"
+git -C "$tmp" tag v1.0.0
+
+printf 'feature\n' >> "$tmp/app.txt"
+git -C "$tmp" commit -qam "feat: add billing dashboard"
+printf 'fix\n' >> "$tmp/app.txt"
+git -C "$tmp" commit -qam "fix: resolve invoice rounding"
+printf 'docs\n' >> "$tmp/app.txt"
+git -C "$tmp" commit -qam "docs: update setup guide"
+printf 'remove\n' >> "$tmp/app.txt"
+git -C "$tmp" commit -qam "remove deprecated webhook endpoint"
+
+bash "$root/changelog.sh" --repo "$tmp" --output "$tmp/CHANGELOG.md"
+
+grep -q "Commits since \`v1.0.0\`" "$tmp/CHANGELOG.md"
+grep -q "### Added" "$tmp/CHANGELOG.md"
+grep -q "feat: add billing dashboard" "$tmp/CHANGELOG.md"
+grep -q "### Fixed" "$tmp/CHANGELOG.md"
+grep -q "fix: resolve invoice rounding" "$tmp/CHANGELOG.md"
+grep -q "### Changed" "$tmp/CHANGELOG.md"
+grep -q "docs: update setup guide" "$tmp/CHANGELOG.md"
+grep -q "### Removed" "$tmp/CHANGELOG.md"
+grep -q "remove deprecated webhook endpoint" "$tmp/CHANGELOG.md"
+
+python3 -m py_compile "$root/scripts/generate_changelog.py"
+echo "CHANGELOG generator test passed"


### PR DESCRIPTION
## Summary
- adds a dependency-free `changelog.sh` entrypoint backed by `scripts/generate_changelog.py`
- adds a Claude Code `/generate-changelog` command plus `skills/generate-changelog/SKILL.md`
- documents setup in three steps and includes sample output from this repository

## Bounty
- Resolves #1
- /claim #1

## Verification
- `bash tests/test_changelog.sh`
- `python3 -m py_compile scripts/generate_changelog.py`
- `bash changelog.sh --stdout` on this repository
- `git diff --check`

The test creates a temporary tagged git repository and verifies commits are grouped under Added, Fixed, Changed, and Removed.