### PR TITLE
Add changelog generator script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 2026-05-13
+
+Generated for `claude-builders-bounty` from repository history.
+
+### Added
+
+- feat: initial README with bounty board (`1aeae2a`)
+
+### Fixed
+
+_No entries._
+
+### Changed
+
+- Initial commit (`a80a580`)
+
+### Removed
+
+_No entries._

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 > A community bounty board for Claude Code builders.
 
+## Generate a changelog
+
+This repository includes a small Bash tool for generating a structured
+`CHANGELOG.md` from git history.
+
+1. Run `bash changelog.sh` or `python generate_changelog.py` from any git repository.
+2. Review the generated `CHANGELOG.md`.
+3. Commit the changelog when it looks right.
+
+The script finds the latest git tag and reads commits after that tag. If the
+repository has no tags, it uses the full commit history. Commits are grouped
+into `Added`, `Fixed`, `Changed`, and `Removed` using common Conventional Commit
+prefixes and simple keyword matching.
+
+Example output:
+
+```md
+# Changelog
+
+## 2026-05-13
+
+Generated for `example-project` since v1.2.0.
+
+### Added
+
+- feat: add export command (`abc1234`)
+
+### Fixed
+
+- fix: handle missing config file (`def5678`)
+
+### Changed
+
+- docs: update setup guide (`999aaaa`)
+
+### Removed
+
+_No entries._
+```
+
 Building with Claude Code? Have tasks to delegate?
 Want to get paid for contributing to AI projects?
 You're in the right place.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FILE="${1:-CHANGELOG.md}"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$(dirname "$0")/generate_changelog.py" "$OUTPUT_FILE"
