### PR TITLE
[BOUNTY #1] SKILL: Generate a structured CHANGELOG from git history

### DIFF
--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,43 @@
+# /generate-changelog Skill
+
+A Claude Code skill that auto-generates a structured `CHANGELOG.md` from your git history.
+
+## Install (3 steps)
+
+**Step 1:** Copy the files:
+```bash
+mkdir -p ~/.claude/skills
+cp SKILL.md ~/.claude/skills/generate-changelog.md
+cp changelog.sh ~/.claude/skills/changelog.sh
+chmod +x ~/.claude/skills/changelog.sh
+```
+
+**Step 2:** Register the skill in `~/.claude/settings.json`:
+```json
+{
+  "skills": [
+    { "name": "generate-changelog", "path": "~/.claude/skills/generate-changelog.md" }
+  ]
+}
+```
+
+**Step 3:** Run it in any git project:
+```
+/generate-changelog
+```
+
+## Features
+
+- Fetches commits **since the last git tag** (or all commits if no tags exist)
+- Auto-categorizes commits into `Added` / `Fixed` / `Changed` / `Removed`
+  - Understands [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `chore:`, etc.)
+  - Falls back to keyword matching for non-conventional messages
+- Outputs a [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) formatted `CHANGELOG.md`
+- Preserves existing changelog entries below the new section
+- Works via `/generate-changelog` in Claude Code or directly as `bash changelog.sh`
+
+## Requirements
+
+- bash 4+
+- git
+- Claude Code with skills support

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,27 @@
+# generate-changelog
+
+Generates a structured `CHANGELOG.md` from your project's git history.
+
+## Trigger
+
+```
+/generate-changelog
+```
+
+## What It Does
+
+1. Finds commits since the last git tag (or all commits if no tags exist)
+2. Auto-categorizes each commit into `Added`, `Fixed`, `Changed`, or `Removed`
+3. Writes a Keep-a-Changelog-formatted `CHANGELOG.md` to your project root
+4. Prints a summary of what was written
+
+## Instructions
+
+When the user runs `/generate-changelog`:
+
+1. Run `bash ~/.claude/skills/changelog.sh` and capture its output.
+2. Show the user the generated CHANGELOG content.
+3. Confirm that `CHANGELOG.md` has been written to the project root.
+4. Offer to commit it: `git add CHANGELOG.md && git commit -m "docs: update CHANGELOG"`.
+
+If there are no commits or no git repository, explain clearly and stop.

--- a/skills/generate-changelog/changelog.sh
+++ b/skills/generate-changelog/changelog.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# changelog.sh — generates CHANGELOG.md from git history
+# Usage: bash changelog.sh [--since <ref>] [--output <file>]
+set -eo pipefail
+
+OUTPUT="CHANGELOG.md"
+SINCE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --since) SINCE="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Ensure we're in a git repo
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "ERROR: Not a git repository." >&2
+    exit 1
+fi
+
+# Determine the range: from last tag to HEAD
+if [[ -z "$SINCE" ]]; then
+    LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+    if [[ -n "$LAST_TAG" ]]; then
+        RANGE="${LAST_TAG}..HEAD"
+        SINCE_LABEL="since tag ${LAST_TAG}"
+    else
+        RANGE="HEAD"
+        SINCE_LABEL="all commits (no tags found)"
+    fi
+else
+    RANGE="${SINCE}..HEAD"
+    SINCE_LABEL="since ${SINCE}"
+fi
+
+echo "Collecting commits ${SINCE_LABEL}..." >&2
+
+# Collect commits: hash | subject
+mapfile -t COMMITS < <(git log "$RANGE" --pretty=format:"%h|%s" --no-merges 2>/dev/null || git log --pretty=format:"%h|%s" --no-merges)
+
+if [[ ${#COMMITS[@]} -eq 0 ]]; then
+    echo "No commits found ${SINCE_LABEL}." >&2
+    exit 0
+fi
+
+# Category buckets
+declare -a ADDED FIXED CHANGED REMOVED UNCATEGORIZED
+
+classify() {
+    local subject="$1"
+    local lower="${subject,,}"
+
+    # Conventional commits prefix parsing
+    local prefix="${lower%%:*}"
+
+    case "$prefix" in
+        feat|feature|add|new) echo "added" ;;
+        fix|bugfix|hotfix|patch) echo "fixed" ;;
+        refactor|perf|style|chore|ci|build|test|docs|doc|update|change|improve|enhance) echo "changed" ;;
+        remove|delete|drop|revert|deprecate) echo "removed" ;;
+        *)
+            # Fallback: keyword search in subject
+            if [[ "$lower" =~ ^(add|new |feature|implement|creat|introduc) ]]; then echo "added"
+            elif [[ "$lower" =~ (fix|bug|patch|resolv|repair|correct|error|fail|broken) ]]; then echo "fixed"
+            elif [[ "$lower" =~ (remov|delet|drop|revert|deprecat) ]]; then echo "removed"
+            else echo "changed"
+            fi
+            ;;
+    esac
+}
+
+for entry in "${COMMITS[@]}"; do
+    hash="${entry%%|*}"
+    subject="${entry#*|}"
+    category=$(classify "$subject")
+    line="- ${subject} (\`${hash}\`)"
+    case "$category" in
+        added)   ADDED+=("$line") ;;
+        fixed)   FIXED+=("$line") ;;
+        removed) REMOVED+=("$line") ;;
+        *)       CHANGED+=("$line") ;;
+    esac
+done
+
+# Write CHANGELOG.md
+TODAY=$(date +%Y-%m-%d)
+NEXT_VERSION="Unreleased"
+
+# Read existing tagged sections BEFORE overwriting the file
+EXISTING_SECTIONS=""
+if [[ -f "$OUTPUT" ]]; then
+    EXISTING_SECTIONS=$(awk '/^## \[/{c++} c>=2{print}' "$OUTPUT")
+fi
+
+{
+    echo "# Changelog"
+    echo ""
+    echo "All notable changes to this project will be documented in this file."
+    echo "Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)."
+    echo ""
+    echo "## [${NEXT_VERSION}] — ${TODAY}"
+    echo ""
+
+    if [[ ${#ADDED[@]} -gt 0 ]]; then
+        echo "### Added"
+        printf '%s\n' "${ADDED[@]+"${ADDED[@]}"}"
+        echo ""
+    fi
+
+    if [[ ${#CHANGED[@]} -gt 0 ]]; then
+        echo "### Changed"
+        printf '%s\n' "${CHANGED[@]+"${CHANGED[@]}"}"
+        echo ""
+    fi
+
+    if [[ ${#FIXED[@]} -gt 0 ]]; then
+        echo "### Fixed"
+        printf '%s\n' "${FIXED[@]+"${FIXED[@]}"}"
+        echo ""
+    fi
+
+    if [[ ${#REMOVED[@]} -gt 0 ]]; then
+        echo "### Removed"
+        printf '%s\n' "${REMOVED[@]+"${REMOVED[@]}"}"
+        echo ""
+    fi
+
+    if [[ -n "$EXISTING_SECTIONS" ]]; then
+        echo "$EXISTING_SECTIONS"
+    fi
+} > "$OUTPUT"
+
+echo "✓ CHANGELOG.md written (${#COMMITS[@]} commits, ${SINCE_LABEL})" >&2
+echo "  Added: ${#ADDED[@]}  Changed: ${#CHANGED[@]}  Fixed: ${#FIXED[@]}  Removed: ${#REMOVED[@]}" >&2
+cat "$OUTPUT"


### PR DESCRIPTION
Closes #1

## What this adds

A `/generate-changelog` Claude Code skill that produces a Keep-a-Changelog formatted `CHANGELOG.md` from git history.

**Files:**
- `skills/generate-changelog/changelog.sh` — bash script that does the work
- `skills/generate-changelog/SKILL.md` — Claude Code skill definition
- `skills/generate-changelog/README.md` — install instructions

## Acceptance criteria

- [x] Reads commits since last git tag (falls back to all commits if no tags)
- [x] Auto-categorizes into `Added`, `Fixed`, `Changed`, `Removed` using Conventional Commits prefixes + keyword fallback
- [x] Outputs Keep-a-Changelog format with date header
- [x] Preserves existing changelog sections below the new block on re-runs
- [x] Works via `/generate-changelog` skill trigger in Claude Code
- [x] Supports `--since <ref>` and `--output <file>` CLI flags
- [x] README with install in 3 steps

## Test evidence

Tested in an isolated Docker container (`--network none`, `--memory 256m`) against a repo with mixed conventional and non-conventional commits, with and without tags, and on re-runs to verify no duplication.