### PR TITLE
[BOUNTY #3] Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,50 @@
+# Empire Shield Hook — Block Destructive Bash Commands
+
+**Bounty:** #3 — $100 (Opire)
+
+A Claude Code **pre-tool-use** hook that intercepts and blocks destructive bash commands before execution.
+
+## Installation
+
+### 1-Click Install
+```bash
+mkdir -p ~/.claude/hooks && curl -L https://raw.githubusercontent.com/jiezishu000/claude-builders-bounty/solution/hook-block-destructive/hooks/pre-tool-use -o ~/.claude/hooks/pre-tool-use && chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+### Configure
+Add to your `~/.claude/settings.json`:
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "~/.claude/hooks/pre-tool-use" }] }
+    ]
+  }
+}
+```
+
+Done. Only 2 steps.
+
+## Blocked Patterns
+
+| Command | Example |
+|---|---|
+| `rm -rf` | `rm -rf /project` |
+| `rm -r` | `rm -r src/` |
+| `DROP TABLE` | `DROP TABLE users` |
+| `TRUNCATE` | `TRUNCATE orders` |
+| `DELETE FROM` (no WHERE) | `DELETE FROM users` |
+| `git push --force` | `git push origin main --force` |
+| `git reset --hard` | `git reset --hard HEAD~3` |
+
+## Logging
+All blocked commands logged to `~/.claude/hooks/blocked.log`:
+```
+2026-05-14T12:30:00Z | BLOCKED | Bash | rm -rf /important | /home/user/project
+```
+
+## Testing
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /test"}}' | bash hooks/pre-tool-use
+# => {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"SECURITY: ..."}}
+```

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# ============================================================================
+# pre-tool-use — Claude Code hook that blocks destructive bash commands
+# Part of claude-builders-bounty issue #3 ($100 bounty)
+# ============================================================================
+# Installation: copy this file to ~/.claude/hooks/pre-tool-use && chmod +x
+# ============================================================================
+
+set -euo pipefail
+
+LOG_FILE="$HOME/.claude/hooks/blocked.log"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---------- helper: read JSON field ----------
+read_json() {
+    python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+keys = '$1'.split('.')
+val = data
+for k in keys:
+    if isinstance(val, dict):
+        val = val.get(k, '')
+    else:
+        val = ''
+        break
+print(val)
+"
+}
+
+# ---------- helper: deny response ----------
+deny() {
+    local reason="$1"
+    # Log blocked attempt
+    echo "$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) | BLOCKED | $TOOL_NAME | $COMMAND | $(pwd)" >> "$LOG_FILE"
+    cat <<JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "SECURITY: Command blocked by Empire Shield hook. Reason: $reason"
+  }
+}
+JSON
+    exit 0
+}
+
+# ---------- helper: allow response ----------
+allow() {
+    cat <<JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+JSON
+    exit 0
+}
+
+# ---------- main ----------
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | read_json "tool_name")
+COMMAND=$(echo "$INPUT" | read_json "tool_input.command")
+SESSION_ID=$(echo "$INPUT" | read_json "session_id")
+
+# Only intercept Bash tool calls
+if [ "$TOOL_NAME" != "Bash" ]; then
+    allow
+fi
+
+# Normalize command for pattern matching
+CMD_LOWER=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
+CMD_STRIPPED=$(echo "$CMD_LOWER" | sed 's/^[[:space:]]*//')
+
+# ---------- pattern checks ----------
+# Pattern 1: rm -rf (recursive force remove)
+if echo "$CMD_STRIPPED" | grep -Eq '^rm[[:space:]]+(-rf|-(.-)*r(.-)*f|-(.-)*f(.-)*r)[[:space:]]'; then
+    deny "rm -rf is blocked. Use 'rm -r' with confirmation or move files to trash instead."
+fi
+
+# Pattern 2: DROP TABLE (database destruction)
+if echo "$CMD_STRIPPED" | grep -Eq '(^|[;&|])[[:space:]]*drop[[:space:]]+table'; then
+    deny "DROP TABLE is blocked. Use 'DROP TABLE IF EXISTS' only after backing up."
+fi
+
+# Pattern 3: git push --force (destructive git)
+if echo "$CMD_STRIPPED" | grep -Eq 'git[[:space:]].*push[[:space:]].*--force'; then
+    deny "git push --force is blocked. Use 'git push --force-with-lease' instead."
+fi
+
+# Pattern 4: TRUNCATE (table destruction)
+if echo "$CMD_STRIPPED" | grep -Eq '(^|[;&|])[[:space:]]*truncate[[:space:]]'; then
+    deny "TRUNCATE is blocked. Use DELETE with a WHERE clause after backing up."
+fi
+
+# Pattern 5: DELETE FROM without WHERE clause (data loss)
+# Require WHERE when using DELETE FROM
+if echo "$CMD_STRIPPED" | grep -Eq '(^|[;&|])[[:space:]]*delete[[:space:]]+from'; then
+    if ! echo "$CMD_STRIPPED" | grep -qi 'where[[:space:]]'; then
+        deny "DELETE FROM without WHERE clause is blocked. Add a WHERE clause to limit the scope."
+    fi
+fi
+
+# Pattern 6: rm -r (recursive remove without -f, still dangerous)
+if echo "$CMD_STRIPPED" | grep -Eq '^rm[[:space:]]+(-r|--recursive)[[:space:]]'; then
+    deny "rm -r is blocked without confirmation. Use a safer deletion method."
+fi
+
+# Pattern 7: git reset --hard
+if echo "$CMD_STRIPPED" | grep -Eq 'git[[:space:]].*reset[[:space:]].*--hard'; then
+    deny "git reset --hard is blocked. Use 'git reset --soft' or 'git stash' instead."
+fi
+
+# If no patterns matched, allow
+allow

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -3,15 +3,13 @@
 # pre-tool-use — Claude Code hook that blocks destructive bash commands
 # Part of claude-builders-bounty issue #3 ($100 bounty)
 # ============================================================================
-# Installation: copy this file to ~/.claude/hooks/pre-tool-use && chmod +x
-# ============================================================================
 
 set -euo pipefail
 
 LOG_FILE="$HOME/.claude/hooks/blocked.log"
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# ---------- helper: read JSON field ----------
+# ---------- JSON field reader ----------
 read_json() {
     python3 -c "
 import sys, json
@@ -28,11 +26,10 @@ print(val)
 "
 }
 
-# ---------- helper: deny response ----------
+# ---------- deny: block and log ----------
 deny() {
     local reason="$1"
-    # Log blocked attempt
-    echo "$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) | BLOCKED | $TOOL_NAME | $COMMAND | $(pwd)" >> "$LOG_FILE"
+    echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') | BLOCKED | $TOOL_NAME | $COMMAND | $(pwd)" >> "$LOG_FILE"
     cat <<JSON
 {
   "hookSpecificOutput": {
@@ -45,7 +42,7 @@ JSON
     exit 0
 }
 
-# ---------- helper: allow response ----------
+# ---------- allow: let it pass ----------
 allow() {
     cat <<JSON
 {
@@ -63,20 +60,18 @@ INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | read_json "tool_name")
 COMMAND=$(echo "$INPUT" | read_json "tool_input.command")
-SESSION_ID=$(echo "$INPUT" | read_json "session_id")
 
 # Only intercept Bash tool calls
 if [ "$TOOL_NAME" != "Bash" ]; then
     allow
 fi
 
-# Normalize command for pattern matching
+# Normalize command
 CMD_LOWER=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
 CMD_STRIPPED=$(echo "$CMD_LOWER" | sed 's/^[[:space:]]*//')
 
-# ---------- pattern checks ----------
 # Pattern 1: rm -rf (recursive force remove)
-if echo "$CMD_STRIPPED" | grep -Eq '^rm[[:space:]]+(-rf|-(.-)*r(.-)*f|-(.-)*f(.-)*r)[[:space:]]'; then
+if echo "$CMD_STRIPPED" | grep -Eq '^rm[[:space:]]+(-rf|-(.[r])*(.[f])*f|-(.[f])*(.[r])*r)[[:space:]]'; then
     deny "rm -rf is blocked. Use 'rm -r' with confirmation or move files to trash instead."
 fi
 
@@ -85,27 +80,26 @@ if echo "$CMD_STRIPPED" | grep -Eq '(^|[;&|])[[:space:]]*drop[[:space:]]+table';
     deny "DROP TABLE is blocked. Use 'DROP TABLE IF EXISTS' only after backing up."
 fi
 
-# Pattern 3: git push --force (destructive git)
+# Pattern 3: git push --force (force push)
 if echo "$CMD_STRIPPED" | grep -Eq 'git[[:space:]].*push[[:space:]].*--force'; then
     deny "git push --force is blocked. Use 'git push --force-with-lease' instead."
 fi
 
-# Pattern 4: TRUNCATE (table destruction)
+# Pattern 4: TRUNCATE (table data wipe)
 if echo "$CMD_STRIPPED" | grep -Eq '(^|[;&|])[[:space:]]*truncate[[:space:]]'; then
     deny "TRUNCATE is blocked. Use DELETE with a WHERE clause after backing up."
 fi
 
-# Pattern 5: DELETE FROM without WHERE clause (data loss)
-# Require WHERE when using DELETE FROM
+# Pattern 5: DELETE FROM without WHERE clause
 if echo "$CMD_STRIPPED" | grep -Eq '(^|[;&|])[[:space:]]*delete[[:space:]]+from'; then
     if ! echo "$CMD_STRIPPED" | grep -qi 'where[[:space:]]'; then
-        deny "DELETE FROM without WHERE clause is blocked. Add a WHERE clause to limit the scope."
+        deny "DELETE FROM without WHERE clause is blocked. Add a WHERE clause."
     fi
 fi
 
-# Pattern 6: rm -r (recursive remove without -f, still dangerous)
+# Pattern 6: rm -r (recursive remove without -f)
 if echo "$CMD_STRIPPED" | grep -Eq '^rm[[:space:]]+(-r|--recursive)[[:space:]]'; then
-    deny "rm -r is blocked without confirmation. Use a safer deletion method."
+    deny "rm -r blocked without confirmation. Use a safer deletion method."
 fi
 
 # Pattern 7: git reset --hard
@@ -113,5 +107,5 @@ if echo "$CMD_STRIPPED" | grep -Eq 'git[[:space:]].*reset[[:space:]].*--hard'; t
     deny "git reset --hard is blocked. Use 'git reset --soft' or 'git stash' instead."
 fi
 
-# If no patterns matched, allow
+# Allow safe commands
 allow


### PR DESCRIPTION
## Summary
This PR implements a `pre-tool-use` hook for Claude Code that blocks destructive bash commands before they execute.

## What was done
- Created `hooks/pre-tool-use` — Bash script hook following Claude Code hooks specification
- Created `hooks/README.md` — Installation and usage documentation
- Blocks 7 dangerous patterns
- Logs all blocked attempts to `~/.claude/hooks/blocked.log`

## Acceptance Criteria Checklist
- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, project path
- [x] Displays clear message explaining why command was blocked
- [x] Does not interfere with normal bash commands (ls, cd, git add, etc.)
- [x] README with installation in 2 commands or fewer

## Blocked Patterns
| Pattern | Example |
|---|---|
| `rm -rf` | `rm -rf /project` |
| `rm -r` | `rm -r src/` |
| `DROP TABLE` | `DROP TABLE users` |
| `TRUNCATE` | `TRUNCATE orders` |
| `DELETE FROM` (no WHERE) | `DELETE FROM users` |
| `git push --force` | `git push origin main --force` |
| `git reset --hard` | `git reset --hard HEAD~3` |

Closes #3
