### PR TITLE
Add generate changelog skill and CLI

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,9 @@
+Generate a structured changelog from the current repository's commit history.
+
+Run:
+
+```bash
+bash changelog.sh --output CHANGELOG.md
+```
+
+Then summarize the generated `CHANGELOG.md` and call out any commits that were difficult to categorize.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/skills/generate-changelog/generate_changelog.py" "$@"

--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,39 @@
+# Generate Changelog
+
+Create a structured `CHANGELOG.md` from commits since the most recent git tag.
+
+## Setup
+
+1. Copy `changelog.sh` and `skills/generate-changelog/` into the repository you want to document.
+2. Run `bash changelog.sh --output CHANGELOG.md`.
+3. Review the categories, then commit the generated `CHANGELOG.md`.
+
+## Usage
+
+Local git repository:
+
+```bash
+bash changelog.sh --output CHANGELOG.md
+```
+
+Public GitHub repository, useful for testing or CI without a clone:
+
+```bash
+bash changelog.sh --repo owner/name --dry-run
+```
+
+Useful options:
+
+- `--since-tag v1.2.3` uses a specific tag instead of auto-detecting the latest tag.
+- `--max-commits 50` limits the number of commits included.
+- `--dry-run` prints the changelog instead of writing a file.
+- `GITHUB_TOKEN` raises the GitHub API rate limit for `--repo` mode.
+
+## Categorization
+
+The generator maps commits into Keep a Changelog-style sections:
+
+- `Added`: `feat:`, `feature:`, and add/create/introduce subjects.
+- `Fixed`: `fix:`, `bugfix:`, `security:`, and repair/prevent/correct subjects.
+- `Removed`: `remove:`, `delete:`, `drop:`, and deprecate subjects.
+- `Changed`: refactors, chores, docs, tests, and anything that is not clearly one of the above.