+fi
+
+if command -v python >/dev/null 2>&1; then
+  exec python "$(dirname "$0")/generate_changelog.py" "$OUTPUT_FILE"
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+if [ -n "$latest_tag" ]; then
+  range="${latest_tag}..HEAD"
+  range_label="since ${latest_tag}"
+else
+  range="HEAD"
+  range_label="from repository history"
+fi
+
+repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+today="$(date +%Y-%m-%d)"
+
+commit_lines="$(git log "$range" --no-merges --pretty=format:'%s%x09%h' 2>/dev/null || true)"
+
+if [ -z "$commit_lines" ]; then
+  {
+    echo "# Changelog"
+    echo
+    echo "## ${today}"
+    echo
+    echo "_No commits found ${range_label}._"
+  } > "$OUTPUT_FILE"
+  echo "Wrote ${OUTPUT_FILE}"
+  exit 0
+fi
+
+added_file="$(mktemp)"
+fixed_file="$(mktemp)"
+changed_file="$(mktemp)"
+removed_file="$(mktemp)"
+trap 'rm -f "$added_file" "$fixed_file" "$changed_file" "$removed_file"' EXIT
+
+append_commit() {
+  local subject="$1"
+  local hash="$2"
+  local bucket="$changed_file"
+  local normalized
+  normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$normalized" in
+    feat:*|feature:*|add:*|added:*|*' add '*|*' adds '*|*' introduce '*|*' introduces '*')
+      bucket="$added_file"
+      ;;
+    fix:*|bugfix:*|hotfix:*|*' fix '*|*' fixes '*|*' bug '*|*' repair '*')
+      bucket="$fixed_file"
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|*' remove '*|*' removes '*|*' delete '*|*' deletes '*')
+      bucket="$removed_file"
+      ;;
+    refactor:*|change:*|changed:*|update:*|updated:*|perf:*|docs:*|style:*|test:*|chore:*)
+      bucket="$changed_file"
+      ;;
+  esac
+
+  printf -- '- %s (`%s`)\n' "$subject" "$hash" >> "$bucket"
+}
+
+while IFS=$'\t' read -r subject hash; do
+  [ -n "$subject" ] || continue
+  append_commit "$subject" "$hash"
+done <<EOF
+$commit_lines
+EOF
+
+write_section() {
+  local title="$1"
+  local file="$2"
+  echo "### ${title}"
+  echo
+  if [ -s "$file" ]; then
+    cat "$file"
+  else
+    echo "_No entries._"
+  fi
+  echo
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "## ${today}"
+  echo
+  echo "Generated for \`${repo_name}\` ${range_label}."
+  echo
+  write_section "Added" "$added_file"
+  write_section "Fixed" "$fixed_file"
+  write_section "Changed" "$changed_file"
+  write_section "Removed" "$removed_file"
+} > "$OUTPUT_FILE"
+
+echo "Wrote ${OUTPUT_FILE}"

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import pathlib
+import subprocess
+import sys
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def category(subject: str) -> str:
+    normalized = subject.lower()
+    if normalized.startswith(("feat:", "feature:", "add:", "added:")):
+        return "Added"
+    if normalized.startswith(("fix:", "bugfix:", "hotfix:")):
+        return "Fixed"
+    if normalized.startswith(("remove:", "removed:", "delete:", "deleted:", "drop:")):
+        return "Removed"
+    if any(token in normalized for token in (" add ", " adds ", " introduce ", " introduces ")):
+        return "Added"
+    if any(token in normalized for token in (" fix ", " fixes ", " bug ", " repair ")):
+        return "Fixed"
+    if any(token in normalized for token in (" remove ", " removes ", " delete ", " deletes ")):
+        return "Removed"
+    return "Changed"
+
+
+def collect_commits() -> tuple[str, list[tuple[str, str]]]:
+    latest_tag = git("describe", "--tags", "--abbrev=0")
+    if latest_tag:
+        commit_range = f"{latest_tag}..HEAD"
+        label = f"since {latest_tag}"
+    else:
+        commit_range = "HEAD"
+        label = "from repository history"
+
+    raw = git("log", commit_range, "--no-merges", "--pretty=format:%s%x09%h")
+    commits: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        if "\t" in line:
+            subject, short_hash = line.rsplit("\t", 1)
+        else:
+            subject, short_hash = line, ""
+        commits.append((subject.strip(), short_hash.strip()))
+    return label, commits
+
+
+def render(output_path: pathlib.Path, range_label: str, commits: list[tuple[str, str]]) -> str:
+    repo_root = pathlib.Path(git("rev-parse", "--show-toplevel") or ".")
+    repo_name = repo_root.name
+    today = dt.date.today().isoformat()
+    buckets = {"Added": [], "Fixed": [], "Changed": [], "Removed": []}
+
+    for subject, short_hash in commits:
+        entry = f"- {subject}"
+        if short_hash:
+            entry += f" (`{short_hash}`)"
+        buckets[category(subject)].append(entry)
+
+    lines = [
+        "# Changelog",
+        "",
+        f"## {today}",
+        "",
+        f"Generated for `{repo_name}` {range_label}.",
+        "",
+    ]
+
+    if not commits:
+        lines.append(f"_No commits found {range_label}._")
+        lines.append("")
+        return "\n".join(lines)
+
+    for heading in ("Added", "Fixed", "Changed", "Removed"):
+        lines.extend([f"### {heading}", ""])
+        lines.extend(buckets[heading] or ["_No entries._"])
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git history.")
+    parser.add_argument("output", nargs="?", default="CHANGELOG.md", help="Output file path")
+    args = parser.parse_args()
+
+    if not git("rev-parse", "--is-inside-work-tree"):
+        print("error: generate_changelog.py must be run inside a git repository", file=sys.stderr)
+        return 1
+
+    output_path = pathlib.Path(args.output)
+    range_label, commits = collect_commits()
+    output_path.write_text(render(output_path, range_label, commits), encoding="utf-8")
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a changelog generator that can be run with either:

- `bash changelog.sh`
- `python generate_changelog.py`

The tool detects the latest git tag, collects commits since that tag, categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`, and writes a formatted `CHANGELOG.md`.

## Test

Tested on this repository:

```bash
python generate_changelog.py
```

Sample generated output is included in `CHANGELOG.md`.

## Acceptance criteria

- [x] Works via `bash changelog.sh`
- [x] Fetches commits since the last git tag, or all history if no tag exists
- [x] Auto-categorizes into `Added` / `Fixed` / `Changed` / `Removed`
- [x] Outputs a properly formatted `CHANGELOG.md`
- [x] Tested on a real GitHub repo with sample output included
- [x] README includes setup instructions in 3 steps
