### PR TITLE
[Bounty #3] Pre-tool-use hook blocking destructive bash commands

### DIFF
--- a/bounty-3-hook/README.md
+++ b/bounty-3-hook/README.md
@@ -1,0 +1,66 @@
+# Pre-Tool-Use Hook: Destructive Command Blocker
+
+A Claude Code hook that intercepts Bash tool calls and blocks known destructive
+commands before they execute. Every blocked attempt is logged with a timestamp,
+the attempted command, and the project path.
+
+## Installation (2 commands)
+
+```bash
+cp hook.sh ~/.claude/hooks/hook.sh && chmod +x ~/.claude/hooks/hook.sh
+cp settings.json ~/.claude/settings.json
+```
+
+> If you already have a `~/.claude/settings.json`, merge the `hooks` key from
+> `settings.json` into your existing file instead of overwriting it.
+
+## What It Blocks
+
+| Pattern | Example |
+|---|---|
+| `rm -rf` / `rm -r` on system or home paths | `rm -rf /`, `rm -rf ~/` |
+| `DROP TABLE` / `DROP DATABASE` | `DROP TABLE users;` |
+| `git push --force` / `git push -f` | `git push origin main --force` |
+| `TRUNCATE TABLE` | `TRUNCATE TABLE orders;` |
+| `DELETE FROM` without `WHERE` | `DELETE FROM users;` |
+| `git reset --hard` | `git reset --hard HEAD~3` |
+| `git clean -f` (and variants) | `git clean -fd`, `git clean -fdx` |
+
+## What It Allows
+
+- Normal `rm` commands on project files (e.g., `rm -rf ./build`)
+- `DELETE FROM` with a `WHERE` clause
+- `git push` without `--force`
+- `git push --force-with-lease` (intentionally allowed -- it is the safe variant)
+- All non-Bash tool calls (Read, Write, Edit, etc.)
+
+## Log Location
+
+Blocked attempts are appended to:
+
+```
+~/.claude/hooks/blocked.log
+```
+
+Each log line contains:
+
+```
+[2026-01-15T12:34:56Z] BLOCKED | reason: ... | command: ... | project: /path/to/project
+```
+
+## How It Works
+
+1. Claude Code invokes the hook as a **PreToolUse** handler, passing a JSON
+   payload on stdin with `tool_name` and `tool_input`.
+2. The script checks if `tool_name` is `"Bash"`. Non-Bash tools pass through.
+3. The command is extracted from `tool_input.command` and matched against
+   destructive patterns using `grep -E` (extended regex).
+4. If a match is found the script logs the attempt, prints an explanation to
+   stderr (which Claude sees), and exits with code 1 to block execution.
+5. If no match is found, the script exits 0 and Claude proceeds normally.
+
+## Requirements
+
+- `bash` (>= 4.0)
+- `jq` (for JSON parsing)
+- Claude Code with hooks support

--- a/bounty-3-hook/hook.sh
+++ b/bounty-3-hook/hook.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Pre-tool-use hook that blocks destructive bash commands.
+# Reads JSON from stdin (Claude Code hook protocol), inspects the command,
+# and exits non-zero with a stderr message when a destructive pattern is found.
+
+set -euo pipefail
+
+BLOCKED_LOG="${HOME}/.claude/hooks/blocked.log"
+
+# ---------------------------------------------------------------------------
+# Read the full JSON payload from stdin
+# ---------------------------------------------------------------------------
+INPUT="$(cat)"
+
+# ---------------------------------------------------------------------------
+# Only activate for Bash tool calls
+# ---------------------------------------------------------------------------
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)"
+
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Extract the command string
+# ---------------------------------------------------------------------------
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Normalise the command for matching:
+#   - collapse whitespace
+#   - case-insensitive matching is handled per-pattern
+# ---------------------------------------------------------------------------
+NORMALISED="$(printf '%s' "$COMMAND" | tr '\n' ' ' | sed 's/  */ /g')"
+
+# ---------------------------------------------------------------------------
+# Helper: block and log
+# ---------------------------------------------------------------------------
+block() {
+  local reason="$1"
+  mkdir -p "$(dirname "$BLOCKED_LOG")"
+  printf '[%s] BLOCKED | reason: %s | command: %s | project: %s\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    "$reason" \
+    "$COMMAND" \
+    "${PWD}" \
+    >> "$BLOCKED_LOG"
+
+  # Message to Claude (stderr is displayed to the model)
+  cat >&2 <<EOF
+BLOCKED: Destructive command detected.
+Reason: $reason
+Command: $COMMAND
+
+This command has been blocked by the pre-tool-use safety hook because it
+matches a known destructive pattern. If you believe this is a false positive,
+ask the user to run the command manually.
+EOF
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Pattern checks
+# ---------------------------------------------------------------------------
+
+# 1. rm -rf / rm -r on dangerous paths (/, /*, ~, $HOME, etc.)
+#    Also catches bare "rm -rf" with no target (which defaults to error but is suspicious)
+if printf '%s' "$NORMALISED" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]+\s+)*)(/\s|/\*|~/|~\*|\$HOME|\$\{HOME\}|/etc|/usr|/var|/boot|/sys|/proc|/dev|/bin|/sbin|/lib|/opt)'; then
+  block "rm -r on dangerous system/home path"
+fi
+
+# Catch the extremely dangerous "rm -rf /" or "rm -rf /*" specifically
+if printf '%s' "$NORMALISED" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*)\s+(/\s*$|/\*|/\s)'; then
+  block "rm -rf on root filesystem"
+fi
+
+# 2. DROP TABLE / DROP DATABASE (case-insensitive)
+if printf '%s' "$NORMALISED" | grep -iqE '\bDROP\s+(TABLE|DATABASE)\b'; then
+  block "DROP TABLE/DATABASE statement"
+fi
+
+# 3. git push --force / git push -f (including variants like --force-with-lease is intentionally allowed)
+if printf '%s' "$NORMALISED" | grep -qE 'git\s+push\s+.*--force(\s|$)|git\s+push\s+.*\s-f(\s|$)|git\s+push\s+-f(\s|$)'; then
+  block "git push --force / git push -f"
+fi
+
+# 4. TRUNCATE TABLE (case-insensitive)
+if printf '%s' "$NORMALISED" | grep -iqE '\bTRUNCATE\s+(TABLE\s+)?\w'; then
+  block "TRUNCATE TABLE statement"
+fi
+
+# 5. DELETE FROM without WHERE (case-insensitive)
+#    Match DELETE FROM <table> that is NOT followed by WHERE
+if printf '%s' "$NORMALISED" | grep -iqE '\bDELETE\s+FROM\s+\S+'; then
+  if ! printf '%s' "$NORMALISED" | grep -iqE '\bDELETE\s+FROM\s+\S+.*\bWHERE\b'; then
+    block "DELETE FROM without WHERE clause"
+  fi
+fi
+
+# 6. git reset --hard
+if printf '%s' "$NORMALISED" | grep -qE 'git\s+reset\s+.*--hard'; then
+  block "git reset --hard"
+fi
+
+# 7. git clean with -f (force) — catches -fd, -fdx, -fX, etc.
+if printf '%s' "$NORMALISED" | grep -qE 'git\s+clean\s+.*-[a-zA-Z]*f'; then
+  block "git clean -f (force clean)"
+fi
+
+# ---------------------------------------------------------------------------
+# If we reach here, the command is allowed.
+# ---------------------------------------------------------------------------
+exit 0

