### PR TITLE
Add changelog generator

### DIFF
--- a/README-changelog.md
+++ b/README-changelog.md
@@ -1,0 +1,16 @@
+# Generate a changelog from git history
+
+This adds a small `changelog.sh` command for bounty #1. It reads commits since the latest git tag, groups them into Added, Fixed, Changed, and Removed, then writes a Markdown `CHANGELOG.md`.
+
+## Setup
+
+1. Copy `changelog.sh` into a git repository.
+2. Run `chmod +x changelog.sh`.
+3. Run `bash changelog.sh` or `bash changelog.sh SAMPLE_CHANGELOG.md`.
+
+## Notes
+
+- If the repo has tags, the script uses commits after the latest tag.
+- If there are no tags, it uses the full commit history.
+- Conventional commit prefixes such as `feat:`, `fix:`, `refactor:`, and `remove:` are categorized automatically.
+

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Initial history] - 2026-05-14
+
+### Added
+- initial README with bounty board (1aeae2a)

--- a/agents/generate-changelog/SKILL.md
+++ b/agents/generate-changelog/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history.
+---
+
+# Generate changelog
+
+Use this skill when a user asks for a changelog from git history.
+
+## Command
+
+Run:
+
+```bash
+bash changelog.sh
+```
+
+The script finds the latest git tag, reads commits after that tag, and writes a `CHANGELOG.md` with these sections:
+
+- Added
+- Fixed
+- Changed
+- Removed
+
+If no git tag exists, it uses the whole history.
+

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [ -n "$last_tag" ]; then
+  range="$last_tag..HEAD"
+  heading="Unreleased"
+else
+  range="HEAD"
+  heading="Initial history"
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+git log "$range" --reverse --pretty=format:'%s%x09%h' > "$tmp"
+
+declare -a added fixed changed removed
+
+clean_subject() {
+  local subject="$1"
+  subject="${subject#*: }"
+  subject="${subject#*:}"
+  subject="${subject#*) }"
+  subject="${subject#*)}"
+  printf '%s' "$subject"
+}
+
+while IFS=$'\t' read -r subject hash || [ -n "${subject:-}" ]; do
+  [ -n "${subject:-}" ] || continue
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  line="$(clean_subject "$subject") ($hash)"
+
+  case "$lower" in
+    feat:*|feat\(*|feature:*|add:*|added:*|create:*|new:*)
+      added+=("$line")
+      ;;
+    fix:*|fix\(*|bug:*|bugfix:*|hotfix:*|repair:*)
+      fixed+=("$line")
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|deprecate:*|deprecated:*)
+      removed+=("$line")
+      ;;
+    refactor:*|refactor\(*|change:*|changed:*|update:*|updated:*|improve:*|improved:*|perf:*|docs:*|chore:*)
+      changed+=("$line")
+      ;;
+    *)
+      changed+=("$line")
+      ;;
+  esac
+done < "$tmp"
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+  [ "${#items[@]}" -gt 0 ] || return 0
+
+  {
+    echo
+    echo "### $title"
+    for item in "${items[@]}"; do
+      echo "- $item"
+    done
+  } >> "$OUT"
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "## [$heading] - $(date +%Y-%m-%d)"
+} > "$OUT"
+
+write_section "Added" "${added[@]}"
+write_section "Fixed" "${fixed[@]}"
+write_section "Changed" "${changed[@]}"
+write_section "Removed" "${removed[@]}"
+
+echo "Wrote $OUT"


### PR DESCRIPTION
Adds a focused changelog generator for bounty #1.

What is included:
- `changelog.sh` for `bash changelog.sh`
- `README-changelog.md` with 3 setup steps
- `agents/generate-changelog/SKILL.md`
- `SAMPLE_CHANGELOG.md` generated from this repo

Validation run:
- `bash -n changelog.sh`
- `bash changelog.sh SAMPLE_CHANGELOG.md` in this repo
- A temporary git repo with a tag, then two commits after the tag, to confirm only post-tag commits are included
- A temporary git repo without tags, with feat/fix/refactor/remove commits, to confirm Added, Fixed, Changed, and Removed sections are all written

Closes #1