### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes text eol=lf
+hooks/destructive-command-blocker/* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /.gitattributes text eol=lf
+/.gitignore text eol=lf
 hooks/destructive-command-blocker/* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -6,12 +6,12 @@ Claude Code `PreToolUse` hook that blocks destructive Bash commands before they 
 
 - Recursive forced deletion through `rm -rf`, `rm -fr`, `rm --recursive --force`, and wrapper commands such as `sudo rm -rf`, `bash -lc "rm -rf ..."`, or `find ... -exec rm -rf`.
 - Forced Git pushes through `git push --force`, `git push -f`, `git push --force-with-lease`, and forced refspecs such as `git push origin +main`.
-- Destructive SQL sent to common database clients such as `psql`, `mysql`, `mariadb`, `sqlite3`, `duckdb`, and `sqlcmd`:
+- Direct destructive SQL statements, plus destructive SQL sent to common database clients such as `psql`, `mysql`, `mariadb`, `sqlite3`, `duckdb`, and `sqlcmd`:
   - `DROP TABLE`, `DROP DATABASE`, and `DROP SCHEMA`
   - `TRUNCATE`
   - `DELETE FROM` statements without a `WHERE` clause
 
-The detector tokenizes the shell command before matching, so documentation/search commands such as `echo "rm -rf build"` and `grep -R "DROP TABLE" docs` are not blocked.
+The detector tokenizes the shell command before matching, so documentation/search commands such as `echo "rm -rf build"`, `grep -R "DROP TABLE" docs`, and `printf "DELETE FROM users" >> examples.sql` are not blocked.
 
 Blocked attempts are appended as JSON lines to `~/.claude/hooks/blocked.log` with the UTC timestamp, severity, rule, reason, evidence, attempted command, and project path.
 
@@ -52,4 +52,4 @@ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules","cwd":"/
 
 Expected output contains `permissionDecision: "deny"` and a clear reason for Claude. Safe Bash commands exit without output so they do not interfere with normal work.
 
-The included tests cover the required acceptance criteria plus wrapper commands, nested shell commands, Git forced refspecs, SQL clients, piped SQL input, false-positive strings, non-Bash tool payloads, invalid input, logging, and installer idempotency.
+The included tests cover the required acceptance criteria plus wrapper commands, nested shell commands, Git forced refspecs, direct SQL statements, SQL clients, piped SQL input, false-positive strings, non-Bash tool payloads, invalid input, logging, and installer idempotency.

--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -4,13 +4,16 @@ Claude Code `PreToolUse` hook that blocks destructive Bash commands before they 
 
 ## What It Blocks
 
-- `rm -rf`
-- `DROP TABLE`
-- `git push --force` and `git push -f`
-- `TRUNCATE`
-- `DELETE FROM` statements without a `WHERE` clause
+- Recursive forced deletion through `rm -rf`, `rm -fr`, `rm --recursive --force`, and wrapper commands such as `sudo rm -rf`, `bash -lc "rm -rf ..."`, or `find ... -exec rm -rf`.
+- Forced Git pushes through `git push --force`, `git push -f`, `git push --force-with-lease`, and forced refspecs such as `git push origin +main`.
+- Destructive SQL sent to common database clients such as `psql`, `mysql`, `mariadb`, `sqlite3`, `duckdb`, and `sqlcmd`:
+  - `DROP TABLE`, `DROP DATABASE`, and `DROP SCHEMA`
+  - `TRUNCATE`
+  - `DELETE FROM` statements without a `WHERE` clause
 
-Blocked attempts are appended as JSON lines to `~/.claude/hooks/blocked.log` with the UTC timestamp, matched pattern, attempted command, and project path.
+The detector tokenizes the shell command before matching, so documentation/search commands such as `echo "rm -rf build"` and `grep -R "DROP TABLE" docs` are not blocked.
+
+Blocked attempts are appended as JSON lines to `~/.claude/hooks/blocked.log` with the UTC timestamp, severity, rule, reason, evidence, attempted command, and project path.
 
 ## Install
 
@@ -39,6 +42,8 @@ The installer copies `destructive-command-blocker.py` into `~/.claude/hooks/` an
 }
 ```
 
+On Windows, the installer writes a command that invokes the current Python executable explicitly. On macOS/Linux, it writes the copied hook path and marks it executable. Re-running the installer updates the existing hook entry instead of duplicating it.
+
 ## Manual Check
 
 ```bash
@@ -46,3 +51,5 @@ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules","cwd":"/
 ```
 
 Expected output contains `permissionDecision: "deny"` and a clear reason for Claude. Safe Bash commands exit without output so they do not interfere with normal work.
+
+The included tests cover the required acceptance criteria plus wrapper commands, nested shell commands, Git forced refspecs, SQL clients, piped SQL input, false-positive strings, non-Bash tool payloads, invalid input, logging, and installer idempotency.

--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -1,0 +1,48 @@
+# Destructive Command Blocker
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## What It Blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force` and `git push -f`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+
+Blocked attempts are appended as JSON lines to `~/.claude/hooks/blocked.log` with the UTC timestamp, matched pattern, attempted command, and project path.
+
+## Install
+
+```bash
+python hooks/destructive-command-blocker/install.py
+python hooks/destructive-command-blocker/test_destructive_command_blocker.py
+```
+
+The installer copies `destructive-command-blocker.py` into `~/.claude/hooks/` and adds an equivalent Claude Code hook configuration to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/destructive-command-blocker.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Manual Check
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules","cwd":"/tmp/project"}}' | ~/.claude/hooks/destructive-command-blocker.py
+```
+
+Expected output contains `permissionDecision: "deny"` and a clear reason for Claude. Safe Bash commands exit without output so they do not interfere with normal work.

--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -10,8 +10,9 @@ Claude Code `PreToolUse` hook that blocks destructive Bash commands before they 
   - `DROP TABLE`, `DROP DATABASE`, and `DROP SCHEMA`
   - `TRUNCATE`
   - `DELETE FROM` statements without a `WHERE` clause
+  - SQL loaded from explicit local input files such as `psql -f migration.sql`, `sqlcmd -i migration.sql`, `mysql < migration.sql`, and `cat migration.sql | psql`
 
-The detector tokenizes the shell command before matching, so documentation/search commands such as `echo "rm -rf build"`, `grep -R "DROP TABLE" docs`, and `printf "DELETE FROM users" >> examples.sql` are not blocked.
+The detector tokenizes the shell command before matching, so documentation/search commands such as `echo "rm -rf build"`, `grep -R "DROP TABLE" docs`, and `printf "DELETE FROM users" >> examples.sql` are not blocked. SQL file inspection is limited to local files explicitly passed to a recognized database client, and files larger than 1 MiB are skipped to avoid slowing normal Bash usage.
 
 Blocked attempts are appended as JSON lines to `~/.claude/hooks/blocked.log` with the UTC timestamp, severity, rule, reason, evidence, attempted command, and project path.
 
@@ -52,4 +53,4 @@ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules","cwd":"/
 
 Expected output contains `permissionDecision: "deny"` and a clear reason for Claude. Safe Bash commands exit without output so they do not interfere with normal work.
 
-The included tests cover the required acceptance criteria plus wrapper commands, nested shell commands, Git forced refspecs, direct SQL statements, SQL clients, piped SQL input, false-positive strings, non-Bash tool payloads, invalid input, logging, and installer idempotency.
+The included tests cover the required acceptance criteria plus wrapper commands, nested shell commands, Git forced refspecs, direct SQL statements, SQL clients, SQL input files and redirections, piped SQL input, false-positive strings, non-Bash tool payloads, invalid input, logging, and installer idempotency.

--- a/hooks/destructive-command-blocker/destructive-command-blocker.py
+++ b/hooks/destructive-command-blocker/destructive-command-blocker.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+HOOK_EVENT_NAME = "PreToolUse"
+
+BLOCKERS: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "rm -rf",
+        re.compile(r"(?i)(?:^|[\s;&|()])rm\s+-(?=[A-Za-z-]*r)(?=[A-Za-z-]*f)[A-Za-z-]*\b"),
+        "Recursive forced deletion can remove large parts of the project or home directory.",
+    ),
+    (
+        "DROP TABLE",
+        re.compile(r"(?is)\bdrop\s+table\b"),
+        "DROP TABLE deletes an entire database table.",
+    ),
+    (
+        "TRUNCATE",
+        re.compile(r"(?is)\btruncate(?:\s+table)?\b"),
+        "TRUNCATE removes all rows from a table.",
+    ),
+    (
+        "git push --force",
+        re.compile(r"(?is)\bgit\s+push\b[^;&|\n]*?(?:--force\b|\s-f(?:\s|$))"),
+        "Force pushing can overwrite remote history.",
+    ),
+]
+
+DELETE_FROM_RE = re.compile(r"(?is)\bdelete\s+from\b")
+WHERE_RE = re.compile(r"(?is)\bwhere\b")
+
+
+def main() -> int:
+    payload = read_json(sys.stdin.read())
+    if payload is None:
+        return 0
+
+    tool_name = str(payload.get("tool_name", ""))
+    if tool_name.lower() != "bash":
+        return 0
+
+    command = extract_command(payload)
+    if not command:
+        return 0
+
+    match = first_blocking_match(command)
+    if match is None:
+        return 0
+
+    pattern_name, reason = match
+    project_path = extract_project_path(payload)
+    log_blocked_attempt(command, project_path, pattern_name)
+    print(deny_response(pattern_name, reason))
+    return 0
+
+
+def read_json(raw: str) -> dict[str, Any] | None:
+    try:
+        data = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return ""
+
+    command = tool_input.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def first_blocking_match(command: str) -> tuple[str, str] | None:
+    for pattern_name, pattern, reason in BLOCKERS:
+        if pattern.search(command):
+            return pattern_name, reason
+
+    if delete_from_without_where(command):
+        return (
+            "DELETE FROM without WHERE",
+            "DELETE FROM without a WHERE clause can delete every row in the table.",
+        )
+
+    return None
+
+
+def delete_from_without_where(command: str) -> bool:
+    for statement in command.split(";"):
+        match = DELETE_FROM_RE.search(statement)
+        if not match:
+            continue
+
+        after_delete = statement[match.end() :]
+        if not WHERE_RE.search(after_delete):
+            return True
+
+    return False
+
+
+def extract_project_path(payload: dict[str, Any]) -> str:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("cwd", "project_path"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+    for key in ("cwd", "project_path"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def hook_dir() -> Path:
+    override = os.environ.get("CLAUDE_HOOKS_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude" / "hooks"
+
+
+def log_blocked_attempt(command: str, project_path: str, pattern_name: str) -> None:
+    log_path = hook_dir() / "blocked.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "pattern": pattern_name,
+            "command": command,
+            "project_path": project_path,
+        }
+        with log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except OSError:
+        # Blocking should not depend on logging success.
+        pass
+
+
+def deny_response(pattern_name: str, reason: str) -> str:
+    message = (
+        f"Blocked potentially destructive Bash command ({pattern_name}). "
+        f"{reason} Use a narrower, reversible, or explicitly reviewed command instead."
+    )
+    response = {
+        "hookSpecificOutput": {
+            "hookEventName": HOOK_EVENT_NAME,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": message,
+        }
+    }
+    return json.dumps(response)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-blocker/destructive-command-blocker.py
+++ b/hooks/destructive-command-blocker/destructive-command-blocker.py
@@ -58,14 +58,33 @@ SQL_OPTION_FLAGS = {
     "/Q",
 }
 
+SQL_FILE_OPTION_FLAGS_BY_CLIENT = {
+    "psql": {"-f", "--file"},
+    "sqlcmd": {"-i", "--input", "--input-file"},
+    "sqlite": {"-init"},
+    "sqlite3": {"-init"},
+}
+
+SQL_STDIN_SOURCE_COMMANDS = {
+    "cat",
+    "type",
+}
+
+SQL_STDIN_TEXT_COMMANDS = {
+    "echo",
+    "printf",
+}
+
+MAX_SQL_FILE_BYTES = 1024 * 1024
+
 SQL_KEYWORD_RE = re.compile(
-    r"(?is)\b(drop\s+(?:table|database|schema)|truncate(?:\s+table)?|delete\s+from)\b"
+    r"(?is)\b(drop\s+(?:table|database|schema)(?=\s|;|$)|truncate(?:\s+table)?(?=\s|;|$)|delete\s+from\b)"
 )
 SQL_STATEMENT_START_RE = re.compile(
-    r"(?is)^\s*(?:drop\s+(?:table|database|schema)|truncate(?:\s+table)?|delete\s+from)\b"
+    r"(?is)^\s*(?:drop\s+(?:table|database|schema)(?=\s|;|$)|truncate(?:\s+table)?(?=\s|;|$)|delete\s+from\b)"
 )
 DROP_OR_TRUNCATE_RE = re.compile(
-    r"(?is)\b(?:drop\s+(?:table|database|schema)|truncate(?:\s+table)?)\b"
+    r"(?is)\b(?:drop\s+(?:table|database|schema)(?=\s|;|$)|truncate(?:\s+table)?(?=\s|;|$))"
 )
 DELETE_FROM_RE = re.compile(r"(?is)\bdelete\s+from\b")
 WHERE_RE = re.compile(r"(?is)\bwhere\b")
@@ -92,11 +111,11 @@ def main() -> int:
     if not command:
         return 0
 
-    detection = detect_destructive_command(command)
+    project_path = extract_project_path(payload)
+    detection = detect_destructive_command(command, project_path)
     if detection is None:
         return 0
 
-    project_path = extract_project_path(payload)
     log_blocked_attempt(command, project_path, detection)
     print(deny_response(detection))
     return 0
@@ -119,7 +138,7 @@ def extract_command(payload: dict[str, Any]) -> str:
     return command if isinstance(command, str) else ""
 
 
-def detect_destructive_command(command: str, depth: int = 0) -> Detection | None:
+def detect_destructive_command(command: str, cwd: str | None = None, depth: int = 0) -> Detection | None:
     if depth > 3:
         return None
 
@@ -128,18 +147,18 @@ def detect_destructive_command(command: str, depth: int = 0) -> Detection | None
         return fallback_text_detection(command)
 
     for embedded_command in embedded_shell_commands(tokens):
-        detection = detect_destructive_command(embedded_command, depth + 1)
+        detection = detect_destructive_command(embedded_command, cwd, depth + 1)
         if detection is not None:
             return detection
 
-    for detector in (
-        detect_rm_recursive_force,
-        detect_git_force_push,
-        detect_destructive_sql,
-    ):
+    for detector in (detect_rm_recursive_force, detect_git_force_push):
         detection = detector(command, tokens)
         if detection is not None:
             return detection
+
+    detection = detect_destructive_sql(command, tokens, cwd)
+    if detection is not None:
+        return detection
 
     return None
 
@@ -295,7 +314,7 @@ def git_subcommand_index(args: list[str]) -> int | None:
     return None
 
 
-def detect_destructive_sql(command: str, tokens: list[str]) -> Detection | None:
+def detect_destructive_sql(command: str, tokens: list[str], cwd: str | None = None) -> Detection | None:
     direct_payload = direct_sql_payload(command)
     if direct_payload:
         detection = classify_sql(direct_payload)
@@ -304,13 +323,24 @@ def detect_destructive_sql(command: str, tokens: list[str]) -> Detection | None:
 
     payloads = sql_payloads_from_clients(tokens)
     if has_sql_client(tokens):
-        payloads.extend(token for token in tokens if looks_like_sql(token))
-        payloads.append(command)
+        payloads.extend(sql_stdin_text_payloads_from_clients(tokens))
+        if "<<" in command:
+            payloads.append(command)
 
     for payload in payloads:
         detection = classify_sql(payload)
         if detection is not None:
             return detection
+
+    for path, payload in sql_file_payloads_from_clients(tokens, cwd):
+        detection = classify_sql(payload)
+        if detection is not None:
+            return Detection(
+                detection.rule,
+                detection.reason,
+                f"{detection.evidence} in SQL input file {path}",
+                detection.severity,
+            )
 
     return None
 
@@ -340,6 +370,129 @@ def sql_payloads_from_clients(tokens: list[str]) -> list[str]:
                 payloads.append(arg)
 
     return payloads
+
+
+def sql_stdin_text_payloads_from_clients(tokens: list[str]) -> list[str]:
+    payloads: list[str] = []
+    for index, token in enumerate(tokens):
+        if base_name(token) in SQL_CLIENTS:
+            payloads.extend(piped_text_payloads(tokens, index))
+    return payloads
+
+
+def piped_text_payloads(tokens: list[str], sql_client_index: int) -> Iterable[str]:
+    source_command = piped_source_command(tokens, sql_client_index)
+    if not source_command or base_name(source_command[0]) not in SQL_STDIN_TEXT_COMMANDS:
+        return
+
+    args = [
+        arg
+        for arg in source_command[1:]
+        if arg != "--" and not (base_name(source_command[0]) == "echo" and arg.startswith("-"))
+    ]
+    if args:
+        yield " ".join(args)
+
+
+def sql_file_payloads_from_clients(tokens: list[str], cwd: str | None = None) -> list[tuple[str, str]]:
+    payloads: list[tuple[str, str]] = []
+    seen: set[Path] = set()
+
+    for index, token in enumerate(tokens):
+        if base_name(token) not in SQL_CLIENTS:
+            continue
+
+        for candidate in sql_file_candidates(tokens, index):
+            resolved = resolve_sql_file(candidate, cwd)
+            if resolved is None or resolved in seen:
+                continue
+            seen.add(resolved)
+            content = read_sql_file(resolved)
+            if content is not None:
+                payloads.append((str(resolved), content))
+
+    return payloads
+
+
+def sql_file_candidates(tokens: list[str], sql_client_index: int) -> Iterable[str]:
+    client = base_name(tokens[sql_client_index])
+    file_flags = SQL_FILE_OPTION_FLAGS_BY_CLIENT.get(client, set())
+    args = list(command_args_after(tokens, sql_client_index))
+    for arg_index, arg in enumerate(args):
+        lowered = arg.lower()
+        if lowered in file_flags and arg_index + 1 < len(args):
+            yield args[arg_index + 1]
+        elif any(
+            lowered.startswith(flag + "=")
+            for flag in file_flags
+            if flag.startswith("--")
+        ):
+            yield arg.split("=", 1)[1]
+        elif "-f" in file_flags and lowered.startswith("-f") and len(arg) > 2:
+            yield arg[2:]
+        elif "-i" in file_flags and lowered.startswith("-i") and len(arg) > 2:
+            yield arg[2:]
+        elif lowered.startswith("<") and len(arg) > 1 and not lowered.startswith("<<"):
+            yield arg[1:]
+        elif arg == "<" and arg_index + 1 < len(args):
+            yield args[arg_index + 1]
+
+    yield from piped_file_candidates(tokens, sql_client_index)
+
+
+def piped_file_candidates(tokens: list[str], sql_client_index: int) -> Iterable[str]:
+    source_command = piped_source_command(tokens, sql_client_index)
+    if not source_command or base_name(source_command[0]) not in SQL_STDIN_SOURCE_COMMANDS:
+        return
+
+    for arg in source_command[1:]:
+        if arg == "--":
+            continue
+        if arg.startswith("-"):
+            continue
+        yield arg
+
+
+def piped_source_command(tokens: list[str], sql_client_index: int) -> list[str]:
+    pipe_index = sql_client_index - 1
+    while pipe_index >= 0 and tokens[pipe_index] not in {"|", "|&"}:
+        if tokens[pipe_index] in COMMAND_SEPARATORS:
+            return []
+        pipe_index -= 1
+    if pipe_index < 1:
+        return []
+
+    source_start = pipe_index - 1
+    while source_start > 0 and tokens[source_start - 1] not in COMMAND_SEPARATORS:
+        source_start -= 1
+    return tokens[source_start:pipe_index]
+
+
+def resolve_sql_file(candidate: str, cwd: str | None = None) -> Path | None:
+    if not candidate or candidate in {"-", "/dev/stdin"}:
+        return None
+    if any(char in candidate for char in "\x00$`*?[]{}"):
+        return None
+
+    path = Path(os.path.expanduser(candidate))
+    if not path.is_absolute():
+        path = Path(cwd or os.getcwd()).expanduser() / path
+
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError:
+        return None
+    return resolved
+
+
+def read_sql_file(path: Path) -> str | None:
+    try:
+        file_stat = path.stat()
+        if not path.is_file() or file_stat.st_size > MAX_SQL_FILE_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
 
 
 def has_sql_client(tokens: list[str]) -> bool:

--- a/hooks/destructive-command-blocker/destructive-command-blocker.py
+++ b/hooks/destructive-command-blocker/destructive-command-blocker.py
@@ -61,6 +61,9 @@ SQL_OPTION_FLAGS = {
 SQL_KEYWORD_RE = re.compile(
     r"(?is)\b(drop\s+(?:table|database|schema)|truncate(?:\s+table)?|delete\s+from)\b"
 )
+SQL_STATEMENT_START_RE = re.compile(
+    r"(?is)^\s*(?:drop\s+(?:table|database|schema)|truncate(?:\s+table)?|delete\s+from)\b"
+)
 DROP_OR_TRUNCATE_RE = re.compile(
     r"(?is)\b(?:drop\s+(?:table|database|schema)|truncate(?:\s+table)?)\b"
 )
@@ -81,7 +84,7 @@ def main() -> int:
     if payload is None:
         return 0
 
-    tool_name = str(payload.get("tool_name", ""))
+    tool_name = str(payload.get("tool_name") or payload.get("tool") or "")
     if tool_name.lower() != "bash":
         return 0
 
@@ -293,6 +296,12 @@ def git_subcommand_index(args: list[str]) -> int | None:
 
 
 def detect_destructive_sql(command: str, tokens: list[str]) -> Detection | None:
+    direct_payload = direct_sql_payload(command)
+    if direct_payload:
+        detection = classify_sql(direct_payload)
+        if detection is not None:
+            return detection
+
     payloads = sql_payloads_from_clients(tokens)
     if has_sql_client(tokens):
         payloads.extend(token for token in tokens if looks_like_sql(token))
@@ -304,6 +313,14 @@ def detect_destructive_sql(command: str, tokens: list[str]) -> Detection | None:
             return detection
 
     return None
+
+
+def direct_sql_payload(command: str) -> str:
+    normalized = strip_sql_comments_and_literals(command)
+    for statement in split_sql_statements(normalized):
+        if SQL_STATEMENT_START_RE.search(statement):
+            return statement
+    return ""
 
 
 def sql_payloads_from_clients(tokens: list[str]) -> list[str]:
@@ -427,17 +444,31 @@ def base_name(token: str) -> str:
 def extract_project_path(payload: dict[str, Any]) -> str:
     tool_input = payload.get("tool_input")
     if isinstance(tool_input, dict):
-        for key in ("cwd", "project_path"):
+        for key in ("cwd", "workdir", "project_path", "project_dir", "workspace"):
             value = tool_input.get(key)
             if isinstance(value, str) and value:
                 return value
 
-    for key in ("cwd", "project_path"):
+    for key in ("cwd", "workdir", "project_path", "project_dir", "workspace"):
         value = payload.get(key)
         if isinstance(value, str) and value:
             return value
 
+    transcript_path = payload.get("transcript_path")
+    if isinstance(transcript_path, str) and transcript_path:
+        return parent_path_string(transcript_path)
+
     return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def parent_path_string(value: str) -> str:
+    expanded = os.path.expanduser(value).rstrip("/\\")
+    separator_index = max(expanded.rfind("/"), expanded.rfind("\\"))
+    if separator_index > 0:
+        return expanded[:separator_index]
+    if separator_index == 0:
+        return expanded[:1]
+    return str(Path(expanded).parent)
 
 
 def hook_dir() -> Path:

--- a/hooks/destructive-command-blocker/destructive-command-blocker.py
+++ b/hooks/destructive-command-blocker/destructive-command-blocker.py
@@ -6,39 +6,74 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 
 HOOK_EVENT_NAME = "PreToolUse"
 
-BLOCKERS: list[tuple[str, re.Pattern[str], str]] = [
-    (
-        "rm -rf",
-        re.compile(r"(?i)(?:^|[\s;&|()])rm\s+-(?=[A-Za-z-]*r)(?=[A-Za-z-]*f)[A-Za-z-]*\b"),
-        "Recursive forced deletion can remove large parts of the project or home directory.",
-    ),
-    (
-        "DROP TABLE",
-        re.compile(r"(?is)\bdrop\s+table\b"),
-        "DROP TABLE deletes an entire database table.",
-    ),
-    (
-        "TRUNCATE",
-        re.compile(r"(?is)\btruncate(?:\s+table)?\b"),
-        "TRUNCATE removes all rows from a table.",
-    ),
-    (
-        "git push --force",
-        re.compile(r"(?is)\bgit\s+push\b[^;&|\n]*?(?:--force\b|\s-f(?:\s|$))"),
-        "Force pushing can overwrite remote history.",
-    ),
-]
+COMMAND_SEPARATORS = {
+    ";",
+    "&",
+    "&&",
+    "|",
+    "|&",
+    "||",
+    "(",
+    ")",
+    "{",
+    "}",
+}
 
+SHELL_INTERPRETERS = {
+    "bash",
+    "dash",
+    "fish",
+    "ksh",
+    "sh",
+    "zsh",
+}
+
+SQL_CLIENTS = {
+    "duckdb",
+    "mariadb",
+    "mysql",
+    "psql",
+    "sqlite",
+    "sqlite3",
+    "sqlcmd",
+}
+
+SQL_OPTION_FLAGS = {
+    "-c",
+    "--command",
+    "-e",
+    "--execute",
+    "-q",
+    "-Q",
+    "/Q",
+}
+
+SQL_KEYWORD_RE = re.compile(
+    r"(?is)\b(drop\s+(?:table|database|schema)|truncate(?:\s+table)?|delete\s+from)\b"
+)
+DROP_OR_TRUNCATE_RE = re.compile(
+    r"(?is)\b(?:drop\s+(?:table|database|schema)|truncate(?:\s+table)?)\b"
+)
 DELETE_FROM_RE = re.compile(r"(?is)\bdelete\s+from\b")
 WHERE_RE = re.compile(r"(?is)\bwhere\b")
+
+
+@dataclass(frozen=True)
+class Detection:
+    rule: str
+    reason: str
+    evidence: str
+    severity: str = "high"
 
 
 def main() -> int:
@@ -54,14 +89,13 @@ def main() -> int:
     if not command:
         return 0
 
-    match = first_blocking_match(command)
-    if match is None:
+    detection = detect_destructive_command(command)
+    if detection is None:
         return 0
 
-    pattern_name, reason = match
     project_path = extract_project_path(payload)
-    log_blocked_attempt(command, project_path, pattern_name)
-    print(deny_response(pattern_name, reason))
+    log_blocked_attempt(command, project_path, detection)
+    print(deny_response(detection))
     return 0
 
 
@@ -82,31 +116,312 @@ def extract_command(payload: dict[str, Any]) -> str:
     return command if isinstance(command, str) else ""
 
 
-def first_blocking_match(command: str) -> tuple[str, str] | None:
-    for pattern_name, pattern, reason in BLOCKERS:
-        if pattern.search(command):
-            return pattern_name, reason
+def detect_destructive_command(command: str, depth: int = 0) -> Detection | None:
+    if depth > 3:
+        return None
 
-    if delete_from_without_where(command):
-        return (
-            "DELETE FROM without WHERE",
-            "DELETE FROM without a WHERE clause can delete every row in the table.",
-        )
+    tokens = shell_tokens(command)
+    if not tokens:
+        return fallback_text_detection(command)
+
+    for embedded_command in embedded_shell_commands(tokens):
+        detection = detect_destructive_command(embedded_command, depth + 1)
+        if detection is not None:
+            return detection
+
+    for detector in (
+        detect_rm_recursive_force,
+        detect_git_force_push,
+        detect_destructive_sql,
+    ):
+        detection = detector(command, tokens)
+        if detection is not None:
+            return detection
 
     return None
 
 
-def delete_from_without_where(command: str) -> bool:
-    for statement in command.split(";"):
-        match = DELETE_FROM_RE.search(statement)
-        if not match:
+def shell_tokens(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|(){}")
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    try:
+        return list(lexer)
+    except ValueError:
+        return []
+
+
+def fallback_text_detection(command: str) -> Detection | None:
+    lowered = command.lower()
+    if re.search(r"(?:^|[\s;&|()])rm\s+-(?=[a-z-]*r)(?=[a-z-]*f)[a-z-]*\b", lowered):
+        return Detection(
+            "rm -rf",
+            "Recursive forced deletion can remove large parts of the project or home directory.",
+            "raw command matched rm with recursive and force flags",
+            "critical",
+        )
+    if re.search(r"\bgit\s+push\b[^;&|\n]*?(?:--force(?:-with-lease)?\b|\s-f(?:\s|$)|\s\+\S+)", command, re.I):
+        return Detection(
+            "git push --force",
+            "Force pushing can overwrite remote history.",
+            "raw command matched git push with a force option or forced refspec",
+            "high",
+        )
+    if SQL_KEYWORD_RE.search(strip_sql_comments_and_literals(command)):
+        return classify_sql(command)
+    return None
+
+
+def embedded_shell_commands(tokens: list[str]) -> Iterable[str]:
+    for index, token in enumerate(tokens):
+        if base_name(token) not in SHELL_INTERPRETERS:
             continue
 
-        after_delete = statement[match.end() :]
-        if not WHERE_RE.search(after_delete):
-            return True
+        for option_index in range(index + 1, len(tokens)):
+            option = tokens[option_index]
+            if option in COMMAND_SEPARATORS:
+                break
+            if not option.startswith("-"):
+                break
+            if "c" in option.lstrip("-"):
+                command_index = option_index + 1
+                if command_index < len(tokens):
+                    yield tokens[command_index]
+                break
 
-    return False
+
+def detect_rm_recursive_force(command: str, tokens: list[str]) -> Detection | None:
+    del command
+    for index, token in enumerate(tokens):
+        if base_name(token) != "rm":
+            continue
+
+        recursive = False
+        force = False
+        operands: list[str] = []
+        end_of_options = False
+
+        for arg in command_args_after(tokens, index):
+            if arg == "--":
+                end_of_options = True
+                continue
+            if end_of_options:
+                operands.append(arg)
+                continue
+            if arg.startswith("--"):
+                recursive = recursive or arg in {"--recursive", "--dir"}
+                force = force or arg == "--force"
+                continue
+            if arg.startswith("-") and arg != "-":
+                flags = arg.lstrip("-")
+                recursive = recursive or "r" in flags.lower() or "R" in flags
+                force = force or "f" in flags
+                continue
+            operands.append(arg)
+
+        if recursive and force:
+            target = " ".join(operands) if operands else "(no explicit target)"
+            return Detection(
+                "rm -rf",
+                "Recursive forced deletion can remove large parts of the project or home directory.",
+                f"rm was invoked with recursive and force flags against {target}",
+                "critical",
+            )
+
+    return None
+
+
+def detect_git_force_push(command: str, tokens: list[str]) -> Detection | None:
+    del command
+    for index, token in enumerate(tokens):
+        if base_name(token) != "git":
+            continue
+
+        args = list(command_args_after(tokens, index))
+        subcommand_index = git_subcommand_index(args)
+        if subcommand_index is None or args[subcommand_index] != "push":
+            continue
+
+        push_args = args[subcommand_index + 1 :]
+        for arg in push_args:
+            if arg in {"--force", "-f"} or arg.startswith("--force-with-lease"):
+                return Detection(
+                    "git push --force",
+                    "Force pushing can overwrite remote history.",
+                    f"git push used force option {arg}",
+                    "high",
+                )
+            if arg.startswith("+") and len(arg) > 1:
+                return Detection(
+                    "git push forced refspec",
+                    "A leading plus in a git push refspec forces the remote update.",
+                    f"git push used forced refspec {arg}",
+                    "high",
+                )
+
+    return None
+
+
+def git_subcommand_index(args: list[str]) -> int | None:
+    index = 0
+    options_with_values = {
+        "-C",
+        "-c",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--config-env",
+        "--exec-path",
+    }
+
+    while index < len(args):
+        arg = args[index]
+        if arg == "--":
+            return index + 1 if index + 1 < len(args) else None
+        if arg in options_with_values:
+            index += 2
+            continue
+        if any(arg.startswith(option + "=") for option in options_with_values if option.startswith("--")):
+            index += 1
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return index
+
+    return None
+
+
+def detect_destructive_sql(command: str, tokens: list[str]) -> Detection | None:
+    payloads = sql_payloads_from_clients(tokens)
+    if has_sql_client(tokens):
+        payloads.extend(token for token in tokens if looks_like_sql(token))
+        payloads.append(command)
+
+    for payload in payloads:
+        detection = classify_sql(payload)
+        if detection is not None:
+            return detection
+
+    return None
+
+
+def sql_payloads_from_clients(tokens: list[str]) -> list[str]:
+    payloads: list[str] = []
+    for index, token in enumerate(tokens):
+        if base_name(token) not in SQL_CLIENTS:
+            continue
+
+        args = list(command_args_after(tokens, index))
+        for arg_index, arg in enumerate(args):
+            normalized_arg = arg.lower()
+            if normalized_arg in {flag.lower() for flag in SQL_OPTION_FLAGS} and arg_index + 1 < len(args):
+                payloads.append(args[arg_index + 1])
+            elif any(arg.lower().startswith(flag.lower() + "=") for flag in SQL_OPTION_FLAGS if flag.startswith("--")):
+                payloads.append(arg.split("=", 1)[1])
+            elif base_name(token) in {"sqlite", "sqlite3", "duckdb"} and looks_like_sql(arg):
+                payloads.append(arg)
+
+    return payloads
+
+
+def has_sql_client(tokens: list[str]) -> bool:
+    return any(base_name(token) in SQL_CLIENTS for token in tokens)
+
+
+def classify_sql(sql: str) -> Detection | None:
+    normalized = strip_sql_comments_and_literals(sql)
+    drop_or_truncate = DROP_OR_TRUNCATE_RE.search(normalized)
+    if drop_or_truncate:
+        matched_keyword = " ".join(drop_or_truncate.group(0).upper().split())
+        rule = "TRUNCATE" if matched_keyword.startswith("TRUNCATE") else matched_keyword
+        return Detection(
+            rule,
+            f"{rule} can irreversibly remove database objects or table contents.",
+            drop_or_truncate.group(0),
+            "critical",
+        )
+
+    for statement in split_sql_statements(normalized):
+        delete_match = DELETE_FROM_RE.search(statement)
+        if not delete_match:
+            continue
+        if not WHERE_RE.search(statement[delete_match.end() :]):
+            return Detection(
+                "DELETE FROM without WHERE",
+                "DELETE FROM without a WHERE clause can delete every row in the table.",
+                statement.strip(),
+                "critical",
+            )
+
+    return None
+
+
+def strip_sql_comments_and_literals(sql: str) -> str:
+    result: list[str] = []
+    index = 0
+    quote: str | None = None
+    while index < len(sql):
+        char = sql[index]
+        next_char = sql[index + 1] if index + 1 < len(sql) else ""
+
+        if quote:
+            if char == quote:
+                if index + 1 < len(sql) and sql[index + 1] == quote:
+                    index += 2
+                    continue
+                quote = None
+            result.append(" ")
+            index += 1
+            continue
+
+        if char in {"'", '"'}:
+            quote = char
+            result.append(" ")
+            index += 1
+            continue
+
+        if char == "-" and next_char == "-":
+            while index < len(sql) and sql[index] not in "\r\n":
+                result.append(" ")
+                index += 1
+            continue
+
+        if char == "/" and next_char == "*":
+            result.extend("  ")
+            index += 2
+            while index + 1 < len(sql) and not (sql[index] == "*" and sql[index + 1] == "/"):
+                result.append(" ")
+                index += 1
+            if index + 1 < len(sql):
+                result.extend("  ")
+                index += 2
+            continue
+
+        result.append(char)
+        index += 1
+
+    return "".join(result)
+
+
+def split_sql_statements(sql: str) -> list[str]:
+    return [statement for statement in sql.split(";") if statement.strip()]
+
+
+def looks_like_sql(value: str) -> bool:
+    return bool(SQL_KEYWORD_RE.search(value))
+
+
+def command_args_after(tokens: list[str], command_index: int) -> Iterable[str]:
+    for token in tokens[command_index + 1 :]:
+        if token in COMMAND_SEPARATORS:
+            break
+        yield token
+
+
+def base_name(token: str) -> str:
+    normalized = token.replace("\\", "/").rstrip("/")
+    return normalized.rsplit("/", 1)[-1].lower()
 
 
 def extract_project_path(payload: dict[str, Any]) -> str:
@@ -132,13 +447,17 @@ def hook_dir() -> Path:
     return Path.home() / ".claude" / "hooks"
 
 
-def log_blocked_attempt(command: str, project_path: str, pattern_name: str) -> None:
+def log_blocked_attempt(command: str, project_path: str, detection: Detection) -> None:
     log_path = hook_dir() / "blocked.log"
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         event = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "pattern": pattern_name,
+            "severity": detection.severity,
+            "rule": detection.rule,
+            "pattern": detection.rule,
+            "reason": detection.reason,
+            "evidence": detection.evidence,
             "command": command,
             "project_path": project_path,
         }
@@ -149,10 +468,11 @@ def log_blocked_attempt(command: str, project_path: str, pattern_name: str) -> N
         pass
 
 
-def deny_response(pattern_name: str, reason: str) -> str:
+def deny_response(detection: Detection) -> str:
     message = (
-        f"Blocked potentially destructive Bash command ({pattern_name}). "
-        f"{reason} Use a narrower, reversible, or explicitly reviewed command instead."
+        f"Blocked potentially destructive Bash command ({detection.rule}). "
+        f"{detection.reason} Evidence: {detection.evidence}. "
+        "Use a narrower, reversible, or explicitly reviewed command instead."
     )
     response = {
         "hookSpecificOutput": {

--- a/hooks/destructive-command-blocker/install.py
+++ b/hooks/destructive-command-blocker/install.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Install the destructive command blocker hook for Claude Code."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SOURCE_HOOK = SCRIPT_DIR / "destructive-command-blocker.py"
+
+
+def main() -> int:
+    claude_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")).expanduser()
+    hook_dir = claude_dir / "hooks"
+    settings_file = claude_dir / "settings.json"
+    hook_file = hook_dir / "destructive-command-blocker.py"
+
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE_HOOK, hook_file)
+    make_executable(hook_file)
+
+    settings = read_settings(settings_file)
+    command = hook_command(hook_file)
+    add_hook(settings, command)
+    settings_file.parent.mkdir(parents=True, exist_ok=True)
+    settings_file.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Installed destructive command blocker at {hook_file}")
+    print(f"Updated Claude Code settings at {settings_file}")
+    return 0
+
+
+def make_executable(path: Path) -> None:
+    try:
+        current_mode = path.stat().st_mode
+        path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError:
+        pass
+
+
+def read_settings(settings_file: Path) -> dict[str, object]:
+    if not settings_file.exists():
+        return {}
+
+    try:
+        data = json.loads(settings_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {settings_file}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SystemExit(f"Expected object JSON in {settings_file}")
+    return data
+
+
+def hook_command(hook_file: Path) -> str:
+    if os.name == "nt":
+        return f'"{sys.executable}" "{hook_file}"'
+    return str(hook_file)
+
+
+def add_hook(settings: dict[str, object], command: str) -> None:
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise SystemExit("settings.hooks must be an object")
+
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    if not isinstance(pre_tool_use, list):
+        raise SystemExit("settings.hooks.PreToolUse must be an array")
+
+    for entry in pre_tool_use:
+        if not isinstance(entry, dict):
+            continue
+        entry_hooks = entry.get("hooks")
+        if not isinstance(entry_hooks, list):
+            continue
+        for hook in entry_hooks:
+            if isinstance(hook, dict) and "destructive-command-blocker.py" in str(hook.get("command", "")):
+                hook["type"] = "command"
+                hook["command"] = command
+                return
+
+    pre_tool_use.append(
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": command}],
+        }
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-blocker/install.py
+++ b/hooks/destructive-command-blocker/install.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import stat
 import sys
@@ -61,7 +62,7 @@ def read_settings(settings_file: Path) -> dict[str, object]:
 def hook_command(hook_file: Path) -> str:
     if os.name == "nt":
         return f'"{sys.executable}" "{hook_file}"'
-    return str(hook_file)
+    return shlex.quote(str(hook_file))
 
 
 def add_hook(settings: dict[str, object], command: str) -> None:

--- a/hooks/destructive-command-blocker/install.sh
+++ b/hooks/destructive-command-blocker/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if command -v python3 >/dev/null 2>&1; then
+  python3 "$SCRIPT_DIR/install.py"
+else
+  python "$SCRIPT_DIR/install.py"
+fi

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -11,26 +11,34 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("destructive-command-blocker.py")
+INSTALLER = Path(__file__).with_name("install.py")
 
 
 class DestructiveCommandBlockerTests(unittest.TestCase):
-    def run_hook(self, command: str, hooks_dir: Path) -> subprocess.CompletedProcess[str]:
+    def run_hook(
+        self,
+        command: str,
+        hooks_dir: Path,
+        *,
+        tool_name: str = "Bash",
+        raw_input: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         payload = {
-            "tool_name": "Bash",
+            "tool_name": tool_name,
             "tool_input": {"command": command, "cwd": "/tmp/example-project"},
         }
         env = os.environ.copy()
         env["CLAUDE_HOOKS_DIR"] = str(hooks_dir)
         return subprocess.run(
             [sys.executable, str(SCRIPT)],
-            input=json.dumps(payload),
+            input=raw_input if raw_input is not None else json.dumps(payload),
             text=True,
             capture_output=True,
             env=env,
             check=False,
         )
 
-    def assert_blocked(self, command: str, expected_pattern: str) -> None:
+    def assert_blocked(self, command: str, expected_rule: str) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks_dir = Path(tmpdir)
             result = self.run_hook(command, hooks_dir)
@@ -40,45 +48,136 @@ class DestructiveCommandBlockerTests(unittest.TestCase):
             hook_output = response["hookSpecificOutput"]
             self.assertEqual(hook_output["hookEventName"], "PreToolUse")
             self.assertEqual(hook_output["permissionDecision"], "deny")
-            self.assertIn(expected_pattern, hook_output["permissionDecisionReason"])
+            self.assertIn(expected_rule, hook_output["permissionDecisionReason"])
 
             log_path = hooks_dir / "blocked.log"
             self.assertTrue(log_path.exists())
             log_event = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(log_event["command"], command)
             self.assertEqual(log_event["project_path"], "/tmp/example-project")
-            self.assertEqual(log_event["pattern"], expected_pattern)
+            self.assertEqual(log_event["rule"], expected_rule)
+            self.assertEqual(log_event["pattern"], expected_rule)
+            self.assertIn("reason", log_event)
+            self.assertIn("evidence", log_event)
+            self.assertIn("severity", log_event)
 
-    def test_blocks_rm_rf(self) -> None:
-        self.assert_blocked("rm -rf build", "rm -rf")
-
-    def test_blocks_drop_table(self) -> None:
-        self.assert_blocked('psql -c "DROP TABLE users"', "DROP TABLE")
-
-    def test_blocks_force_push(self) -> None:
-        self.assert_blocked("git push origin main --force", "git push --force")
-
-    def test_blocks_truncate(self) -> None:
-        self.assert_blocked('mysql -e "TRUNCATE TABLE sessions"', "TRUNCATE")
-
-    def test_blocks_delete_without_where(self) -> None:
-        self.assert_blocked('psql -c "DELETE FROM users"', "DELETE FROM without WHERE")
-
-    def test_allows_normal_bash(self) -> None:
+    def assert_allowed(self, command: str, *, tool_name: str = "Bash", raw_input: str | None = None) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks_dir = Path(tmpdir)
-            result = self.run_hook("git status --short", hooks_dir)
+            result = self.run_hook(command, hooks_dir, tool_name=tool_name, raw_input=raw_input)
             self.assertEqual(result.returncode, 0)
             self.assertEqual(result.stdout, "")
             self.assertFalse((hooks_dir / "blocked.log").exists())
 
-    def test_allows_delete_with_where(self) -> None:
+    def test_blocks_required_acceptance_patterns(self) -> None:
+        cases = [
+            ("rm -rf build", "rm -rf"),
+            ('psql -c "DROP TABLE users"', "DROP TABLE"),
+            ("git push origin main --force", "git push --force"),
+            ('mysql -e "TRUNCATE TABLE sessions"', "TRUNCATE"),
+            ('psql -c "DELETE FROM users"', "DELETE FROM without WHERE"),
+        ]
+        for command, expected_rule in cases:
+            with self.subTest(command=command):
+                self.assert_blocked(command, expected_rule)
+
+    def test_blocks_rm_variants_and_wrappers(self) -> None:
+        cases = [
+            "rm -fr build",
+            "rm -Rf ./dist",
+            "sudo command rm --recursive --force ./dist",
+            'bash -lc "rm -rf build"',
+            "find . -exec rm -rf {} +",
+        ]
+        for command in cases:
+            with self.subTest(command=command):
+                self.assert_blocked(command, "rm -rf")
+
+    def test_blocks_git_force_push_variants(self) -> None:
+        cases = [
+            "git -C repo push origin main --force-with-lease",
+            "git push origin +main",
+            "sudo git push -f origin HEAD",
+        ]
+        for command in cases:
+            with self.subTest(command=command):
+                expected = "git push forced refspec" if "+main" in command else "git push --force"
+                self.assert_blocked(command, expected)
+
+    def test_blocks_sql_client_payloads(self) -> None:
+        cases = [
+            ('echo "DROP TABLE users" | psql mydb', "DROP TABLE"),
+            ('sqlite3 app.db "DELETE FROM users"', "DELETE FROM without WHERE"),
+            ('mysql --execute="DROP DATABASE prod"', "DROP DATABASE"),
+            ('sqlcmd -Q "TRUNCATE TABLE dbo.sessions"', "TRUNCATE"),
+            ('docker exec db psql -c "DELETE FROM audit_log"', "DELETE FROM without WHERE"),
+        ]
+        for command, expected_rule in cases:
+            with self.subTest(command=command):
+                self.assert_blocked(command, expected_rule)
+
+    def test_allows_safe_commands_and_false_positive_strings(self) -> None:
+        cases = [
+            "git status --short",
+            "rm -f build.log",
+            "rm -r old-cache",
+            'echo "rm -rf build"',
+            'printf "git push --force"',
+            'grep -R "DROP TABLE" docs',
+            'psql -c "DELETE FROM users WHERE id = 1"',
+            "psql -c \"SELECT 'DELETE FROM users' AS example\"",
+        ]
+        for command in cases:
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+    def test_ignores_non_bash_tool_and_invalid_input(self) -> None:
+        self.assert_allowed("rm -rf build", tool_name="Read")
+        self.assert_allowed("", raw_input="{not json")
+
+    def test_installer_is_idempotent_and_preserves_existing_hooks(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            hooks_dir = Path(tmpdir)
-            result = self.run_hook('psql -c "DELETE FROM users WHERE id = 1"', hooks_dir)
-            self.assertEqual(result.returncode, 0)
-            self.assertEqual(result.stdout, "")
-            self.assertFalse((hooks_dir / "blocked.log").exists())
+            claude_dir = Path(tmpdir)
+            settings_path = claude_dir / "settings.json"
+            settings_path.write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "PreToolUse": [
+                                {
+                                    "matcher": "Edit",
+                                    "hooks": [{"type": "command", "command": "echo edit"}],
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+
+            for _ in range(2):
+                result = subprocess.run(
+                    [sys.executable, str(INSTALLER)],
+                    text=True,
+                    capture_output=True,
+                    env=env,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            pre_tool_use = settings["hooks"]["PreToolUse"]
+            blocker_entries = [
+                entry
+                for entry in pre_tool_use
+                for hook in entry.get("hooks", [])
+                if "destructive-command-blocker.py" in hook.get("command", "")
+            ]
+            self.assertEqual(len(blocker_entries), 1)
+            self.assertTrue((claude_dir / "hooks" / "destructive-command-blocker.py").exists())
+            self.assertTrue(any(entry.get("matcher") == "Edit" for entry in pre_tool_use))
 
 
 if __name__ == "__main__":

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -107,10 +107,13 @@ class DestructiveCommandBlockerTests(unittest.TestCase):
     def test_blocks_sql_client_payloads(self) -> None:
         cases = [
             ('echo "DROP TABLE users" | psql mydb', "DROP TABLE"),
+            ("echo DROP TABLE users | psql mydb", "DROP TABLE"),
+            ('printf "DROP TABLE users;" | psql mydb', "DROP TABLE"),
             ('sqlite3 app.db "DELETE FROM users"', "DELETE FROM without WHERE"),
             ('mysql --execute="DROP DATABASE prod"', "DROP DATABASE"),
             ('sqlcmd -Q "TRUNCATE TABLE dbo.sessions"', "TRUNCATE"),
             ('docker exec db psql -c "DELETE FROM audit_log"', "DELETE FROM without WHERE"),
+            ("psql <<SQL\nDROP TABLE users;\nSQL", "DROP TABLE"),
         ]
         for command, expected_rule in cases:
             with self.subTest(command=command):
@@ -127,6 +130,56 @@ class DestructiveCommandBlockerTests(unittest.TestCase):
         for command, expected_rule in cases:
             with self.subTest(command=command):
                 self.assert_blocked(command, expected_rule)
+
+    def test_blocks_destructive_sql_from_input_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workdir = Path(tmpdir) / "project"
+            hooks_dir = Path(tmpdir) / "hooks"
+            workdir.mkdir()
+            hooks_dir.mkdir()
+
+            files = {
+                "drop.sql": "DROP TABLE users;\n",
+                "drop_schema.sql": "DROP SCHEMA private;\n",
+                "truncate.sql": "TRUNCATE TABLE audit_log;\n",
+                "delete.sql": "DELETE FROM sessions;\n",
+                "prod": "DROP TABLE production_users;\n",
+                "DROP TABLE users.sql": "DELETE FROM sessions WHERE expires_at < now();\n",
+                "safe.sql": "DELETE FROM sessions WHERE expires_at < now();\n",
+            }
+            for filename, contents in files.items():
+                (workdir / filename).write_text(contents, encoding="utf-8")
+
+            blocked_cases = [
+                ("psql -f drop.sql", "DROP TABLE"),
+                ("psql --file=drop_schema.sql", "DROP SCHEMA"),
+                ("sqlcmd -i truncate.sql", "TRUNCATE"),
+                ("mysql < delete.sql", "DELETE FROM without WHERE"),
+                ("cat drop.sql | psql mydb", "DROP TABLE"),
+            ]
+            for command, expected_rule in blocked_cases:
+                with self.subTest(command=command):
+                    payload = {
+                        "tool_name": "Bash",
+                        "tool_input": {"command": command, "cwd": str(workdir)},
+                    }
+                    result = self.run_hook(command, hooks_dir, raw_input=json.dumps(payload))
+                    self.assertEqual(result.returncode, 0)
+                    response = json.loads(result.stdout)
+                    reason = response["hookSpecificOutput"]["permissionDecisionReason"]
+                    self.assertIn(expected_rule, reason)
+                    self.assertIn("SQL input file", reason)
+
+            safe_payload = {
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": 'psql -f safe.sql && mysql -f prod && psql -f "DROP TABLE users.sql"',
+                    "cwd": str(workdir),
+                },
+            }
+            safe_result = self.run_hook("", hooks_dir, raw_input=json.dumps(safe_payload))
+            self.assertEqual(safe_result.returncode, 0)
+            self.assertEqual(safe_result.stdout, "")
 
     def test_allows_safe_commands_and_false_positive_strings(self) -> None:
         cases = [

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -116,6 +116,18 @@ class DestructiveCommandBlockerTests(unittest.TestCase):
             with self.subTest(command=command):
                 self.assert_blocked(command, expected_rule)
 
+    def test_blocks_direct_destructive_sql_statements(self) -> None:
+        cases = [
+            ("DROP TABLE users", "DROP TABLE"),
+            ("TRUNCATE audit_log", "TRUNCATE"),
+            ("DELETE FROM sessions", "DELETE FROM without WHERE"),
+            ("-- maintenance\nDROP TABLE stale_sessions", "DROP TABLE"),
+            ("echo done; DELETE FROM audit_log", "DELETE FROM without WHERE"),
+        ]
+        for command, expected_rule in cases:
+            with self.subTest(command=command):
+                self.assert_blocked(command, expected_rule)
+
     def test_allows_safe_commands_and_false_positive_strings(self) -> None:
         cases = [
             "git status --short",
@@ -124,6 +136,8 @@ class DestructiveCommandBlockerTests(unittest.TestCase):
             'echo "rm -rf build"',
             'printf "git push --force"',
             'grep -R "DROP TABLE" docs',
+            "printf 'DELETE FROM users' >> examples.sql",
+            "DELETE FROM users WHERE id = 1",
             'psql -c "DELETE FROM users WHERE id = 1"',
             "psql -c \"SELECT 'DELETE FROM users' AS example\"",
         ]
@@ -134,6 +148,20 @@ class DestructiveCommandBlockerTests(unittest.TestCase):
     def test_ignores_non_bash_tool_and_invalid_input(self) -> None:
         self.assert_allowed("rm -rf build", tool_name="Read")
         self.assert_allowed("", raw_input="{not json")
+
+    def test_project_path_fallback_uses_transcript_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_dir = Path(tmpdir)
+            payload = {
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf build"},
+                "transcript_path": "/tmp/example-project/.claude/session.jsonl",
+            }
+            result = self.run_hook("", hooks_dir, raw_input=json.dumps(payload))
+
+            self.assertEqual(result.returncode, 0)
+            log_event = json.loads((hooks_dir / "blocked.log").read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(log_event["project_path"], "/tmp/example-project/.claude")
 
     def test_installer_is_idempotent_and_preserves_existing_hooks(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("destructive-command-blocker.py")
+
+
+class DestructiveCommandBlockerTests(unittest.TestCase):
+    def run_hook(self, command: str, hooks_dir: Path) -> subprocess.CompletedProcess[str]:
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command, "cwd": "/tmp/example-project"},
+        }
+        env = os.environ.copy()
+        env["CLAUDE_HOOKS_DIR"] = str(hooks_dir)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+    def assert_blocked(self, command: str, expected_pattern: str) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_dir = Path(tmpdir)
+            result = self.run_hook(command, hooks_dir)
+
+            self.assertEqual(result.returncode, 0)
+            response = json.loads(result.stdout)
+            hook_output = response["hookSpecificOutput"]
+            self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+            self.assertEqual(hook_output["permissionDecision"], "deny")
+            self.assertIn(expected_pattern, hook_output["permissionDecisionReason"])
+
+            log_path = hooks_dir / "blocked.log"
+            self.assertTrue(log_path.exists())
+            log_event = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(log_event["command"], command)
+            self.assertEqual(log_event["project_path"], "/tmp/example-project")
+            self.assertEqual(log_event["pattern"], expected_pattern)
+
+    def test_blocks_rm_rf(self) -> None:
+        self.assert_blocked("rm -rf build", "rm -rf")
+
+    def test_blocks_drop_table(self) -> None:
+        self.assert_blocked('psql -c "DROP TABLE users"', "DROP TABLE")
+
+    def test_blocks_force_push(self) -> None:
+        self.assert_blocked("git push origin main --force", "git push --force")
+
+    def test_blocks_truncate(self) -> None:
+        self.assert_blocked('mysql -e "TRUNCATE TABLE sessions"', "TRUNCATE")
+
+    def test_blocks_delete_without_where(self) -> None:
+        self.assert_blocked('psql -c "DELETE FROM users"', "DELETE FROM without WHERE")
+
+    def test_allows_normal_bash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_dir = Path(tmpdir)
+            result = self.run_hook("git status --short", hooks_dir)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((hooks_dir / "blocked.log").exists())
+
+    def test_allows_delete_with_where(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_dir = Path(tmpdir)
+            result = self.run_hook('psql -c "DELETE FROM users WHERE id = 1"', hooks_dir)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((hooks_dir / "blocked.log").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a Claude Code PreToolUse Bash hook that returns protocol-compliant `permissionDecision: "deny"` JSON before destructive commands run.
- Replace simple text matching with shell-token-aware detection using `shlex`, including nested `bash -c` / `sh -c` payloads and wrapper commands such as `sudo`, `command`, `find -exec`, `docker exec`, and database clients in pipelines.
- Block required patterns plus practical variants: `rm -fr` / `rm --recursive --force`, `git push -f`, `--force-with-lease`, forced refspecs like `+main`, direct destructive SQL statements, `DROP DATABASE` / `DROP SCHEMA`, and SQL delivered through `psql`, `mysql`, `sqlite3`, `duckdb`, `sqlcmd`, etc.
- Inspect explicit local SQL input files for recognized database clients, including `psql -f file.sql`, `psql --file=file.sql`, `sqlcmd -i file.sql`, `mysql < file.sql`, and `cat file.sql | psql`, with a 1 MiB file-size cap to avoid slowing normal Bash usage.
- Reduce false positives by allowing documentation/search strings like `echo "rm -rf build"`, `grep -R "DROP TABLE" docs`, `printf "DELETE FROM users" >> examples.sql`, SQL string literals such as `SELECT 'DELETE FROM users'`, safe SQL files, and dangerous-looking filenames that do not contain destructive SQL.
- Add cross-platform installer behavior, idempotent settings updates, structured JSONL audit logging, README coverage, and `.gitignore` for Python cache output.

## Verification
- `python -B -m unittest -v hooks/destructive-command-blocker/test_destructive_command_blocker.py`
  - required acceptance patterns
  - rm variants and wrappers
  - git force-push variants and forced refspecs
  - direct destructive SQL statements
  - SQL clients, piped stdin SQL, heredoc SQL, SQL input files, and file redirections
  - false-positive strings and dangerous-looking safe filenames
  - non-Bash payloads and invalid input
  - transcript-path project fallback
  - installer idempotency and preservation of existing hooks
- `python -B -m py_compile hooks/destructive-command-blocker/destructive-command-blocker.py hooks/destructive-command-blocker/test_destructive_command_blocker.py hooks/destructive-command-blocker/install.py`
- `git diff --check`
- Targeted hardening check with a temporary `CLAUDE_HOOKS_DIR` confirmed destructive SQL file denial, stdin redirection denial, `cat file.sql | psql` denial, heredoc denial, safe SQL file pass-through, dangerous-looking filename pass-through, and `mysql -f` not being misread as a file-input flag.

Closes #3