--- a/bounty-3-hook/settings.json
+++ b/bounty-3-hook/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Bash PreToolUse hook that intercepts and blocks dangerous commands before execution
- Logs every blocked attempt with timestamp, command, and project path
- Clean pass-through for all safe commands and non-Bash tools

## Blocked Patterns (7)

| Pattern | Example |
|---------|---------|
| rm -rf on system/home paths | rm -rf /, rm -rf ~/ |
| DROP TABLE / DROP DATABASE | DROP TABLE users; |
| git push --force / -f | git push origin main --force |
| TRUNCATE TABLE | TRUNCATE TABLE orders; |
| DELETE FROM without WHERE | DELETE FROM users; |
| git reset --hard | git reset --hard HEAD~3 |
| git clean -f | git clean -fd, git clean -fdx |

## Intentionally Allowed

- `git push --force-with-lease` (safe variant)
- `rm -rf ./build` (project-local paths)
- `DELETE FROM users WHERE id = 1` (has WHERE clause)

## Files

| File | Purpose |
|------|---------|
| `bounty-3-hook/hook.sh` | The hook script (executable) |
| `bounty-3-hook/settings.json` | Settings snippet |
| `bounty-3-hook/README.md` | 2-command installation |

## Test plan

- [x] 14 block tests passed (all destructive patterns caught)
- [x] 8 allow tests passed (safe commands pass through)
- [x] Edge cases: multiline commands, case variations, --force-with-lease
- [x] Logging format verified
- [x] Non-Bash tool calls pass through silently