### PR TITLE
Add destructive Bash command guard hook

### DIFF
--- a/hooks/destructive_bash_guard/README.md
+++ b/hooks/destructive_bash_guard/README.md
@@ -1,0 +1,55 @@
+# Destructive Bash Guard
+
+A Claude Code `PreToolUse` hook that blocks high-risk Bash commands before they run.
+
+## Install
+
+Run these two commands from the repository root:
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/destructive_bash_guard/destructive_bash_guard.py ~/.claude/hooks/destructive_bash_guard.py && chmod +x ~/.claude/hooks/destructive_bash_guard.py
+python3 hooks/destructive_bash_guard/install.py
+```
+
+The installer adds a `PreToolUse` hook for the `Bash` tool to `~/.claude/settings.json`.
+
+## What Gets Blocked
+
+| Pattern | Example |
+| --- | --- |
+| Recursive forced deletes | `rm -rf build`, `sudo rm -Rf /tmp/app` |
+| Destructive SQL schema changes | `DROP TABLE users` |
+| Table truncation | `TRUNCATE TABLE audit_log` |
+| Unscoped row deletion | `DELETE FROM users` |
+| Forced Git pushes | `git push --force origin main`, `git push -f` |
+
+Normal Bash commands are allowed. Safer variants such as `DELETE FROM users WHERE id = 1`,
+`git push --force-with-lease`, and `rm -r build` do not get blocked by this hook.
+
+## Logging
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with:
+
+- UTC timestamp
+- attempted command
+- project path
+- matched rule
+- block reason
+
+## Claude Code Hook Format
+
+The hook reads Claude Code JSON from `stdin`, checks `tool_name == "Bash"`, and inspects
+`tool_input.command`. When a command is blocked, it returns:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Clear block reason shown to Claude"
+  }
+}
+```
+
+This follows Claude Code's current `PreToolUse` decision format and does not interfere with
+other tools or safe Bash commands.

