### PR TITLE
[Bounty #1] CHANGELOG generator skill + bash script

### DIFF
--- a/bounty-1-changelog/README.md
+++ b/bounty-1-changelog/README.md
@@ -1,0 +1,24 @@
+# Generate Changelog Skill
+
+Generate a structured CHANGELOG.md from git history with automatic commit categorization.
+
+## Setup
+
+1. **Copy the skill file** into your Claude Code skills directory:
+   ```bash
+   cp bounty-1-changelog/SKILL.md .claude/skills/generate-changelog.md
+   ```
+
+2. **Run it** -- choose one method:
+   - **Claude Code:** type `/generate-changelog` in any git repository
+   - **Standalone bash:** run `bash bounty-1-changelog/changelog.sh` from your repo root
+
+3. **Review** the generated `CHANGELOG.md` and commit it when ready.
+
+## How It Works
+
+- Finds the latest git tag and collects all commits since that tag (or all commits if no tags exist)
+- Categorizes commits using conventional commit prefixes (`feat:`, `fix:`, `refactor:`, etc.)
+- Falls back to keyword heuristics when no prefix is found (e.g., "add", "fix", "remove")
+- Outputs a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) formatted file with sections: **Added**, **Fixed**, **Changed**, **Removed**
+- Preserves existing changelog entries when appending new versions

--- a/bounty-1-changelog/SAMPLE_OUTPUT.md
+++ b/bounty-1-changelog/SAMPLE_OUTPUT.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [v2.4.1] - 2026-05-12
+
+### Added
+- Add OAuth2 PKCE flow for mobile clients (a3f82c1)
+- Implement rate limiting middleware with sliding window (7b1d4e9)
+- Add bulk export endpoint for analytics data (e92ca3f)
+- Introduce dark mode toggle in user preferences (4d8f1a2)
+- Support WebSocket connections for real-time notifications (c5e7b30)
+
+### Fixed
+- Fix race condition in session token refresh (1f4a8d2)
+- Resolve memory leak in connection pool under high concurrency (8c2e6f1)
+- Correct pagination offset calculation for filtered queries (3a9d7b5)
+- Fix CORS headers not applied to preflight requests (6e1c4a8)
+
+### Changed
+- Refactor database migration runner to support rollbacks (b4c91e7)
+- Update Node.js minimum version to 20 LTS (d7f2a35)
+- Improve search query performance with trigram indexes (5e8b1c9)
+- Migrate CI pipeline from CircleCI to GitHub Actions (9a3f6d2)
+- Upgrade dependencies to patch known CVEs (2c7e4b8)
+- Update API documentation for v2.4 endpoints (f1d8a93)
+
+### Removed
+- Remove deprecated v1 authentication endpoints (0b5c2e4)
+- Drop support for Node.js 16 (7d4f9a1)
+
+## [v2.4.0] - 2026-04-28
+
+### Added
+- Add team management API with role-based access control (cc81f4a)
+- Implement CSV import for batch user creation (2e9a7d3)
+
+### Fixed
+- Fix timezone handling in scheduled report generation (5b3c8e1)
+
+### Changed
+- Refactor logging to use structured JSON format (a1d4f72)
+- Update rate limit response to include retry-after header (8f2b6c9)

