### PR TITLE
Add changelog generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Create a structured `CHANGELOG.md` from commits since the latest git tag:
 3. Commit the changelog when it looks right.
 
 The script categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+It supports conventional commit scopes like `feat(auth): add OAuth login`, ignores merge
+commits, and falls back to all commits when no git tag exists. `SKILL.md` is included for
+Claude Code users who prefer a skill-based workflow.
 
 Sample output from the test repository:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,46 @@ You're in the right place.
 
 ---
 
+## Generate a Changelog
+
+Create a structured `CHANGELOG.md` from commits since the latest git tag:
+
+1. Run `bash changelog.sh` from the repository root.
+2. Review the generated `CHANGELOG.md`.
+3. Commit the changelog when it looks right.
+
+The script categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+
+Sample output from the test repository:
+
+```markdown
+# Changelog
+
+Changes since `v1.0.0`.
+
+## Unreleased
+
+### Added
+
+- add OAuth login
+
+### Fixed
+
+- handle empty changelog
+
+### Changed
+
+- clarify setup instructions
+
+### Removed
+
+- remove deprecated API
+```
+
+Run the test with `bash tests/test_changelog.sh`.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history using the bundled changelog.sh script. Use when a user asks to create release notes or a changelog from commits since the latest git tag.
+---
+
+# Generate Changelog
+
+Use `changelog.sh` from the repository root to create a categorized `CHANGELOG.md`.
+
+## Workflow
+
+1. Confirm the current directory is a git repository.
+2. Run `bash changelog.sh` to write `CHANGELOG.md`, or pass a custom output path such as `bash changelog.sh RELEASE_NOTES.md`.
+3. Review the generated sections and commit the result.
+
+## Behavior
+
+- Reads commits since the latest git tag.
+- Falls back to all commits when no tag exists.
+- Ignores merge commits.
+- Categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Supports conventional commit scopes such as `feat(auth): add OAuth login`.
+
+## Validation
+
+Run:
+
+```bash
+bash tests/test_changelog.sh
+```

--- a/changelog.sh
+++ b/changelog.sh
@@ -24,8 +24,7 @@ declare -a removed=()
 
 clean_subject() {
   local subject="$1"
-  subject="${subject#*: }"
-  subject="${subject#*:}"
+  subject="$(printf '%s\n' "$subject" | sed -E 's/^[[:alnum:]_-]+(\([^)]+\))?!?:[[:space:]]*//')"
   subject="${subject#- }"
   printf '%s\n' "$subject"
 }
@@ -49,9 +48,9 @@ while IFS= read -r subject; do
 
   normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
   case "$normalized" in
