### PR TITLE
CHANGELOG Generator — bash script with conventional commit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [v0.1.0] - 2026-05-14
+
+### Added
+
+  -  add data processing module ([6c4e216](https://github.com/Dannier314/claude-builders-bounty/commit/6c4e21601ab9a8991d9106a7a5ee05e20294aaf2))
+  -  initial README with bounty board ([1aeae2a](https://github.com/Dannier314/claude-builders-bounty/commit/1aeae2adc82d33f971fd7731644348dcdd24b5a6))
+
+### Fixed
+
+  -  correct memory leak in parser ([c615e91](https://github.com/Dannier314/claude-builders-bounty/commit/c615e913310b8f486d8e15255c4a1ef07f321682))
+
+### Changed
+
+  -  add test readme documentation ([c781a8c](https://github.com/Dannier314/claude-builders-bounty/commit/c781a8c91715a398a37f349285e46143d5f7e497))
+

--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -1,0 +1,35 @@
+# CHANGELOG Generator
+
+A bash script that automatically generates a structured `CHANGELOG.md` from a repository's git history.
+
+## Setup (2 steps)
+
+```bash
+# 1. Clone this repo or copy changelog.sh
+git clone <this-repo>
+
+# 2. Make it executable
+chmod +x changelog.sh
+```
+
+## Usage
+
+```bash
+# Generate CHANGELOG.md in the current repo
+bash changelog.sh
+
+# Or specify a repo path
+bash changelog.sh /path/to/your/project
+```
+
+## Features
+
+- Fetches commits since the last git tag
+- Auto-categorizes into **Added** / **Fixed** / **Changed** / **Removed**
+  - `feat:` → Added
+  - `fix:` → Fixed
+  - `remove:` / `deprecate:` → Removed
+  - Breaking changes (`!`) auto-detected
+  - Everything else → Changed
+- Outputs a properly formatted `CHANGELOG.md`
+- No external dependencies — pure bash + git

--- a/changelog-generator/changelog.sh
+++ b/changelog-generator/changelog.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CHANGELOG Generator
+# Usage: bash changelog.sh [path-to-repo]
+# Generates a structured CHANGELOG.md for the repository.
+
+REPO_DIR="${1:-.}"
+cd "$REPO_DIR"
+
+# Ensure it's a git repo
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "Error: Not a git repository: $REPO_DIR"
+  exit 1
+fi
+
+# Get the repo name
+REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed 's/.*github.com[:\/]//' | sed 's/\.git$//' | sed 's/.*@//' | sed 's/\/\/.*@/\//')
+[ -z "$REPO_SLUG" ] && REPO_SLUG=$(basename "$(git rev-parse --show-toplevel)")
+
+# Get the last tag (fallback to first commit if no tags)
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+
+echo "   Generating for $REPO_SLUG"
+echo "   Base: $LAST_TAG → HEAD"
+echo ""
+
+# Get commits since last tag
+COMMITS=$(git log "$LAST_TAG..HEAD" --pretty=format:"%H@@%s@@%aI" --no-merges 2>/dev/null || echo "")
+
+if [ -z "$COMMITS" ]; then
+  echo "No new commits since $LAST_TAG."
+  exit 0
+fi
+
+# Initialize categories
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  
+  HASH=$(echo "$line" | awk -F'@@' '{print $1}')
+  MSG=$(echo "$line" | awk -F'@@' '{print $2}')
+  DATE=$(echo "$line" | awk -F'@@' '{print $3}' | cut -d'T' -f1)
+
+  SHORT_HASH=$(echo "$HASH" | head -c 7)
+
+  # Categorize by conventional commit prefix
+  CATEGORY="Changed"  # default
+  BODY=""
+  
+  case "$MSG" in
+    feat!*|feat:*)
+      CATEGORY="Added"
+      BODY=$(echo "$MSG" | sed -E 's/^feat(!?)(\([^)]*\))?:\s*//')
+      ;;
+    fix!*|fix:*)
+      CATEGORY="Fixed"
+      BODY=$(echo "$MSG" | sed -E 's/^fix(!?)(\([^)]*\))?:\s*//')
+      ;;
+    remove!*|remove:*|deprecate!*|deprecate:*)
+      CATEGORY="Removed"
+      BODY=$(echo "$MSG" | sed -E 's/^(remove|deprecate)(!?)(\([^)]*\))?:\s*//')
+      ;;
+    *!*)
+      # Breaking change (any type with !)
+      CATEGORY="Changed"
+      BODY=$(echo "$MSG" | sed -E 's/^[a-z]+(!?)(\([^)]*\))?:\s*//')
+      [ -z "$BODY" ] && BODY="$MSG"
+      ;;
+    refactor*|perf*|style*|chore*|docs*|test*|build*|ci*|revert*)
+      CATEGORY="Changed"
+      BODY=$(echo "$MSG" | sed -E 's/^[a-z]+(!?)(\([^)]*\))?:\s*//')
+      ;;
+    add*|create*|implement*|support*)
+      CATEGORY="Added"
+      BODY="$MSG"
+      ;;
+    fix*|correct*|patch*)
+      CATEGORY="Fixed"
+      BODY="$MSG"
+      ;;
+    *)
+      CATEGORY="Changed"
+      BODY="$MSG"
+      ;;
+  esac
+
+  ENTRY="  - $BODY ([$SHORT_HASH](https://github.com/$REPO_SLUG/commit/$HASH))"
+
+  case "$CATEGORY" in
+    Added)   ADDED="$ADDED\n$ENTRY" ;;
+    Fixed)   FIXED="$FIXED\n$ENTRY" ;;
+    Removed) REMOVED="$REMOVED\n$ENTRY" ;;
+    *)       CHANGED="$CHANGED\n$ENTRY" ;;
+  esac
+done <<< "$COMMITS"
+
+# Get version from latest tag or date
+VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0")
+DATE_NOW=$(date +%Y-%m-%d)
+
+# Generate CHANGELOG.md
+OUTPUT="# Changelog\n\n## [$VERSION] - $DATE_NOW\n"
+
+[ -n "$(echo -e "$ADDED" | tr -d ' \n')" ] && OUTPUT="$OUTPUT\n### Added\n$ADDED\n"
+[ -n "$(echo -e "$FIXED" | tr -d ' \n')" ] && OUTPUT="$OUTPUT\n### Fixed\n$FIXED\n"
+[ -n "$(echo -e "$CHANGED" | tr -d ' \n')" ] && OUTPUT="$OUTPUT\n### Changed\n$CHANGED\n"
+[ -n "$(echo -e "$REMOVED" | tr -d ' \n')" ] && OUTPUT="$OUTPUT\n### Removed\n$REMOVED\n"
+
+# Write file
+echo -e "$OUTPUT" > CHANGELOG.md
+
+echo "✅ CHANGELOG.md generated successfully!"
+echo ""
+head -30 CHANGELOG.md


### PR DESCRIPTION
## CHANGELOG Generator

A bash script that automatically generates a structured `CHANGELOG.md` from git history.

### How it works
- Fetches commits since the last git tag
- Auto-categorizes into **Added** / **Fixed** / **Changed** / **Removed**
  - `feat:` → Added
  - `fix:` → Fixed
  - `remove:` / `deprecate:` → Removed
  - `docs:`, `refactor:`, `chore:` → Changed
  - Breaking changes (`!`) auto-detected
- Outputs properly formatted `CHANGELOG.md`
- Zero dependencies — pure bash + git

### Usage
```bash
bash changelog.sh          # generate in current repo
bash changelog.sh /path    # or specify a path
```

### Sample Output
See the included `CHANGELOG.md` for a real generated example (run against this repo itself).

### Acceptance Criteria
- ✅ Works via `bash changelog.sh`
- ✅ Fetches commits since last git tag
- ✅ Auto-categorizes: Added / Fixed / Changed / Removed
- ✅ Outputs formatted `CHANGELOG.md`
- ✅ Tested on a real GitHub repo (sample CHANGELOG.md included)
- ✅ README with setup in 3 steps or fewer