### PR TITLE
Add PreToolUse hook to block destructive bash commands

### DIFF
--- a/submissions/destructive-bash-hook/.claude/hooks/block_destructive_bash.py
+++ b/submissions/destructive-bash-hook/.claude/hooks/block_destructive_bash.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCK_RULES = [
+    (
+        "recursive force delete",
+        re.compile(r"(^|[\s;&|()])rm\s+-(?=[A-Za-z-]*r)(?=[A-Za-z-]*f)[A-Za-z-]*\b", re.I),
+        "Refusing to run recursive force deletion. Review the target path and delete manually if intentional.",
+    ),
+    (
+        "drop table",
+        re.compile(r"\bDROP\s+TABLE\b", re.I),
+        "Refusing to run DROP TABLE from an automated tool call.",
+    ),
+    (
+        "truncate",
+        re.compile(r"\bTRUNCATE(?:\s+TABLE)?\b", re.I),
+        "Refusing to run TRUNCATE from an automated tool call.",
+    ),
+    (
+        "force push",
+        re.compile(r"\bgit\s+push\b[^\n;&|]*?(?:--force(?:\b|=)|\s-f(?:\s|$))", re.I),
+        "Refusing to run a force push from an automated tool call.",
+    ),
+]
+
+DELETE_FROM_RE = re.compile(r"\bDELETE\s+FROM\b", re.I)
+WHERE_RE = re.compile(r"\bWHERE\b", re.I)
+
+
+def read_event() -> dict[str, Any]:
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def extract_command(event: dict[str, Any]) -> str:
+    tool_input = event.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd", "script"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+
+    command = event.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def project_path(event: dict[str, Any]) -> str:
+    cwd = event.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        return cwd
+
+    tool_input = event.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("cwd", "workdir", "working_directory"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+
+    return os.getcwd()
+
+
+def delete_without_where(command: str) -> bool:
+    statements = re.split(r";|\n", command)
+    for statement in statements:
+        if DELETE_FROM_RE.search(statement) and not WHERE_RE.search(statement):
+            return True
+    return False
+
+
+def blocked_reason(command: str) -> str | None:
+    for _name, pattern, reason in BLOCK_RULES:
+        if pattern.search(command):
+            return reason
+
+    if delete_without_where(command):
+        return "Refusing to run DELETE FROM without a WHERE clause."
+
+    return None
+
+
+def append_block_log(command: str, project: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    entry = {
+        "timestamp": timestamp,
+        "project_path": project,
+        "reason": reason,
+        "command": command,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def deny(reason: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        },
+    }))
+
+
+def main() -> int:
+    event = read_event()
+    command = extract_command(event)
+
+    if not command:
+        return 0
+
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    append_block_log(command, project_path(event), reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/submissions/destructive-bash-hook/.claude/settings.json
+++ b/submissions/destructive-bash-hook/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/submissions/destructive-bash-hook/.gitignore
+++ b/submissions/destructive-bash-hook/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/submissions/destructive-bash-hook/README.md
+++ b/submissions/destructive-bash-hook/README.md
@@ -1,0 +1,93 @@
+# Claude Code Destructive Bash Guard
+
+PreToolUse hook for Claude Code that blocks destructive bash commands before they run.
+
+## Blocks
+
+- `rm -rf` and `rm -fr`
+- `DROP TABLE`
+- `TRUNCATE` / `TRUNCATE TABLE`
+- `git push --force` and `git push -f`
+- `DELETE FROM ...` without a `WHERE` clause
+
+Every blocked attempt is logged to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each log line is JSON with:
+
+- `timestamp`
+- `project_path`
+- `reason`
+- `command`
+
+## Install
+
+From your project root:
+
+```bash
+mkdir -p .claude/hooks
+cp block_destructive_bash.py .claude/hooks/block_destructive_bash.py
+chmod +x .claude/hooks/block_destructive_bash.py
+```
+
+Add this to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Safe Example
+
+```bash
+npm test
+```
+
+Allowed. No output from the hook.
+
+## Blocked Example
+
+```bash
+rm -rf ./dist
+```
+
+Denied with a clear reason:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Refusing to run recursive force deletion. Review the target path and delete manually if intentional."
+  }
+}
+```
+
+## Test
+
+```bash
+python -m unittest discover tests
+```
+
+or:
+
+```bash
+python -m pytest tests
+```
+

--- a/submissions/destructive-bash-hook/tests/test_block_destructive_bash.py
+++ b/submissions/destructive-bash-hook/tests/test_block_destructive_bash.py
@@ -1,0 +1,81 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / ".claude" / "hooks" / "block_destructive_bash.py"
+
+spec = importlib.util.spec_from_file_location("hook", HOOK)
+hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook)
+
+
+class BlockDestructiveBashTest(unittest.TestCase):
+    def test_blocks_required_patterns(self):
+        blocked = [
+            "rm -rf /tmp/build",
+            "rm -fr node_modules",
+            "psql -c 'DROP TABLE users'",
+            "mysql -e 'TRUNCATE sessions'",
+            "git push --force origin main",
+            "sqlite3 app.db 'DELETE FROM users'",
+        ]
+
+        for command in blocked:
+            with self.subTest(command=command):
+                self.assertTrue(hook.blocked_reason(command))
+
+    def test_allows_normal_commands_and_scoped_delete(self):
+        allowed = [
+            "npm test",
+            "rm -r ./dist",
+            "git push origin main",
+            "sqlite3 app.db 'DELETE FROM users WHERE id = 1'",
+        ]
+
+        for command in allowed:
+            with self.subTest(command=command):
+                self.assertIsNone(hook.blocked_reason(command))
+
+    def test_hook_denies_and_logs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env["USERPROFILE"] = tmp
+            env["HOME"] = tmp
+
+            event = {
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf ./dist"},
+                "cwd": str(ROOT),
+            }
+
+            result = subprocess.run(
+                [sys.executable, str(HOOK)],
+                input=json.dumps(event),
+                text=True,
+                capture_output=True,
+                check=True,
+                env=env,
+            )
+
+            output = json.loads(result.stdout)
+            self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+            self.assertIn(
+                "recursive force deletion",
+                output["hookSpecificOutput"]["permissionDecisionReason"],
+            )
+
+            log = Path(tmp) / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log.exists())
+            self.assertIn("rm -rf ./dist", log.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## What changed

- Added a Python Claude Code `PreToolUse` hook for Bash commands.
- Blocks the required destructive patterns:
  - `rm -rf` / `rm -fr`
  - `DROP TABLE`
  - `TRUNCATE`
  - `git push --force` / `git push -f`
  - `DELETE FROM` without `WHERE`
- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
- Returns a Claude Code deny decision with a clear explanation.
- Added install docs, safe/blocked examples, and tests.

## Verification

- `python -m unittest discover tests`