### PR TITLE
Add structured PR review agent CLI

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,30 @@
+# PR Reviewer Agent
+
+Use this agent when asked to review a GitHub pull request and produce a concise
+Markdown review comment.
+
+## Inputs
+
+- A GitHub pull request URL, or
+- A unified diff file.
+
+## Procedure
+
+1. Run `bin/claude-review --pr <pull-request-url>` or
+   `bin/claude-review --diff-file <path>`.
+2. Read the generated Markdown.
+3. Add human judgment for project-specific context if repository docs or tests
+   reveal requirements the diff-only pass cannot infer.
+
+## Output Contract
+
+Return Markdown with exactly these sections:
+
+- `Summary`
+- `Identified Risks`
+- `Improvement Suggestions`
+- `Confidence`
+
+Do not approve a PR solely because the script reports high confidence. The
+script is a deterministic first pass; the agent remains responsible for checking
+project-specific behavior, test coverage, and security assumptions.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,25 @@ You're in the right place.
 ---
 
 *Started by the Claude builder community · March 2026 · MIT License*
+
+---
+
+## PR Review Agent
+
+This repository includes a deterministic Claude Code PR review helper. It reads
+a GitHub pull request diff and prints a structured Markdown review comment with
+summary, risks, suggestions, and confidence.
+
+Run it against a public GitHub PR:
+
+```bash
+bin/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Or run it against a saved diff:
+
+```bash
+bin/claude-review --diff-file path/to/pr.diff
+```
+
+The companion agent instructions live at `.claude/agents/pr-reviewer.md`.

--- a/bin/claude-review
+++ b/bin/claude-review
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Generate a structured Markdown review from a GitHub PR diff."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import textwrap
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)/?$")
+
+
+@dataclass
+class FileChange:
+    path: str
+    additions: int = 0
+    deletions: int = 0
+    hunks: int = 0
+    added_lines: list[str] = field(default_factory=list)
+    deleted_lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Review:
+    files: list[FileChange]
+    risks: list[str]
+    suggestions: list[str]
+    confidence: str
+
+
+def fetch_pr_diff(pr_url: str) -> str:
+    match = PR_RE.match(pr_url)
+    if not match:
+        raise ValueError("Expected PR URL like https://github.com/owner/repo/pull/123")
+
+    diff_url = pr_url.rstrip("/") + ".diff"
+    request = urllib.request.Request(diff_url, headers={"User-Agent": "claude-review/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except Exception:
+        result = subprocess.run(
+            ["curl", "-fsSL", "-A", "claude-review/1.0", diff_url],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise
+        return result.stdout
+
+
+def parse_diff(diff: str) -> list[FileChange]:
+    files: list[FileChange] = []
+    current: FileChange | None = None
+
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split(" ")
+            path = parts[-1][2:] if len(parts) >= 4 and parts[-1].startswith("b/") else "unknown"
+            current = FileChange(path=path)
+            files.append(current)
+            continue
+
+        if current is None:
+            continue
+
+        if line.startswith("+++ b/"):
+            current.path = line[6:]
+        elif line.startswith("@@"):
+            current.hunks += 1
+        elif line.startswith("+") and not line.startswith("+++"):
+            current.additions += 1
+            current.added_lines.append(line[1:])
+        elif line.startswith("-") and not line.startswith("---"):
+            current.deletions += 1
+            current.deleted_lines.append(line[1:])
+
+    return files
+
+
+def _touches(paths: list[str], fragments: tuple[str, ...]) -> bool:
+    return any(any(fragment in path.lower() for fragment in fragments) for path in paths)
+
+
+def _added_contains(files: list[FileChange], pattern: str) -> bool:
+    regex = re.compile(pattern, re.IGNORECASE)
+    return any(regex.search(line) for change in files for line in change.added_lines)
+
+
+def analyze(files: list[FileChange]) -> Review:
+    paths = [change.path for change in files]
+    total_added = sum(change.additions for change in files)
+    total_deleted = sum(change.deletions for change in files)
+    risks: list[str] = []
+    suggestions: list[str] = []
+
+    if not files:
+        risks.append("No diff content was found, so the review cannot validate behavior.")
+        suggestions.append("Re-run the review with a PR URL or diff file that includes patch content.")
+        return Review(files, risks, suggestions, "Low")
+
+    if total_added + total_deleted > 800:
+        risks.append("Large diff size increases the chance of missed regressions.")
+        suggestions.append("Split unrelated changes or add a focused reviewer guide for the largest files.")
+
+    if _touches(paths, ("auth", "session", "permission", "policy", "token", "secret")):
+        risks.append("Authentication, authorization, or secret-handling paths changed.")
+        suggestions.append("Add negative permission tests and verify secrets are not logged or exposed.")
+
+    if _touches(paths, ("migration", "schema", ".sql", "db/")):
+        risks.append("Database or migration files changed and may affect persisted data.")
+        suggestions.append("Run migrations against a disposable database and document rollback behavior.")
+
+    if _touches(paths, ("package.json", "pnpm-lock", "package-lock", "yarn.lock")):
+        risks.append("Dependency or lockfile changes can alter build and runtime behavior.")
+        suggestions.append("Confirm the lockfile is intentional and run a clean install before merge.")
+
+    if _added_contains(files, r"\bTODO\b|\bFIXME\b"):
+        risks.append("New TODO/FIXME markers suggest unfinished behavior.")
+        suggestions.append("Resolve the marker or convert it into a tracked issue before merging.")
+
+    if _added_contains(files, r"console\.log|debugger"):
+        risks.append("Debug statements were added to the diff.")
+        suggestions.append("Remove debug output or replace it with structured logging where appropriate.")
+
+    if not _touches(paths, ("test", "spec", "__tests__", ".snap")):
+        risks.append("No test files changed, so the behavior may be under-verified.")
+        suggestions.append("Add or update tests for the highest-risk path touched by this PR.")
+
+    if not risks:
+        risks.append("No obvious high-risk patterns were detected from the diff alone.")
+
+    if not suggestions:
+        suggestions.append("Keep the PR focused and ensure the project test suite passes before merge.")
+
+    confidence = "High"
+    if total_added + total_deleted > 800 or len(risks) >= 4:
+        confidence = "Medium"
+    if not files or total_added + total_deleted > 2000:
+        confidence = "Low"
+
+    return Review(files, risks, suggestions, confidence)
+
+
+def render_markdown(review: Review) -> str:
+    file_count = len(review.files)
+    total_added = sum(change.additions for change in review.files)
+    total_deleted = sum(change.deletions for change in review.files)
+    notable = sorted(review.files, key=lambda change: change.additions + change.deletions, reverse=True)[:5]
+    notable_text = ", ".join(change.path for change in notable) if notable else "none"
+
+    lines = [
+        "## Summary",
+        "",
+        (
+            f"This PR changes {file_count} file(s), with {total_added} added line(s) "
+            f"and {total_deleted} removed line(s)."
+        ),
+        f"The largest touched area(s) are: {notable_text}.",
+        "",
+        "## Identified Risks",
+        "",
+    ]
+    lines.extend(f"- {risk}" for risk in review.risks)
+    lines.extend(["", "## Improvement Suggestions", ""])
+    lines.extend(f"- {suggestion}" for suggestion in review.suggestions)
+    lines.extend(["", "## Confidence", "", review.confidence, ""])
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Review a GitHub PR diff and print a structured Markdown comment."
+    )
+    parser.add_argument("--pr", help="GitHub PR URL, e.g. https://github.com/owner/repo/pull/123")
+    parser.add_argument("--diff-file", help="Read a unified diff from a local file instead of GitHub")
+    args = parser.parse_args(argv)
+
+    if not args.pr and not args.diff_file:
+        parser.error("one of --pr or --diff-file is required")
+
+    try:
+        if args.diff_file:
+            diff = Path(args.diff_file).read_text(encoding="utf-8")
+        else:
+            diff = fetch_pr_diff(args.pr)
+    except Exception as exc:
+        print(f"claude-review: {exc}", file=sys.stderr)
+        return 2
+
+    review = analyze(parse_diff(diff))
+    print(render_markdown(review))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/review-pr-1364.md
+++ b/samples/review-pr-1364.md
@@ -1,0 +1,17 @@
+## Summary
+
+This PR changes 4 file(s), with 359 added line(s) and 0 removed line(s).
+The largest touched area(s) are: .claude/hooks/block_dangerous_bash.py, tests/test_block_dangerous_bash.py, install.py, README.md.
+
+## Identified Risks
+
+- No obvious high-risk patterns were detected from the diff alone.
+
+## Improvement Suggestions
+
+- Keep the PR focused and ensure the project test suite passes before merge.
+
+## Confidence
+
+High
+

--- a/samples/review-pr-1365.md
+++ b/samples/review-pr-1365.md
@@ -1,0 +1,17 @@
+## Summary
+
+This PR changes 1 file(s), with 248 added line(s) and 0 removed line(s).
+The largest touched area(s) are: CLAUDE.md.
+
+## Identified Risks
+
+- No test files changed, so the behavior may be under-verified.
+
+## Improvement Suggestions
+
+- Add or update tests for the highest-risk path touched by this PR.
+
+## Confidence
+
+High
+

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "bin" / "claude-review"
+
+
+class ClaudeReviewCliTest(unittest.TestCase):
+    def run_review(self, diff: str) -> str:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(textwrap.dedent(diff).strip() + "\n")
+            path = handle.name
+
+        result = subprocess.run(
+            [sys.executable, str(CLI), "--diff-file", path],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
+    def test_outputs_required_sections(self) -> None:
+        output = self.run_review(
+            """
+            diff --git a/src/auth.ts b/src/auth.ts
+            index 1111111..2222222 100644
+            --- a/src/auth.ts
+            +++ b/src/auth.ts
+            @@ -1,2 +1,3 @@
+             export function canRead() {
+            +  console.log("debug");
+               return true;
+             }
+            """
+        )
+
+        self.assertIn("## Summary", output)
+        self.assertIn("## Identified Risks", output)
+        self.assertIn("## Improvement Suggestions", output)
+        self.assertIn("## Confidence", output)
+        self.assertIn("Authentication", output)
+        self.assertIn("Debug", output)
+
+    def test_empty_diff_is_low_confidence(self) -> None:
+        output = self.run_review("")
+        self.assertIn("No diff content was found", output)
+        self.assertIn("Low", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4.

## Summary
- Adds `bin/claude-review`, a zero-dependency CLI that accepts `--pr` or `--diff-file` and emits a structured Markdown review comment.
- Adds `.claude/agents/pr-reviewer.md` with the agent procedure and output contract.
- Includes sample outputs from two real GitHub PRs plus unit tests for required sections and low-confidence empty diffs.

## Output Contract
The CLI prints:
- Summary of changes
- Identified risks
- Improvement suggestions
- Confidence score: Low / Medium / High

## Validation
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile bin/claude-review tests/test_claude_review.py`
- `git diff --check`
- Generated sample outputs for PR #1364 and PR #1365