-    feat:*|feature:*|add:*|added:*|add\ *) append_item added "$subject" ;;
-    fix:*|fixed:*|bugfix:*|bug:*|repair:*|fix\ *) append_item fixed "$subject" ;;
-    remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*|remove\ *) append_item removed "$subject" ;;
+    feat:*|feat\(*|feature:*|feature\(*|add:*|added:*|add\ *) append_item added "$subject" ;;
+    fix:*|fix\(*|fixed:*|bugfix:*|bugfix\(*|bug:*|repair:*|fix\ *) append_item fixed "$subject" ;;
+    remove:*|remove\(*|removed:*|delete:*|delete\(*|deleted:*|drop:*|drop\(*|dropped:*|remove\ *) append_item removed "$subject" ;;
     *) append_item changed "$subject" ;;
   esac
 done <<< "$commit_lines"

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FILE="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+else
+  range="HEAD"
+fi
+
+commit_lines="$(git log "$range" --pretty=format:'%s' --no-merges)"
+
+declare -a added=()
+declare -a fixed=()
+declare -a changed=()
+declare -a removed=()
+
+clean_subject() {
+  local subject="$1"
+  subject="${subject#*: }"
+  subject="${subject#*:}"
+  subject="${subject#- }"
+  printf '%s\n' "$subject"
+}
+
+append_item() {
+  local category="$1"
+  local subject="$2"
+  local cleaned
+
+  cleaned="$(clean_subject "$subject")"
+  case "$category" in
+    added) added+=("$cleaned") ;;
+    fixed) fixed+=("$cleaned") ;;
+    changed) changed+=("$cleaned") ;;
+    removed) removed+=("$cleaned") ;;
+  esac
+}
+
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+
+  normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  case "$normalized" in
+    feat:*|feature:*|add:*|added:*|add\ *) append_item added "$subject" ;;
+    fix:*|fixed:*|bugfix:*|bug:*|repair:*|fix\ *) append_item fixed "$subject" ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*|remove\ *) append_item removed "$subject" ;;
+    *) append_item changed "$subject" ;;
+  esac
+done <<< "$commit_lines"
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  [[ "${#items[@]}" -eq 0 ]] && return
+
+  printf '### %s\n\n' "$title"
+  for item in "${items[@]}"; do
+    printf -- '- %s\n' "$item"
+  done
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  if [[ -n "$latest_tag" ]]; then
+    printf 'Changes since `%s`.\n\n' "$latest_tag"
+  else
+    printf 'Changes from all commits.\n\n'
+  fi
+  printf '## Unreleased\n\n'
+
+  if [[ -z "$commit_lines" ]]; then
+    printf 'No changes found.\n'
+  else
+    write_section "Added" "${added[@]}"
+    write_section "Fixed" "${fixed[@]}"
+    write_section "Changed" "${changed[@]}"
+    write_section "Removed" "${removed[@]}"
+  fi
+} > "$OUTPUT_FILE"
+
+echo "Wrote $OUTPUT_FILE"

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "Expected to find: $expected" >&2
+    echo "--- $file ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+cd "$WORK_DIR"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+echo "initial" > app.txt
+git add app.txt
+git commit -q -m "chore: initial release"
+git tag v1.0.0
+
+echo "feature" >> app.txt
+git add app.txt
+git commit -q -m "feat: add OAuth login"
+
+echo "fix" >> app.txt
+git add app.txt
+git commit -q -m "fix: handle empty changelog"
+
+echo "docs" >> app.txt
+git add app.txt
+git commit -q -m "docs: clarify setup instructions"
+
+echo "remove" >> app.txt
+git add app.txt
+git commit -q -m "remove deprecated API"
+
+"$ROOT_DIR/changelog.sh"
+
+assert_contains CHANGELOG.md "## Unreleased"
+assert_contains CHANGELOG.md "### Added"
+assert_contains CHANGELOG.md "- add OAuth login"
+assert_contains CHANGELOG.md "### Fixed"
+assert_contains CHANGELOG.md "- handle empty changelog"
+assert_contains CHANGELOG.md "### Changed"
+assert_contains CHANGELOG.md "- clarify setup instructions"
+assert_contains CHANGELOG.md "### Removed"
+assert_contains CHANGELOG.md "- remove deprecated API"
+
+echo "changelog generation test passed"

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -29,7 +29,7 @@ git tag v1.0.0
 
 echo "feature" >> app.txt
 git add app.txt
-git commit -q -m "feat: add OAuth login"
+git commit -q -m "feat(auth): add OAuth login"
 
 echo "fix" >> app.txt
 git add app.txt
@@ -54,5 +54,21 @@ assert_contains CHANGELOG.md "### Changed"
 assert_contains CHANGELOG.md "- clarify setup instructions"
 assert_contains CHANGELOG.md "### Removed"
 assert_contains CHANGELOG.md "- remove deprecated API"
+
+NO_TAG_DIR="$(mktemp -d)"
+cd "$NO_TAG_DIR"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+echo "first" > app.txt
+git add app.txt
+git commit -q -m "add first public command"
+
+"$ROOT_DIR/changelog.sh" RELEASE_NOTES.md
+
+assert_contains RELEASE_NOTES.md "Changes from all commits."
+assert_contains RELEASE_NOTES.md "### Added"
+assert_contains RELEASE_NOTES.md "- add first public command"
 
 echo "changelog generation test passed"


### PR DESCRIPTION
## Summary
- Add `changelog.sh` to generate `CHANGELOG.md` from commits since the latest git tag
- Categorize commit subjects into Added, Fixed, Changed, and Removed
- Document usage in three steps and include sample output
- Add a shell test that creates a real git repo, tags it, generates a changelog, and verifies the sections

## Validation
- `bash tests/test_changelog.sh`
