### PR TITLE
Add dangerous Bash command guard hook

### DIFF
--- a/.claude/hooks/block_dangerous_bash.py
+++ b/.claude/hooks/block_dangerous_bash.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""PreToolUse hook that denies destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+HOOK_NAME = "PreToolUse"
+
+
+def _tokenize(command: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return shlex.split(command, posix=False)
+
+
+def _short_option_has(option: str, flag: str) -> bool:
+    return option.startswith("-") and not option.startswith("--") and flag in option[1:]
+
+
+def _has_rm_force_recursive(tokens: Iterable[str]) -> bool:
+    tokens = list(tokens)
+    separators = {";", "&&", "||", "|", "(", ")"}
+
+    for index, token in enumerate(tokens):
+        if token != "rm":
+            continue
+
+        has_force = False
+        has_recursive = False
+
+        for next_token in tokens[index + 1 :]:
+            if next_token in separators:
+                break
+            if not next_token.startswith("-"):
+                break
+
+            has_force = has_force or _short_option_has(next_token, "f") or next_token == "--force"
+            has_recursive = (
+                has_recursive
+                or _short_option_has(next_token, "r")
+                or _short_option_has(next_token, "R")
+                or next_token in {"--recursive", "--dir"}
+            )
+
+            if has_force and has_recursive:
+                return True
+
+    return False
+
+
+def _has_force_push(tokens: Iterable[str]) -> bool:
+    tokens = list(tokens)
+    separators = {";", "&&", "||", "|", "(", ")"}
+
+    for index, token in enumerate(tokens):
+        if token != "git":
+            continue
+
+        command_tokens: list[str] = []
+        for next_token in tokens[index + 1 :]:
+            if next_token in separators:
+                break
+            command_tokens.append(next_token)
+
+        if not command_tokens or command_tokens[0] != "push":
+            continue
+
+        for option in command_tokens[1:]:
+            if option in {"-f", "--force", "--force-with-lease"}:
+                return True
+            if option.startswith("--force=") or option.startswith("--force-with-lease="):
+                return True
+
+    return False
+
+
+def _has_delete_without_where(command: str) -> bool:
+    for statement in re.split(r";|\n", command):
+        delete_match = re.search(r"\bdelete\s+from\b", statement, re.IGNORECASE)
+        if delete_match and not re.search(r"\bwhere\b", statement[delete_match.end() :], re.IGNORECASE):
+            return True
+    return False
+
+
+def _danger_reason(command: str) -> str | None:
+    tokens = _tokenize(command)
+
+    if _has_rm_force_recursive(tokens):
+        return "rm with both recursive and force flags can delete entire directory trees"
+    if re.search(r"\bdrop\s+table\b", command, re.IGNORECASE):
+        return "DROP TABLE can destroy database schema and data"
+    if re.search(r"\btruncate(?:\s+table)?\b", command, re.IGNORECASE):
+        return "TRUNCATE can erase table contents without row-level review"
+    if _has_delete_without_where(command):
+        return "DELETE FROM without a WHERE clause can erase every row"
+    if _has_force_push(tokens):
+        return "git push with force can rewrite remote branch history"
+
+    return None
+
+
+def _project_path(payload: dict) -> str:
+    return (
+        payload.get("cwd")
+        or payload.get("project_path")
+        or payload.get("workspace")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+
+
+def _log_block(command: str, reason: str, payload: dict) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "project_path": _project_path(payload),
+        "attempted_command": command,
+        "reason": reason,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def _deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": HOOK_NAME,
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "Blocked dangerous Bash command: "
+                        f"{reason}. Revise the command into a safer form or ask the user before proceeding."
+                    ),
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = _danger_reason(command)
+    if not reason:
+        return 0
+
+    _log_block(command, reason, payload)
+    _deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -51,3 +51,34 @@ You're in the right place.
 ---
 
 *Started by the Claude builder community · March 2026 · MIT License*
+
+---
+
+## Dangerous Bash Command Guard
+
+This repository includes a Claude Code `PreToolUse` hook that blocks destructive
+Bash commands before they run. It is designed for `~/.claude/hooks/` and logs
+every blocked attempt to `~/.claude/hooks/blocked.log`.
+
+The hook denies:
+
+- `rm` commands that combine recursive and force flags
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+- `git push` with `--force`, `--force-with-lease`, or `-f`
+
+Install in one command:
+
+```bash
+python3 install.py
+```
+
+Verify it:
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+Claude Code receives a clear denial reason when a command is blocked. Normal
+Bash commands and non-Bash tools pass through without extra output.

--- a/install.py
+++ b/install.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Install the dangerous Bash command guard into ~/.claude/hooks."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SOURCE_HOOK = ROOT / ".claude" / "hooks" / "block_dangerous_bash.py"
+CLAUDE_DIR = Path.home() / ".claude"
+HOOK_DIR = CLAUDE_DIR / "hooks"
+DEST_HOOK = HOOK_DIR / "block_dangerous_bash.py"
+SETTINGS = CLAUDE_DIR / "settings.json"
+
+
+def _load_settings() -> dict:
+    if not SETTINGS.exists():
+        return {}
+    try:
+        return json.loads(SETTINGS.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        backup = SETTINGS.with_suffix(".json.bak")
+        shutil.copy2(SETTINGS, backup)
+        return {}
+
+
+def _install_hook(settings: dict) -> dict:
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    command = f"python3 {shlex.quote(str(DEST_HOOK))}"
+    hook = {"type": "command", "command": command}
+
+    for existing in pre_tool_use:
+        if existing.get("matcher") != "Bash":
+            continue
+        existing_hooks = existing.setdefault("hooks", [])
+        if not any(existing_hook.get("command") == command for existing_hook in existing_hooks):
+            existing_hooks.append(hook)
+        return settings
+
+    pre_tool_use.append({"matcher": "Bash", "hooks": [hook]})
+    return settings
+
+
+def main() -> int:
+    HOOK_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE_HOOK, DEST_HOOK)
+    DEST_HOOK.chmod(0o755)
+
+    settings = _install_hook(_load_settings())
+    SETTINGS.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"Installed {DEST_HOOK}")
+    print(f"Updated {SETTINGS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_dangerous_bash.py
+++ b/tests/test_block_dangerous_bash.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "block_dangerous_bash.py"
+
+
+def run_hook(
+    command: str, *, tool_name: str = "Bash", home: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+        "cwd": "/tmp/example-project",
+    }
+    env = {**os.environ, "HOME": home or tempfile.mkdtemp()}
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+class DangerousBashHookTest(unittest.TestCase):
+    def assert_denied(self, command: str, reason_fragment: str) -> None:
+        result = run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        response = json.loads(result.stdout)
+        output = response["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "PreToolUse")
+        self.assertEqual(output["permissionDecision"], "deny")
+        self.assertIn(reason_fragment, output["permissionDecisionReason"])
+
+    def test_blocks_rm_rf(self) -> None:
+        self.assert_denied("rm -rf build", "recursive and force")
+
+    def test_logs_blocked_attempt(self) -> None:
+        home = tempfile.mkdtemp()
+        result = run_hook("rm -rf build", home=home)
+        self.assertEqual(result.returncode, 0)
+
+        log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
+        entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+        self.assertIn("timestamp", entry)
+        self.assertEqual(entry["attempted_command"], "rm -rf build")
+        self.assertEqual(entry["project_path"], "/tmp/example-project")
+
+    def test_blocks_drop_table(self) -> None:
+        self.assert_denied("sqlite3 app.db 'DROP TABLE users;'", "DROP TABLE")
+
+    def test_blocks_truncate(self) -> None:
+        self.assert_denied('psql -c "TRUNCATE TABLE audit_events;"', "TRUNCATE")
+
+    def test_blocks_delete_without_where(self) -> None:
+        self.assert_denied('sqlite3 app.db "DELETE FROM sessions;"', "DELETE FROM")
+
+    def test_allows_delete_with_where(self) -> None:
+        result = run_hook('sqlite3 app.db "DELETE FROM sessions WHERE expires_at < datetime();"')
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_blocks_force_push(self) -> None:
+        self.assert_denied("git push origin main --force", "rewrite remote")
+
+    def test_allows_normal_commands(self) -> None:
+        for command in ["ls -la", "git push origin main", "python3 -m pytest", "rm -r build"]:
+            result = run_hook(command)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_ignores_other_tools(self) -> None:
+        result = run_hook("rm -rf build", tool_name="Read")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3.

## Summary
- Adds a Claude Code `PreToolUse` hook for Bash commands.
- Blocks destructive patterns requested in the bounty and logs blocked attempts to `~/.claude/hooks/blocked.log`.
- Adds a one-command installer and unit tests for blocked and allowed commands.

## Validation
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile .claude/hooks/block_dangerous_bash.py install.py tests/test_block_dangerous_bash.py`
- Install smoke test with a temporary HOME