--- a/skills/generate-changelog/generate_changelog.py
+++ b/skills/generate-changelog/generate_changelog.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Generate a structured changelog from local git or GitHub commits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Iterable
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    body: str = ""
+    author: str = ""
+    url: str = ""
+
+
+def run_git(args: list[str]) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit("git was not found. Use --repo owner/name for GitHub API mode.") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or exc.stdout.strip() or "git command failed"
+        raise SystemExit(detail) from exc
+    return completed.stdout.strip()
+
+
+def latest_local_tag() -> str | None:
+    try:
+        return run_git(["describe", "--tags", "--abbrev=0"])
+    except SystemExit:
+        return None
+
+
+def local_commits(since_tag: str | None, max_commits: int) -> list[Commit]:
+    revision_range = f"{since_tag}..HEAD" if since_tag else "HEAD"
+    fmt = "%H%x1f%an%x1f%s%x1f%b%x1e"
+    output = run_git(["log", "--no-merges", revision_range, f"--pretty=format:{fmt}"])
+    commits: list[Commit] = []
+    for raw in output.split("\x1e"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        parts = raw.split("\x1f", 3)
+        if len(parts) != 4:
+            continue
+        sha, author, subject, body = parts
+        commits.append(Commit(sha=sha, author=author, subject=subject, body=body))
+    return commits[:max_commits]
+
+
+def parse_github_repo(value: str) -> tuple[str, str]:
+    if re.fullmatch(r"[\w.-]+/[\w.-]+", value):
+        owner, repo = value.split("/", 1)
+        return owner, repo.removesuffix(".git")
+
+    match = re.search(r"github\.com[:/]([^/\s]+)/([^/\s#?]+)", value)
+    if not match:
+        raise SystemExit("--repo must be owner/name or a GitHub repository URL")
+    owner, repo = match.groups()
+    return owner, repo.removesuffix(".git")
+
+
+def github_json(path: str, token: str | None = None) -> object:
+    url = f"https://api.github.com{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "claude-builders-generate-changelog",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    if os.name == "nt":
+        return powershell_json(url, headers)
+
+    return urllib_json(url, headers)
+
+
+def powershell_json(url: str, headers: dict[str, str]) -> object:
+    script = r"""
+$ErrorActionPreference = 'Stop'
+$payload = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$requestHeaders = @{}
+$payload.headers.PSObject.Properties | ForEach-Object {
+  $requestHeaders[$_.Name] = [string]$_.Value
+}
+Invoke-RestMethod -Uri $payload.url -Headers $requestHeaders -TimeoutSec 30 | ConvertTo-Json -Depth 100
+"""
+    completed = subprocess.run(
+        ["powershell", "-NoProfile", "-Command", script],
+        input=json.dumps({"url": url, "headers": headers}),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"GitHub API request failed: {detail}")
+    return json.loads(completed.stdout)
+
+
+def urllib_json(url: str, headers: dict[str, str]) -> object:
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        message = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"GitHub API request failed ({exc.code}): {message}") from exc
+
+
+def latest_github_tag(owner: str, repo: str, token: str | None) -> str | None:
+    payload = github_json(f"/repos/{owner}/{repo}/tags?per_page=1", token)
+    if isinstance(payload, list) and payload:
+        name = payload[0].get("name")
+        return str(name) if name else None
+    return None
+
+
+def github_commits(owner: str, repo: str, since_tag: str | None, max_commits: int, token: str | None) -> list[Commit]:
+    if since_tag:
+        encoded_tag = quote(since_tag, safe="")
+        payload = github_json(f"/repos/{owner}/{repo}/compare/{encoded_tag}...HEAD", token)
+        raw_commits = payload.get("commits", []) if isinstance(payload, dict) else []
+    else:
+        payload = github_json(f"/repos/{owner}/{repo}/commits?per_page={min(max_commits, 100)}", token)
+        raw_commits = payload if isinstance(payload, list) else []
+
+    commits: list[Commit] = []
+    for item in reversed(raw_commits):
+        commit = item.get("commit", {})
+        message = str(commit.get("message", "")).strip()
+        subject, _, body = message.partition("\n")
+        if subject.lower().startswith("merge "):
+            continue
+        author = commit.get("author", {}).get("name", "")
+        commits.append(
+            Commit(
+                sha=str(item.get("sha", "")),
+                author=str(author),
+                subject=subject.strip(),
+                body=body.strip(),
+                url=str(item.get("html_url", "")),
+            )
+        )
+    return commits[:max_commits]
+
+
+def classify_commit(commit: Commit) -> str:
+    text = f"{commit.subject}\n{commit.body}".lower()
+    subject = commit.subject.lower().strip()
+
+    if re.match(r"^(feat|feature)(\(.+\))?!?:", subject):
+        return "Added"
+    if re.match(r"^(fix|bugfix|security)(\(.+\))?!?:", subject):
+        return "Fixed"
+    if re.match(r"^(remove|removed|delete|drop|deprecate)(\(.+\))?!?:", subject):
+        return "Removed"
+
+    if re.search(r"\b(add|adds|added|create|creates|created|introduce|introduces)\b", text):
+        return "Added"
+    if re.search(r"\b(fix|fixes|fixed|repair|repairs|prevent|prevents|correct|corrects)\b", text):
+        return "Fixed"
+    if re.search(r"\b(remove|removes|removed|delete|deletes|deleted|drop|drops|dropped|deprecate|deprecated)\b", text):
+        return "Removed"
+    return "Changed"
+
+
+def format_commit(commit: Commit) -> str:
+    subject = commit.subject.rstrip(".")
+    short_sha = commit.sha[:7]
+    suffix = f" ({short_sha})" if short_sha else ""
+    if commit.url and short_sha:
+        suffix = f" ([{short_sha}]({commit.url}))"
+    if commit.author:
+        suffix += f" by {commit.author}"
+    return f"- {subject}{suffix}"
+
+
+def render_changelog(commits: Iterable[Commit], since_tag: str | None, source: str) -> str:
+    grouped: dict[str, list[str]] = {category: [] for category in CATEGORIES}
+    for commit in commits:
+        grouped[classify_commit(commit)].append(format_commit(commit))
+
+    today = date.today().isoformat()
+    base = f" since `{since_tag}`" if since_tag else ""
+    lines = [
+        "# Changelog",
+        "",
+        f"## Unreleased - {today}",
+        "",
+        f"Generated from `{source}`{base}.",
+        "",
+    ]
+
+    if not any(grouped.values()):
+        lines.extend(["No commits found for this range.", ""])
+        return "\n".join(lines)
+
+    for category in CATEGORIES:
+        if not grouped[category]:
+            continue
+        lines.extend([f"### {category}", "", *grouped[category], ""])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_changelog(args: argparse.Namespace) -> str:
+    if args.repo:
+        owner, repo = parse_github_repo(args.repo)
+        since_tag = args.since_tag or latest_github_tag(owner, repo, args.token)
+        commits = github_commits(owner, repo, since_tag, args.max_commits, args.token)
+        return render_changelog(commits, since_tag, f"github.com/{owner}/{repo}")
+
+    since_tag = args.since_tag or latest_local_tag()
+    commits = local_commits(since_tag, args.max_commits)
+    root = run_git(["rev-parse", "--show-toplevel"])
+    return render_changelog(commits, since_tag, root)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from commits since the latest tag.")
+    parser.add_argument("--output", default="CHANGELOG.md", help="Path to write. Defaults to CHANGELOG.md.")
+    parser.add_argument("--repo", help="GitHub owner/name or URL. Uses the GitHub API instead of local git.")
+    parser.add_argument("--since-tag", help="Tag to compare from. Auto-detects the latest tag when omitted.")
+    parser.add_argument("--max-commits", type=int, default=100, help="Maximum commits to include.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the changelog instead of writing a file.")
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"), help="GitHub token for API mode.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    changelog = build_changelog(args)
+    if args.dry_run:
+        print(changelog, end="")
+        return 0
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(changelog, encoding="utf-8")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/generate-changelog/samples/openai-python.md
+++ b/skills/generate-changelog/samples/openai-python.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased - 2026-05-12
+
+Generated from `github.com/openai/openai-python` since `v2.35.1`.
+
+### Added
+
+- feat(api): realtime 2 ([8fe0ab8](https://github.com/openai/openai-python/commit/8fe0ab87e67eeb3cc27426b50093845229520f0e)) by stainless-app[bot]
+- feat(api): manual updates ([13c639c](https://github.com/openai/openai-python/commit/13c639cc7d57e4fbd4406563511e15eeb88a54b2)) by stainless-app[bot]
+
+### Changed
+
+- release: 2.36.0 ([ff683ff](https://github.com/openai/openai-python/commit/ff683ffbeba94fc01d93966b774c05a3471f2495)) by stainless-app[bot]
+- codegen metadata ([2f1dd28](https://github.com/openai/openai-python/commit/2f1dd2814f8d5af989dfa2077f9f748d94fd472a)) by stainless-app[bot]
+- codegen metadata ([19cda34](https://github.com/openai/openai-python/commit/19cda34ccc9fee540bad3523b223da3ae85f273c)) by stainless-app[bot]
+- codegen metadata ([12fc3e4](https://github.com/openai/openai-python/commit/12fc3e41f28ae433f41a88d71e1a29f6745c7640)) by stainless-app[bot]

--- a/skills/generate-changelog/test_changelog.py
+++ b/skills/generate-changelog/test_changelog.py
@@ -1,0 +1,38 @@
+import unittest
+
+from generate_changelog import Commit, classify_commit, parse_github_repo, render_changelog
+
+
+class GenerateChangelogTests(unittest.TestCase):
+    def test_parses_github_repo_values(self):
+        self.assertEqual(parse_github_repo("owner/repo"), ("owner", "repo"))
+        self.assertEqual(parse_github_repo("https://github.com/owner/repo.git"), ("owner", "repo"))
+
+    def test_classifies_common_commit_styles(self):
+        cases = {
+            "feat: add billing dashboard": "Added",
+            "fix(api): prevent null response crash": "Fixed",
+            "remove deprecated sqlite adapter": "Removed",
+            "docs: clarify setup": "Changed",
+        }
+        for subject, category in cases.items():
+            with self.subTest(subject=subject):
+                self.assertEqual(classify_commit(Commit(sha="abc1234", subject=subject)), category)
+
+    def test_renders_only_populated_sections(self):
+        output = render_changelog(
+            [
+                Commit(sha="abc1234", subject="feat: add export command", author="Ada"),
+                Commit(sha="def5678", subject="fix: correct date heading", author="Grace"),
+            ],
+            since_tag="v1.0.0",
+            source="github.com/example/repo",
+        )
+        self.assertIn("### Added", output)
+        self.assertIn("### Fixed", output)
+        self.assertNotIn("### Removed", output)
+        self.assertIn("Generated from `github.com/example/repo` since `v1.0.0`.", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1.

/opire try

## Summary
- Adds a /generate-changelog Claude command and bash changelog.sh entrypoint.
- Implements a Python changelog generator that uses commits since the latest git tag and groups entries into Added, Fixed, Changed, and Removed.
- Supports local git mode plus GitHub API mode for --repo owner/name.
- Includes focused unittest coverage, 3-step README instructions, and sample output from openai/openai-python.

## Validation
- Reviewed branch diff against upstream main: 6 focused files added, 0 behind.
- Included skills/generate-changelog/test_changelog.py covering repo parsing, commit categorization, and rendered sections.
- Included skills/generate-changelog/samples/openai-python.md as a real-repo sample output.

AI-assisted: implemented with Codex and kept scoped to the bounty acceptance criteria.