### PR TITLE
feat: add pre-tool-use safety hook to block destructive commands

### DIFF
--- a/hooks/safety-hook/README.md
+++ b/hooks/safety-hook/README.md
@@ -1,0 +1,22 @@
+# Claude Code Safety Hook
+
+A `pre-tool-use` hook for Claude Code that intercepts and blocks dangerous bash and database commands before they are executed.
+
+## Features
+- Intercepts the `Bash` tool in Claude Code.
+- Blocks destructive commands: `rm -rf`, `git push --force`, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause.
+- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with a timestamp, project path, and the attempted command.
+- Halts execution with a clear, descriptive error message.
+- Allows all other normal commands to pass through safely.
+
+## Installation
+
+You can install this hook in your Claude Code environment with these two commands:
+
+```bash
+mkdir -p ~/.claude/hooks
+curl -o ~/.claude/hooks/pre-tool-use https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/hooks/safety-hook/pre-tool-use.py && chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+## How It Works
+When Claude Code attempts to run a bash command, it passes the tool name as an argument and the tool's JSON arguments via `stdin`. This script reads the JSON, extracts the `command` string, and uses Regex to pattern-match against known dangerous operations. If a match is found, it prints an error and exits with code `1`, causing Claude Code to abort the tool execution.

--- a/hooks/safety-hook/pre-tool-use.py
+++ b/hooks/safety-hook/pre-tool-use.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import sys
+import json
+import re
+import os
+import datetime
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(0)
+        
+    tool_name = sys.argv[1]
+    
+    # Check if the tool is Bash or related to running commands
+    if tool_name not in ["Bash", "run_command", "RunCommand"]:
+        sys.exit(0)
+
+    try:
+        input_data = sys.stdin.read()
+        if not input_data:
+            sys.exit(0)
+        payload = json.loads(input_data)
+    except Exception:
+        sys.exit(0)
+
+    # Claude Code typically sends {"command": "..."} for Bash
+    command = payload.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    patterns = [
+        (r'rm\s+-[A-Za-z]*r[A-Za-z]*f|rm\s+-[A-Za-z]*f[A-Za-z]*r', "rm -rf"),
+        (r'git\s+push\s+(.*\s+)?(--force|-f)(\s|$)', "git push --force"),
+        (r'(?i)\bDROP\s+TABLE\b', "DROP TABLE"),
+        (r'(?i)\bTRUNCATE\s+(TABLE)?\b', "TRUNCATE"),
+    ]
+
+    blocked = False
+    reason = ""
+
+    for pattern, name in patterns:
+        if re.search(pattern, command):
+            blocked = True
+            reason = f"Dangerous command: {name}"
+            break
+
+    if not blocked and re.search(r'(?i)\bDELETE\s+FROM\b', command) and not re.search(r'(?i)\bWHERE\b', command):
+        blocked = True
+        reason = "Dangerous database command: DELETE FROM without WHERE clause"
+
+    if blocked:
+        hook_dir = os.path.expanduser("~/.claude/hooks")
+        os.makedirs(hook_dir, exist_ok=True)
+        log_file = os.path.join(hook_dir, "blocked.log")
+        
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        project_path = os.getcwd()
+        
+        with open(log_file, "a") as f:
+            safe_command = command.replace('\n', ' ')
+            f.write(f"[{timestamp}] [Path: {project_path}] [Command: {safe_command}] [Reason: {reason}]\n")
+        
+        print("❌ ERROR: Command execution blocked by pre-tool-use safety hook.")
+        print(f"Reason: {reason}")
+        print(f"This incident has been logged to {log_file}")
+        sys.exit(1)
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a `pre-tool-use` hook script written in Python to intercept and block dangerous bash/database commands, fulfilling the requirements for Issue #3.

### Features
- Intercepts Claude Code's `Bash` tool executions.
- Safely parses the tool arguments via `stdin` JSON to extract the exact command.
- **Blocks Destructive Operations:** Matches explicit and nested patterns for `rm -rf`, `git push --force`, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause.
- **Audit Logging:** Logs every blocked attempt to `~/.claude/hooks/blocked.log` with a full timestamp, the project directory path, the sanitized command, and the specific reason for blocking.
- **Graceful Rejection:** Prints a clean error message to Claude Code and halts execution by exiting with code `1`, without interfering with benign commands.
- Includes a ready-to-use `README.md` with the 2 commands needed to install it properly.

Closes #3