### PR TITLE
Add destructive Bash command blocker hook

### DIFF
--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -1,0 +1,41 @@
+# Destructive Command Blocker Hook
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## Install in 2 commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/destructive-command-blocker/destructive_command_blocker.py ~/.claude/hooks/destructive_command_blocker.py
+chmod +x ~/.claude/hooks/destructive_command_blocker.py
+```
+
+Then reference `~/.claude/hooks/destructive_command_blocker.py` from your Claude Code `PreToolUse` Bash hook configuration.
+
+## What it blocks
+
+- `rm -rf` and common recursive+force variants such as `rm -fr`
+- `DROP TABLE`
+- `git push --force`, `git push -f`, and `--force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM ...` statements without a `WHERE` clause
+
+## Logging
+
+Every blocked attempt is appended to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each JSONL record includes:
+
+- timestamp
+- attempted command
+- project path
+- matched rule / reason
+
+## Local validation
+
+```bash
+python3 hooks/destructive-command-blocker/test_destructive_command_blocker.py
+```

--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -39,3 +39,6 @@ Each JSONL record includes:
 ```bash
 python3 hooks/destructive-command-blocker/test_destructive_command_blocker.py
 ```
+
+The test suite covers the required destructive patterns, safe Bash commands,
+non-Bash hook payloads, malformed hook input, and the JSONL blocked-attempt log.

--- a/hooks/destructive-command-blocker/destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/destructive_command_blocker.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+The hook reads the Claude Code hook JSON payload from stdin, inspects Bash tool
+commands, and emits a structured deny decision when a dangerous command is
+found. Blocked attempts are appended to ~/.claude/hooks/blocked.log.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+DANGEROUS_MESSAGE = (
+    "Blocked destructive Bash command before execution. This command matched "
+    "a configured safety rule: {reason}. Review the command and use a safer, "
+    "more targeted alternative before retrying."
+)
+
+
+def normalize_space(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def strip_sql_comments(sql: str) -> str:
+    sql = re.sub(r"--[^\n]*(?=\n|$)", " ", sql)
+    sql = re.sub(r"/\*.*?\*/", " ", sql, flags=re.S)
+    return sql
+
+
+def has_delete_without_where(command: str) -> bool:
+    sql = normalize_space(strip_sql_comments(command)).lower()
+    for match in re.finditer(r"\bdelete\s+from\s+[`\"\[]?[\w.\]-]+[`\"\]]?", sql):
+        tail = sql[match.end() :]
+        stop_positions = [pos for pos in (tail.find(";"), tail.find("&&"), tail.find("||")) if pos != -1]
+        statement_tail = tail[: min(stop_positions)] if stop_positions else tail
+        if not re.search(r"\bwhere\b", statement_tail):
+            return True
+    return False
+
+
+def detect_destructive_pattern(command: str) -> str | None:
+    compact = normalize_space(command)
+    lowered = compact.lower()
+
+    # Required shell patterns. Token-aware checks catch common spelling variants
+    # while avoiding harmless strings like `echo rm -rf` where possible.
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = compact.split()
+
+    for index, token in enumerate(tokens):
+        if token == "rm":
+            flags = "".join(t[1:] for t in tokens[index + 1 :] if t.startswith("-") and not t.startswith("--"))
+            long_flags = {t for t in tokens[index + 1 :] if t.startswith("--")}
+            has_recursive = "r" in flags or "R" in flags or "--recursive" in long_flags
+            has_force = "f" in flags or "--force" in long_flags
+            if has_recursive and has_force:
+                return "rm recursive+force (for example rm -rf)"
+
+    if re.search(r"\bgit\s+push\b[^\n;|&]*(?:--force(?:-with-lease)?\b|-f\b|\+[^\s]+)", compact):
+        return "git push --force"
+
+    if re.search(r"\bdrop\s+table\b", lowered):
+        return "DROP TABLE"
+
+    if re.search(r"\btruncate\b", lowered):
+        return "TRUNCATE"
+
+    if has_delete_without_where(command):
+        return "DELETE FROM without a WHERE clause"
+
+    return None
+
+
+def extract_command(payload: dict[str, Any]) -> str | None:
+    tool_name = str(payload.get("tool_name") or payload.get("toolName") or "")
+    tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
+
+    if tool_name and tool_name.lower() not in {"bash", "shell"}:
+        return None
+
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command") or tool_input.get("cmd") or tool_input.get("script")
+        if isinstance(command, str):
+            return command
+    elif isinstance(tool_input, str):
+        return tool_input
+
+    # Be permissive for local tests or format changes.
+    command = payload.get("command") or payload.get("cmd")
+    return command if isinstance(command, str) else None
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "projectPath"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
+    if isinstance(tool_input, dict):
+        for key in ("cwd", "project_path", "projectPath"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return os.getcwd()
+
+
+def log_blocked(command: str, path: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": path,
+        "reason": reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def deny(reason: str) -> None:
+    message = DANGEROUS_MESSAGE.format(reason=reason)
+    print(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": message}))
+
+
+def allow() -> None:
+    print(json.dumps({"permissionDecision": "allow"}))
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        # Malformed hook input should not break normal Claude Code usage.
+        allow()
+        return 0
+
+    command = extract_command(payload)
+    if not command:
+        allow()
+        return 0
+
+    reason = detect_destructive_pattern(command)
+    if not reason:
+        allow()
+        return 0
+
+    path = project_path(payload)
+    log_blocked(command, path, reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-blocker/destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/destructive_command_blocker.py
@@ -46,28 +46,90 @@ def has_delete_without_where(command: str) -> bool:
     return False
 
 
+def shell_tokens(command: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return command.split()
+
+
+def split_shell_commands(tokens: list[str]) -> list[list[str]]:
+    commands: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in {";", "&&", "||", "|", "&", "(", ")"}:
+            if current:
+                commands.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        commands.append(current)
+    return commands
+
+
+def strip_command_prefixes(tokens: list[str]) -> list[str]:
+    remaining = tokens[:]
+    while remaining:
+        head = remaining[0]
+        if "=" in head and not head.startswith("-") and head.split("=", 1)[0].isidentifier():
+            remaining = remaining[1:]
+            continue
+        if head in {"sudo", "command", "builtin", "time"}:
+            remaining = remaining[1:]
+            continue
+        if head == "env":
+            remaining = remaining[1:]
+            while remaining and "=" in remaining[0] and not remaining[0].startswith("-"):
+                remaining = remaining[1:]
+            continue
+        return remaining
+    return remaining
+
+
+def inspect_rm_tokens(tokens: list[str]) -> bool:
+    flags = "".join(t[1:] for t in tokens[1:] if t.startswith("-") and not t.startswith("--"))
+    long_flags = {t for t in tokens[1:] if t.startswith("--")}
+    has_recursive = "r" in flags or "R" in flags or "--recursive" in long_flags
+    has_force = "f" in flags or "--force" in long_flags
+    return has_recursive and has_force
+
+
+def inspect_shell_commands(command: str) -> str | None:
+    for tokens in split_shell_commands(shell_tokens(command)):
+        tokens = strip_command_prefixes(tokens)
+        if not tokens:
+            continue
+
+        executable = Path(tokens[0]).name
+        if executable in {"bash", "sh", "zsh"} and "-c" in tokens:
+            index = tokens.index("-c")
+            if index + 1 < len(tokens):
+                nested = detect_destructive_pattern(tokens[index + 1])
+                if nested:
+                    return nested
+
+        if executable == "rm" and inspect_rm_tokens(tokens):
+            return "rm recursive+force (for example rm -rf)"
+
+        if executable == "git" and len(tokens) >= 3 and tokens[1] == "push":
+            if any(t in {"--force", "--force-with-lease", "-f"} or t.startswith("+refs/") or t.startswith("+") for t in tokens[2:]):
+                return "git push --force"
+
+    return None
+
+
 def detect_destructive_pattern(command: str) -> str | None:
     compact = normalize_space(command)
     lowered = compact.lower()
 
-    # Required shell patterns. Token-aware checks catch common spelling variants
-    # while avoiding harmless strings like `echo rm -rf` where possible.
-    try:
-        tokens = shlex.split(command, posix=True)
-    except ValueError:
-        tokens = compact.split()
-
-    for index, token in enumerate(tokens):
-        if token == "rm":
-            flags = "".join(t[1:] for t in tokens[index + 1 :] if t.startswith("-") and not t.startswith("--"))
-            long_flags = {t for t in tokens[index + 1 :] if t.startswith("--")}
-            has_recursive = "r" in flags or "R" in flags or "--recursive" in long_flags
-            has_force = "f" in flags or "--force" in long_flags
-            if has_recursive and has_force:
-                return "rm recursive+force (for example rm -rf)"
-
-    if re.search(r"\bgit\s+push\b[^\n;|&]*(?:--force(?:-with-lease)?\b|-f\b|\+[^\s]+)", compact):
-        return "git push --force"
+    # Required shell patterns. Token-aware checks catch command variants while
+    # avoiding harmless documentation/search strings such as `echo rm -rf`.
+    shell_reason = inspect_shell_commands(command)
+    if shell_reason:
+        return shell_reason
 
     if re.search(r"\bdrop\s+table\b", lowered):
         return "DROP TABLE"

--- a/hooks/destructive-command-blocker/destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/destructive_command_blocker.py
@@ -97,6 +97,46 @@ def inspect_rm_tokens(tokens: list[str]) -> bool:
     return has_recursive and has_force
 
 
+def git_subcommand_index(tokens: list[str]) -> int | None:
+    """Return the index of the git subcommand, skipping global options.
+
+    Git accepts options before the subcommand (for example
+    `git -c push.default=simple push --force-with-lease`). The hook should still
+    block destructive push variants even when contributors use those options.
+    """
+    index = 1
+    options_with_value = {"-c", "--config-env", "--git-dir", "--work-tree", "--namespace"}
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in options_with_value:
+            index += 2
+            continue
+        if any(token.startswith(prefix + "=") for prefix in options_with_value if prefix.startswith("--")):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return index
+    return index if index < len(tokens) else None
+
+
+def inspect_git_tokens(tokens: list[str]) -> bool:
+    subcommand_index = git_subcommand_index(tokens)
+    if subcommand_index is None or tokens[subcommand_index] != "push":
+        return False
+    return any(
+        t in {"--force", "--force-with-lease", "-f"}
+        or t.startswith("--force-with-lease=")
+        or t.startswith("+refs/")
+        or t.startswith("+")
+        for t in tokens[subcommand_index + 1 :]
+    )
+
+
 def inspect_shell_commands(command: str) -> str | None:
     for tokens in split_shell_commands(shell_tokens(command)):
         tokens = strip_command_prefixes(tokens)
@@ -114,9 +154,8 @@ def inspect_shell_commands(command: str) -> str | None:
         if executable == "rm" and inspect_rm_tokens(tokens):
             return "rm recursive+force (for example rm -rf)"
 
-        if executable == "git" and len(tokens) >= 3 and tokens[1] == "push":
-            if any(t in {"--force", "--force-with-lease", "-f"} or t.startswith("+refs/") or t.startswith("+") for t in tokens[2:]):
-                return "git push --force"
+        if executable == "git" and inspect_git_tokens(tokens):
+            return "git push --force"
 
     return None
 

--- a/hooks/destructive-command-blocker/destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/destructive_command_blocker.py
@@ -82,8 +82,24 @@ def strip_command_prefixes(tokens: list[str]) -> list[str]:
             continue
         if head == "env":
             remaining = remaining[1:]
-            while remaining and "=" in remaining[0] and not remaining[0].startswith("-"):
-                remaining = remaining[1:]
+            # `env` supports option-only prefixes before the command. Keep this
+            # small but practical so variants such as `env -i FOO=bar rm -rf x`
+            # are inspected as the underlying `rm` invocation.
+            env_options_with_value = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+            while remaining:
+                if "=" in remaining[0] and not remaining[0].startswith("-"):
+                    remaining = remaining[1:]
+                    continue
+                if remaining[0] in {"-i", "--ignore-environment", "-0", "--null"}:
+                    remaining = remaining[1:]
+                    continue
+                if remaining[0] in env_options_with_value:
+                    remaining = remaining[2:] if len(remaining) > 1 else []
+                    continue
+                if any(remaining[0].startswith(prefix + "=") for prefix in env_options_with_value if prefix.startswith("--")):
+                    remaining = remaining[1:]
+                    continue
+                break
             continue
         return remaining
     return remaining

--- a/hooks/destructive-command-blocker/install.sh
+++ b/hooks/destructive-command-blocker/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOK_DIR="${HOME}/.claude/hooks"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "${HOOK_DIR}"
+cp "${SCRIPT_DIR}/destructive_command_blocker.py" "${HOOK_DIR}/destructive_command_blocker.py"
+chmod +x "${HOOK_DIR}/destructive_command_blocker.py"
+touch "${HOOK_DIR}/blocked.log"
+
+echo "Installed Claude Code hook at ${HOOK_DIR}/destructive_command_blocker.py"
+echo "Add it as a PreToolUse Bash hook in your Claude Code hooks settings."

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -40,6 +40,8 @@ class DestructiveCommandBlockerTest(unittest.TestCase):
     def test_blocks_rm_rf(self) -> None:
         self.assert_denied("rm -rf build/")
         self.assert_denied("rm -fr build/")
+        self.assert_denied("sudo rm --recursive --force build/")
+        self.assert_denied("bash -c 'rm -rf build/'")
 
     def test_blocks_drop_table(self) -> None:
         self.assert_denied("psql -c 'DROP TABLE users;'")
@@ -47,6 +49,7 @@ class DestructiveCommandBlockerTest(unittest.TestCase):
     def test_blocks_force_push(self) -> None:
         self.assert_denied("git push --force origin main")
         self.assert_denied("git push -f origin main")
+        self.assert_denied("git push origin +main")
 
     def test_blocks_truncate(self) -> None:
         self.assert_denied("mysql -e 'TRUNCATE audit_log;'")

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("destructive_command_blocker.py")
+
+
+class DestructiveCommandBlockerTest(unittest.TestCase):
+    def run_hook(self, command: str, home: str | None = None) -> dict:
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": "/tmp/example-project",
+        }
+        env = os.environ.copy()
+        if home:
+            env["HOME"] = home
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=True,
+            env=env,
+        )
+        return json.loads(result.stdout)
+
+    def assert_denied(self, command: str) -> None:
+        output = self.run_hook(command)
+        self.assertEqual(output["permissionDecision"], "deny")
+        self.assertIn("Blocked destructive Bash command", output["permissionDecisionReason"])
+
+    def test_blocks_rm_rf(self) -> None:
+        self.assert_denied("rm -rf build/")
+        self.assert_denied("rm -fr build/")
+
+    def test_blocks_drop_table(self) -> None:
+        self.assert_denied("psql -c 'DROP TABLE users;'")
+
+    def test_blocks_force_push(self) -> None:
+        self.assert_denied("git push --force origin main")
+        self.assert_denied("git push -f origin main")
+
+    def test_blocks_truncate(self) -> None:
+        self.assert_denied("mysql -e 'TRUNCATE audit_log;'")
+
+    def test_blocks_delete_without_where(self) -> None:
+        self.assert_denied("psql -c 'DELETE FROM users;'")
+
+    def test_allows_normal_commands(self) -> None:
+        safe = [
+            "ls -la",
+            "git status --short",
+            "python3 -m pytest",
+            "psql -c 'DELETE FROM users WHERE id = 1;'",
+            "grep -R 'rm -rf' README.md",
+        ]
+        for command in safe:
+            with self.subTest(command=command):
+                output = self.run_hook(command)
+                self.assertEqual(output["permissionDecision"], "allow")
+
+    def test_logs_blocked_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            output = self.run_hook("rm -rf /tmp/demo", home=home)
+            self.assertEqual(output["permissionDecision"], "deny")
+            log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log_path.exists())
+            record = json.loads(log_path.read_text().strip())
+            self.assertEqual(record["attempted_command"], "rm -rf /tmp/demo")
+            self.assertEqual(record["project_path"], "/tmp/example-project")
+            self.assertIn("timestamp", record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -41,6 +41,7 @@ class DestructiveCommandBlockerTest(unittest.TestCase):
         self.assert_denied("rm -rf build/")
         self.assert_denied("rm -fr build/")
         self.assert_denied("sudo rm --recursive --force build/")
+        self.assert_denied("env -i PATH=/usr/bin rm -rf build/")
         self.assert_denied("bash -c 'rm -rf build/'")
 
     def test_blocks_drop_table(self) -> None:
@@ -52,6 +53,26 @@ class DestructiveCommandBlockerTest(unittest.TestCase):
         self.assert_denied("git push origin +main")
         self.assert_denied("git -c push.default=simple push --force-with-lease origin main")
         self.assert_denied("git --git-dir .git push --force origin main")
+
+    def test_ignores_non_bash_payloads_and_bad_json(self) -> None:
+        payload = {"tool_name": "Read", "tool_input": {"file_path": "rm -rf notes.txt"}}
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(json.loads(result.stdout)["permissionDecision"], "allow")
+
+        bad = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input="not json",
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(json.loads(bad.stdout)["permissionDecision"], "allow")
 
     def test_blocks_truncate(self) -> None:
         self.assert_denied("mysql -e 'TRUNCATE audit_log;'")

--- a/hooks/destructive-command-blocker/test_destructive_command_blocker.py
+++ b/hooks/destructive-command-blocker/test_destructive_command_blocker.py
@@ -50,6 +50,8 @@ class DestructiveCommandBlockerTest(unittest.TestCase):
         self.assert_denied("git push --force origin main")
         self.assert_denied("git push -f origin main")
         self.assert_denied("git push origin +main")
+        self.assert_denied("git -c push.default=simple push --force-with-lease origin main")
+        self.assert_denied("git --git-dir .git push --force origin main")
 
     def test_blocks_truncate(self) -> None:
         self.assert_denied("mysql -e 'TRUNCATE audit_log;'")


### PR DESCRIPTION
## Summary
- Adds a Claude Code `PreToolUse` Bash hook at `hooks/destructive-command-blocker/destructive_command_blocker.py`.
- Blocks the required destructive patterns: `rm -rf` variants, `DROP TABLE`, `git push --force` / `-f` / `--force-with-lease`, `TRUNCATE`, and `DELETE FROM` without `WHERE`.
- Logs every blocked attempt as JSONL to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and matched reason.
- Includes a README with installation in 2 commands and a local unittest suite.

## Acceptance criteria mapping
- ✅ Hook follows Claude Code hook format and installs under `~/.claude/hooks/`.
- ✅ Blocks required destructive patterns, including shell-wrapped `rm -rf` and git force-push variants with global git options.
- ✅ Logs blocked attempts with timestamp, attempted command, and project path.
- ✅ Returns a clear deny message explaining why Claude Code should stop.
- ✅ Allows normal commands such as `ls`, `git status`, tests, and `DELETE FROM ... WHERE ...`.
- ✅ README installation is 2 commands.

## Validation
```bash
python3 -m unittest discover -s hooks/destructive-command-blocker -p 'test_*.py'
python3 -m py_compile hooks/destructive-command-blocker/destructive_command_blocker.py
bash -n hooks/destructive-command-blocker/install.sh
git diff --check origin/main...HEAD
```

Latest local result: 8 unittest cases pass, covering required blocked patterns, env-wrapper handling, non-Bash/malformed hook payloads, safe command pass-through, blocked-attempt logging, and force-push variants with git global options.

Closes #3.