--- a/hooks/destructive_bash_guard/destructive_bash_guard.py
+++ b/hooks/destructive_bash_guard/destructive_bash_guard.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+CONTROL_TOKENS = {";", ";;", "&&", "||", "|", "|&", "\n"}
+WRAPPER_COMMANDS = {"command", "builtin", "noglob", "time"}
+DB_CLIENTS = {"psql", "mysql", "mariadb", "sqlite3", "duckdb", "sqlcmd"}
+SQL_COMMENT_RE = re.compile(r"(--[^\n\r]*|/\*.*?\*/)", re.IGNORECASE | re.DOTALL)
+SQL_DIRECT_RE = re.compile(r"^\s*(?:DROP\s+(?:TEMPORARY\s+)?TABLE|TRUNCATE|DELETE\s+FROM)\b", re.IGNORECASE)
+DROP_TABLE_RE = re.compile(r"\bDROP\s+(?:TEMPORARY\s+)?TABLE\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\bTRUNCATE\s+(?:TABLE\s+)?[A-Za-z_][\w.$`\"-]*", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+
+
+class BlockedCommand(Exception):
+    """Raised when a command matches a destructive pattern."""
+
+    def __init__(self, rule: str, reason: str) -> None:
+        self.rule = rule
+        self.reason = reason
+        super().__init__(reason)
+
+
+def tokenize_shell(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def split_simple_commands(tokens: Iterable[str]) -> Iterable[list[str]]:
+    current: list[str] = []
+    for token in tokens:
+        if token in CONTROL_TOKENS:
+            if current:
+                yield current
+                current = []
+            continue
+        current.append(token)
+    if current:
+        yield current
+
+
+def clean_command_name(token: str) -> str:
+    token = token.lstrip("\\")
+    return Path(token).name
+
+
+def is_assignment(token: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token))
+
+
+def strip_leading_wrappers(tokens: Sequence[str]) -> list[str]:
+    remaining = list(tokens)
+
+    while remaining:
+        name = clean_command_name(remaining[0])
+
+        if is_assignment(remaining[0]):
+            remaining.pop(0)
+            continue
+
+        if name in WRAPPER_COMMANDS:
+            remaining.pop(0)
+            continue
+
+        if name == "sudo" or name == "doas":
+            remaining.pop(0)
+            while remaining and remaining[0].startswith("-"):
+                option = remaining.pop(0)
+                if option in {"-u", "-g", "-h", "-p", "-C", "-T"} and remaining:
+                    remaining.pop(0)
+            continue
+
+        if name == "env":
+            remaining.pop(0)
+            while remaining and (remaining[0].startswith("-") or is_assignment(remaining[0])):
+                remaining.pop(0)
+            continue
+
+        return remaining
+
+    return remaining
+
+
+def short_option_has(option: str, flag: str) -> bool:
+    return option.startswith("-") and not option.startswith("--") and flag.lower() in option[1:].lower()
+
+
+def inspect_rm(tokens: Sequence[str]) -> None:
+    command = strip_leading_wrappers(tokens)
+    if not command or clean_command_name(command[0]) != "rm":
+        return
+
+    recursive = False
+    force = False
+    for token in command[1:]:
+        if token == "--":
+            break
+        if not token.startswith("-"):
+            continue
+        recursive = recursive or token in {"-r", "-R", "--recursive"} or short_option_has(token, "r")
+        force = force or token in {"-f", "--force"} or short_option_has(token, "f")
+
+    if recursive and force:
+        raise BlockedCommand(
+            "rm-recursive-force",
+            "Blocked rm with both recursive and force flags. Use a safer cleanup command or remove files explicitly.",
+        )
+
+
+def inspect_git_push(tokens: Sequence[str]) -> None:
+    command = strip_leading_wrappers(tokens)
+    if not command or clean_command_name(command[0]) != "git":
+        return
+
+    try:
+        push_index = command.index("push")
+    except ValueError:
+        return
+
+    for token in command[push_index + 1 :]:
+        if token == "--force" or token.startswith("--force=") or short_option_has(token, "f"):
+            raise BlockedCommand(
+                "git-push-force",
+                "Blocked git push with force. Use --force-with-lease only after confirming remote history is safe to replace.",
+            )
+
+
+def stripped_sql(command: str) -> str:
+    return SQL_COMMENT_RE.sub("", command)
+
+
+def inspect_sql(command: str) -> None:
+    sql = stripped_sql(command)
+
+    if DROP_TABLE_RE.search(sql):
+        raise BlockedCommand("drop-table", "Blocked DROP TABLE because it can permanently destroy schema and data.")
+
+    if TRUNCATE_RE.search(sql):
+        raise BlockedCommand("truncate", "Blocked TRUNCATE because it removes all rows from a table.")
+
+    for match in DELETE_FROM_RE.finditer(sql):
+        statement_end = sql.find(";", match.end())
+        if statement_end == -1:
+            statement_end = len(sql)
+        statement = sql[match.start() : statement_end]
+        if not re.search(r"\bWHERE\b", statement, re.IGNORECASE):
+            raise BlockedCommand(
+                "delete-without-where",
+                "Blocked DELETE FROM without a WHERE clause because it can remove every row.",
+            )
+
+
+def should_scan_sql(command: str, tokens: Sequence[str]) -> bool:
+    if SQL_DIRECT_RE.search(stripped_sql(command)):
+        return True
+
+    for simple_command in split_simple_commands(tokens):
+        command_tokens = strip_leading_wrappers(simple_command)
+        if command_tokens and clean_command_name(command_tokens[0]).lower() in DB_CLIENTS:
+            return True
+
+    return False
+
+
+def inspect_command(command: str) -> None:
+    try:
+        tokens = tokenize_shell(command)
+    except ValueError:
+        tokens = []
+
+    if not tokens:
+        inspect_sql(command)
+        if re.search(r"\brm\s+(?:-[A-Za-z]*r[A-Za-z]*f|-[A-Za-z]*f[A-Za-z]*r)", command, re.IGNORECASE):
+            raise BlockedCommand(
+                "rm-recursive-force",
+                "Blocked rm with recursive and force flags in an unparsable shell command.",
+            )
+        return
+
+    if should_scan_sql(command, tokens):
+        inspect_sql(command)
+
+    for simple_command in split_simple_commands(tokens):
+        inspect_rm(simple_command)
+        inspect_git_push(simple_command)
+
+
+def log_blocked(command: str, rule: str, reason: str, project_path: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": project_path,
+        "rule": rule,
+        "reason": reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def deny(reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        hook_input = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if hook_input.get("tool_name") != "Bash":
+        return 0
+
+    command = str(hook_input.get("tool_input", {}).get("command", ""))
+    if not command.strip():
+        return 0
+
+    project_path = str(hook_input.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+
+    try:
+        inspect_command(command)
+    except BlockedCommand as blocked:
+        try:
+            log_blocked(command, blocked.rule, blocked.reason, project_path)
+        finally:
+            deny(blocked.reason)
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive_bash_guard/install.py
+++ b/hooks/destructive_bash_guard/install.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Register the destructive Bash guard in Claude Code user settings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+HOOK_PATH = Path.home() / ".claude" / "hooks" / "destructive_bash_guard.py"
+HOOK_ENTRY = {"type": "command", "command": str(HOOK_PATH)}
+
+
+def load_settings() -> dict:
+    if not SETTINGS_PATH.exists():
+        return {}
+    with SETTINGS_PATH.open(encoding="utf-8") as settings_file:
+        return json.load(settings_file)
+
+
+def main() -> int:
+    settings = load_settings()
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    bash_group = next((group for group in pre_tool_use if group.get("matcher") == "Bash"), None)
+    if bash_group is None:
+        bash_group = {"matcher": "Bash", "hooks": []}
+        pre_tool_use.append(bash_group)
+
+    group_hooks = bash_group.setdefault("hooks", [])
+    if not any(hook.get("command") == str(HOOK_PATH) for hook in group_hooks):
+        group_hooks.append(HOOK_ENTRY)
+
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SETTINGS_PATH.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+    print(f"Registered PreToolUse Bash guard in {SETTINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_destructive_bash_guard.py
+++ b/tests/test_destructive_bash_guard.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_PATH = REPO_ROOT / "hooks" / "destructive_bash_guard" / "destructive_bash_guard.py"
+
+spec = importlib.util.spec_from_file_location("destructive_bash_guard", HOOK_PATH)
+guard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(guard)
+
+
+class DestructiveBashGuardTest(unittest.TestCase):
+    def assert_blocked(self, command: str, rule: str) -> None:
+        with self.assertRaises(guard.BlockedCommand) as context:
+            guard.inspect_command(command)
+        self.assertEqual(context.exception.rule, rule)
+
+    def assert_allowed(self, command: str) -> None:
+        guard.inspect_command(command)
+
+    def test_blocks_recursive_forced_rm_variants(self) -> None:
+        for command in [
+            "rm -rf build",
+            "rm -fr build",
+            "sudo rm -Rf /tmp/app",
+            "env FOO=bar rm --recursive --force cache",
+        ]:
+            with self.subTest(command=command):
+                self.assert_blocked(command, "rm-recursive-force")
+
+    def test_allows_non_forced_or_non_recursive_rm(self) -> None:
+        for command in ["rm file.txt", "rm -r build", "rm -f file.txt"]:
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+    def test_blocks_force_push_but_allows_force_with_lease(self) -> None:
+        self.assert_blocked("git push --force origin main", "git-push-force")
+        self.assert_blocked("git push -f origin main", "git-push-force")
+        self.assert_allowed("git push --force-with-lease origin main")
+
+    def test_blocks_destructive_sql(self) -> None:
+        self.assert_blocked("DROP TABLE users", "drop-table")
+        self.assert_blocked('psql -c "DROP TABLE users"', "drop-table")
+        self.assert_blocked('mysql -e "TRUNCATE TABLE audit_log"', "truncate")
+        self.assert_blocked('sqlite3 app.db "DELETE FROM sessions;"', "delete-without-where")
+
+    def test_allows_delete_with_where(self) -> None:
+        self.assert_allowed('psql -c "DELETE FROM users WHERE id = 42;"')
+        self.assert_allowed('echo "DROP TABLE users"')
+
+    def test_hook_returns_deny_json_and_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            hook_input = {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "cwd": "/tmp/project",
+                "tool_input": {"command": "rm -rf build"},
+            }
+            result = subprocess.run(
+                [sys.executable, str(HOOK_PATH)],
+                input=json.dumps(hook_input),
+                text=True,
+                capture_output=True,
+                env={"HOME": home},
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            payload = json.loads(result.stdout)
+            output = payload["hookSpecificOutput"]
+            self.assertEqual(output["hookEventName"], "PreToolUse")
+            self.assertEqual(output["permissionDecision"], "deny")
+            self.assertIn("recursive and force", output["permissionDecisionReason"])
+
+            log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
+            log_entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+            self.assertEqual(log_entry["attempted_command"], "rm -rf build")
+            self.assertEqual(log_entry["project_path"], "/tmp/project")
+            self.assertEqual(log_entry["rule"], "rm-recursive-force")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3.

## Summary

- Adds a Claude Code `PreToolUse` Bash hook that denies destructive commands using the current `hookSpecificOutput.permissionDecision` format.
- Blocks `rm -rf` variants, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without `WHERE`, and `git push --force` / `-f`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, rule, and reason.
- Adds a two-command installation flow and a small installer that registers the hook in `~/.claude/settings.json`.
- Includes unit coverage for blocked commands, allowed safe variants, JSON deny output, and logging.

## Validation

```bash
python3 -m unittest tests/test_destructive_bash_guard.py
PYTHONPYCACHEPREFIX=/tmp/destructive_bash_guard_pycache python3 -m compileall -q hooks/destructive_bash_guard tests
```