### PR TITLE
feat: add bash changelog generator

### DIFF
--- a/CHANGELOG.sample.md
+++ b/CHANGELOG.sample.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Generated on 2026-05-14 from repository history.
+
+## Added
+
+- feat: initial README with bounty board (1aeae2a, 2026-03-27)
+
+## Fixed
+
+- No entries.
+
+## Changed
+
+- No entries.
+
+## Removed
+
+- No entries.
+

--- a/README-changelog-generator.md
+++ b/README-changelog-generator.md
@@ -1,0 +1,17 @@
+# Changelog generator
+
+A small Bash utility that creates a structured `CHANGELOG.md` from git history since the latest tag.
+
+## Setup and usage in 3 steps
+
+1. Copy `changelog.sh` into any git repository and make it executable:
+   ```bash
+   chmod +x changelog.sh
+   ```
+2. Run it from the repository root:
+   ```bash
+   ./changelog.sh
+   ```
+3. Review and commit the generated `CHANGELOG.md`.
+
+The script detects the latest git tag with `git describe --tags --abbrev=0`. If no tag exists, it uses the full repository history. Commits are grouped into `Added`, `Fixed`, `Changed`, and `Removed` using common Conventional Commit prefixes and fallback keyword matching.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_FILE="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+last_tag=""
+if last_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+  range="${last_tag}..HEAD"
+  since_label="since ${last_tag}"
+else
+  range="HEAD"
+  since_label="from repository history"
+fi
+
+mapfile -t commits < <(git log --no-merges --date=short --pretty=format:'%h%x09%ad%x09%s' "$range")
+
+declare -a added fixed changed removed
+
+add_item() {
+  local bucket="$1" item="$2"
+  case "$bucket" in
+    added) added+=("$item") ;;
+    fixed) fixed+=("$item") ;;
+    changed) changed+=("$item") ;;
+    removed) removed+=("$item") ;;
+  esac
+}
+
+categorize() {
+  local subject_lc
+  subject_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$subject_lc" in
+    feat:*|feature:*|add:*|added:*|*' add '*|*' adds '*|*' introduce '*|*' introduces '*) echo added ;;
+    fix:*|bugfix:*|hotfix:*|*' fix '*|*' fixes '*|*' fixed '*|*' bug '*|*' patch '*) echo fixed ;;
+    remove:*|removed:*|delete:*|deleted:*|deprecate:*|*' remove '*|*' removes '*|*' deleted '*|*' drop '*|*' drops '*) echo removed ;;
+    refactor:*|perf:*|docs:*|style:*|test:*|chore:*|ci:*|build:*|change:*|changed:*|update:*|updated:*|*' update '*|*' updates '*|*' change '*|*' changes '*) echo changed ;;
+    *) echo changed ;;
+  esac
+}
+
+for row in "${commits[@]}"; do
+  IFS=$'\t' read -r hash date subject <<< "$row"
+  bucket=$(categorize "$subject")
+  add_item "$bucket" "- ${subject} (${hash}, ${date})"
+done
+
+{
+  echo "# Changelog"
+  echo
+  echo "Generated on $(date -u +%Y-%m-%d) ${since_label}."
+  echo
+  for section in Added Fixed Changed Removed; do
+    var=$(printf '%s' "$section" | tr '[:upper:]' '[:lower:]')
+    echo "## ${section}"
+    echo
+    eval 'items=("${'"$var"'[@]}")'
+    if [ "${#items[@]}" -eq 0 ]; then
+      echo "- No entries."
+    else
+      printf '%s\n' "${items[@]}"
+    fi
+    echo
+  done
+} > "$OUT_FILE"
+
+echo "Generated ${OUT_FILE} with ${#commits[@]} commit(s) ${since_label}."


### PR DESCRIPTION
Closes #1.

## Summary
- Adds a portable Bash `changelog.sh` command that generates a structured changelog from git history.
- Detects commits since the latest git tag, falling back to full history when no tag exists.
- Categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed` using Conventional Commit prefixes plus keyword fallback rules.
- Includes a README with setup/usage in 3 steps and a sample generated changelog output.

## Verification
```bash
./changelog.sh CHANGELOG.sample.md
python3 - <<'PY'
from pathlib import Path
text=Path('CHANGELOG.sample.md').read_text()
for section in ['## Added','## Fixed','## Changed','## Removed']:
    assert section in text, section
print('OK: sample changelog has required sections')
PY
```

The sample output was generated against this repository checkout.