--- a/bounty-1-changelog/SKILL.md
+++ b/bounty-1-changelog/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history, auto-categorizing commits into Added/Fixed/Changed/Removed sections based on conventional commit prefixes or keyword heuristics.
+---
+
+# Generate Changelog
+
+You are generating a structured CHANGELOG.md from git commit history. Follow these steps precisely.
+
+## Step 1: Determine the version range
+
+Run this command to find the latest git tag:
+
+```bash
+git describe --tags --abbrev=0 2>/dev/null
+```
+
+- If a tag is found, store it as `LAST_TAG`. The new version heading will reference commits "since `LAST_TAG`".
+- If no tag exists (command fails), you will use the entire commit history. Note this in your process.
+
+## Step 2: Fetch commits
+
+If `LAST_TAG` was found:
+```bash
+git log ${LAST_TAG}..HEAD --pretty=format:"%h %s" --no-merges
+```
+
+If no tag exists:
+```bash
+git log --pretty=format:"%h %s" --no-merges
+```
+
+Also get the current date:
+```bash
+date +%Y-%m-%d
+```
+
+And attempt to determine the next version. If the last tag looks like a semver (e.g. v1.2.3), suggest the next patch version. Otherwise use "Unreleased".
+
+## Step 3: Categorize each commit
+
+For each commit message, assign it to exactly one category using these rules in priority order:
+
+### Primary: Conventional Commit Prefixes
+Match the prefix before the first colon (case-insensitive):
+
+| Prefix | Category |
+|--------|----------|
+| `feat` | Added |
+| `feature` | Added |
+| `add` | Added |
+| `fix` | Fixed |
+| `bugfix` | Fixed |
+| `hotfix` | Fixed |
+| `refactor` | Changed |
+| `change` | Changed |
+| `update` | Changed |
+| `improve` | Changed |
+| `perf` | Changed |
+| `style` | Changed |
+| `chore` | Changed |
+| `build` | Changed |
+| `ci` | Changed |
+| `docs` | Changed |
+| `test` | Changed |
+| `remove` | Removed |
+| `delete` | Removed |
+| `deprecate` | Removed |
+| `revert` | Changed |
+| `breaking` | Changed |
+
+### Fallback: Keyword Heuristics
+If no conventional commit prefix is detected, scan the commit message body for keywords:
+
+- **Added**: message contains "add", "new", "create", "introduce", "implement", "support"
+- **Fixed**: message contains "fix", "bug", "patch", "resolve", "correct", "repair"
+- **Changed**: message contains "update", "change", "modify", "refactor", "improve", "enhance", "rename", "move", "migrate", "upgrade", "adjust", "optimize"
+- **Removed**: message contains "remove", "delete", "drop", "deprecate", "clean up", "strip"
+
+If a commit matches multiple keyword categories, use the first match from the order: Added, Fixed, Removed, Changed.
+
+If no category can be determined, place it under **Changed**.
+
+## Step 4: Generate the CHANGELOG.md
+
+Write the file `CHANGELOG.md` in the repository root using this exact format:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [VERSION] - YYYY-MM-DD
+
+### Added
+- Commit message here (SHORT_HASH)
+
+### Fixed
+- Commit message here (SHORT_HASH)
+
+### Changed
+- Commit message here (SHORT_HASH)
+
+### Removed
+- Commit message here (SHORT_HASH)
+```
+
+Rules for the output:
+- VERSION is the determined next version or "Unreleased"
+- YYYY-MM-DD is today's date
+- Only include category sections that have at least one commit
+- Strip the conventional commit prefix and scope from the displayed message (e.g., `feat(auth): add login` becomes `Add login`)
+- Capitalize the first letter of each commit message
+- Include the short hash in parentheses at the end of each line
+- If a previous CHANGELOG.md exists, prepend the new version section after the header, preserving existing content
+- Order sections: Added, Fixed, Changed, Removed
+- Each commit appears exactly once
+
+## Step 5: Report results
+
+After writing the file, report:
+- How many commits were processed
+- How many in each category
+- The output file path
+
+Do NOT push or commit the CHANGELOG.md -- just write it and let the user decide what to do next.

--- a/bounty-1-changelog/changelog.sh
+++ b/bounty-1-changelog/changelog.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# changelog.sh - Generate a structured CHANGELOG.md from git history
+#
+# Usage: bash changelog.sh [output_file]
+#
+# Fetches commits since the last git tag (or all commits if no tags exist),
+# categorizes them by conventional commit prefixes or keyword heuristics,
+# and outputs a formatted CHANGELOG.md.
+
+set -euo pipefail
+
+OUTPUT_FILE="${1:-CHANGELOG.md}"
+TODAY=$(date +%Y-%m-%d)
+
+# ---------------------------------------------------------------------------
+# Determine version range
+# ---------------------------------------------------------------------------
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [[ -n "$LAST_TAG" ]]; then
+    echo "Last tag: $LAST_TAG"
+    COMMIT_RANGE="${LAST_TAG}..HEAD"
+
+    # Attempt to compute next patch version from semver tag
+    if [[ "$LAST_TAG" =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        PREFIX=""
+        [[ "$LAST_TAG" == v* ]] && PREFIX="v"
+        MAJOR="${BASH_REMATCH[1]}"
+        MINOR="${BASH_REMATCH[2]}"
+        PATCH="${BASH_REMATCH[3]}"
+        NEXT_VERSION="${PREFIX}${MAJOR}.${MINOR}.$((PATCH + 1))"
+    else
+        NEXT_VERSION="Unreleased"
+    fi
+else
+    echo "No tags found. Using entire commit history."
+    COMMIT_RANGE=""
+    NEXT_VERSION="Unreleased"
+fi
+
+echo "Version: $NEXT_VERSION"
+echo "Date: $TODAY"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fetch commits
+# ---------------------------------------------------------------------------
+
+if [[ -n "$COMMIT_RANGE" ]]; then
+    COMMITS=$(git log "$COMMIT_RANGE" --pretty=format:"%h|||%s" --no-merges 2>/dev/null || echo "")
+else
+    COMMITS=$(git log --pretty=format:"%h|||%s" --no-merges 2>/dev/null || echo "")
+fi
+
+if [[ -z "$COMMITS" ]]; then
+    echo "No commits found. Nothing to generate."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Categorize commits
+# ---------------------------------------------------------------------------
+
+ADDED=()
+FIXED=()
+CHANGED=()
+REMOVED=()
+
+categorize_commit() {
+    local hash="$1"
+    local message="$2"
+    local display_message="$message"
+    local category=""
+
+    # Check for conventional commit prefix (word before first colon)
+    if [[ "$message" =~ ^([a-zA-Z]+)(\(.*\))?:\ *(.*) ]]; then
+        local prefix
+        prefix=$(echo "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+        display_message="${BASH_REMATCH[3]}"
+
+        case "$prefix" in
+            feat|feature|add)
+                category="added" ;;
+            fix|bugfix|hotfix)
+                category="fixed" ;;
+            remove|delete|deprecate)
+                category="removed" ;;
+            refactor|change|update|improve|perf|style|chore|build|ci|docs|test|revert|breaking)
+                category="changed" ;;
+        esac
+    fi
+
+    # Fallback: keyword heuristics
+    if [[ -z "$category" ]]; then
+        local lower
+        lower=$(echo "$message" | tr '[:upper:]' '[:lower:]')
+        if [[ "$lower" =~ (^|[^a-z])(add|new|create|introduce|implement|support)([^a-z]|$) ]]; then
+            category="added"
+        elif [[ "$lower" =~ (^|[^a-z])(fix|bug|patch|resolve|correct|repair)([^a-z]|$) ]]; then
+            category="fixed"
+        elif [[ "$lower" =~ (^|[^a-z])(remove|delete|drop|deprecate|strip)([^a-z]|$) ]]; then
+            category="removed"
+        elif [[ "$lower" =~ (^|[^a-z])(update|change|modify|refactor|improve|enhance|rename|move|migrate|upgrade|adjust|optimize)([^a-z]|$) ]]; then
+            category="changed"
+        else
+            category="changed"
+        fi
+    fi
+
+    # Capitalize first letter of display message
+    display_message="$(echo "${display_message:0:1}" | tr '[:lower:]' '[:upper:]')${display_message:1}"
+
+    local entry="- ${display_message} (${hash})"
+
+    case "$category" in
+        added)   ADDED+=("$entry") ;;
+        fixed)   FIXED+=("$entry") ;;
+        removed) REMOVED+=("$entry") ;;
+        *)       CHANGED+=("$entry") ;;
+    esac
+}
+
+while IFS= read -r line; do
+    hash="${line%%|||*}"
+    message="${line#*|||}"
+    categorize_commit "$hash" "$message"
+done <<< "$COMMITS"
+
+TOTAL=$(( ${#ADDED[@]} + ${#FIXED[@]} + ${#CHANGED[@]} + ${#REMOVED[@]} ))
+
+echo "Commits processed: $TOTAL"
+echo "  Added:   ${#ADDED[@]}"
+echo "  Fixed:   ${#FIXED[@]}"
+echo "  Changed: ${#CHANGED[@]}"
+echo "  Removed: ${#REMOVED[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Build the changelog content
+# ---------------------------------------------------------------------------
+
+HEADER="# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)."
+
+NEW_SECTION="## [$NEXT_VERSION] - $TODAY"
+
+if [[ ${#ADDED[@]} -gt 0 ]]; then
+    NEW_SECTION+=$'\n\n### Added'
+    for entry in "${ADDED[@]}"; do
+        NEW_SECTION+=$'\n'"$entry"
+    done
+fi
+
+if [[ ${#FIXED[@]} -gt 0 ]]; then
+    NEW_SECTION+=$'\n\n### Fixed'
+    for entry in "${FIXED[@]}"; do
+        NEW_SECTION+=$'\n'"$entry"
+    done
+fi
+
+if [[ ${#CHANGED[@]} -gt 0 ]]; then
+    NEW_SECTION+=$'\n\n### Changed'
+    for entry in "${CHANGED[@]}"; do
+        NEW_SECTION+=$'\n'"$entry"
+    done
+fi
+
+if [[ ${#REMOVED[@]} -gt 0 ]]; then
+    NEW_SECTION+=$'\n\n### Removed'
+    for entry in "${REMOVED[@]}"; do
+        NEW_SECTION+=$'\n'"$entry"
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Write output (preserve existing content if present)
+# ---------------------------------------------------------------------------
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+    # Extract existing entries (everything after the header block)
+    EXISTING=$(sed -n '/^## \[/,$p' "$OUTPUT_FILE")
+    if [[ -n "$EXISTING" ]]; then
+        FINAL_CONTENT="${HEADER}"$'\n\n'"${NEW_SECTION}"$'\n\n'"${EXISTING}"
+    else
+        FINAL_CONTENT="${HEADER}"$'\n\n'"${NEW_SECTION}"
+    fi
+else
+    FINAL_CONTENT="${HEADER}"$'\n\n'"${NEW_SECTION}"
+fi
+
+echo "$FINAL_CONTENT" > "$OUTPUT_FILE"
+
+echo "Changelog written to: $OUTPUT_FILE"


### PR DESCRIPTION
## Summary

- Skill (`SKILL.md`) implementing `/generate-changelog` command
- Standalone bash script (`changelog.sh`) for use without IDE integration
- Auto-categorizes commits into Added/Fixed/Changed/Removed using conventional commit prefixes with keyword heuristic fallback
- Handles edge cases: no tags (uses all commits), non-conventional commits

## Files

| File | Purpose |
|------|---------|
| `bounty-1-changelog/SKILL.md` | Skill file with frontmatter |
| `bounty-1-changelog/changelog.sh` | Standalone bash script (macOS compatible) |
| `bounty-1-changelog/README.md` | 3-step setup instructions |
| `bounty-1-changelog/SAMPLE_OUTPUT.md` | Sample output demonstrating formatting |

## Test plan

- [x] Tested changelog.sh on this repository
- [x] Verified conventional commit parsing
- [x] Verified keyword heuristic fallback
- [x] Verified no-tags edge case
- [x] macOS compatible