### PR TITLE
[BOUNTY #3] HOOK: Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/hooks/destructive-bash-hook/README.md
+++ b/hooks/destructive-bash-hook/README.md
@@ -1,0 +1,57 @@
+# Destructive Bash Command Hook
+
+A Claude Code `pre-tool-use` hook that intercepts dangerous bash commands before they execute.
+
+## Install (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks
+cp destructive_bash_hook.py ~/.claude/hooks/
+```
+
+Then add this to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/destructive_bash_hook.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## What It Blocks
+
+| Pattern | Reason |
+|---|---|
+| `rm -rf` | Recursive force delete — irreversible |
+| `DROP TABLE` | Destructive SQL |
+| `TRUNCATE` | Destructive SQL |
+| `git push --force` / `git push -f` | Force push — overwrites remote history |
+| `DELETE FROM <table>` without `WHERE` | Deletes all rows — likely a mistake |
+
+## What It Does When Blocking
+
+1. **Tells Claude** why the command was blocked (so it can try a safer alternative)
+2. **Logs the attempt** to `~/.claude/hooks/blocked.log`:
+   ```
+   [2026-05-14 09:00:00] BLOCKED | reason='rm -rf (recursive force delete)' | project='/home/user/myapp' | cmd='rm -rf ./dist'
+   ```
+
+## Normal Commands
+
+All other bash commands pass through silently with zero overhead.
+
+## Requirements
+
+- Python 3.8+
+- Claude Code with hooks support

--- a/hooks/destructive-bash-hook/destructive_bash_hook.py
+++ b/hooks/destructive-bash-hook/destructive_bash_hook.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: blocks destructive bash commands.
+Install: copy to ~/.claude/hooks/destructive_bash_hook.py
+"""
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+LOG_FILE = Path.home() / ".claude" / "hooks" / "blocked.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+# Patterns that are unconditionally blocked
+BLOCK_PATTERNS = [
+    (r"\brm\s+(-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*)\b", "rm -rf (recursive force delete)"),
+    (r"\bDROP\s+TABLE\b", "DROP TABLE (destructive SQL)"),
+    (r"\bTRUNCATE\b", "TRUNCATE (destructive SQL)"),
+    (r"\bgit\s+push\s+.*--force\b", "git push --force (force push)"),
+    (r"\bgit\s+push\s+.*-f\b", "git push -f (force push)"),
+    # DELETE FROM without a WHERE clause (allow DELETE FROM ... WHERE ...)
+    (r"\bDELETE\s+FROM\s+\w+\s*(?:;|$)", "DELETE FROM without WHERE clause"),
+]
+
+
+def check_command(cmd: str) -> tuple[bool, str]:
+    """Returns (should_block, reason). Case-insensitive for SQL patterns."""
+    for pattern, label in BLOCK_PATTERNS:
+        flags = re.IGNORECASE if any(kw in label for kw in ("SQL", "DELETE", "DROP", "TRUNCATE")) else 0
+        if re.search(pattern, cmd, flags):
+            return True, label
+    return False, ""
+
+
+def log_blocked(cmd: str, reason: str, project_path: str) -> None:
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    entry = f"[{timestamp}] BLOCKED | reason={reason!r} | project={project_path!r} | cmd={cmd!r}\n"
+    with LOG_FILE.open("a") as f:
+        f.write(entry)
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        # Not a valid hook event — allow through
+        sys.exit(0)
+
+    tool_name = event.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)  # Only inspect Bash tool calls
+
+    tool_input = event.get("tool_input", {})
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    # Session context (may not always be present)
+    project_path = event.get("cwd") or event.get("project_path") or "unknown"
+
+    should_block, reason = check_command(command)
+
+    if should_block:
+        log_blocked(command, reason, project_path)
+        output = {
+            "decision": "block",
+            "reason": (
+                f"Blocked by destructive-bash-hook: {reason}. "
+                f"This command pattern is not allowed because it can cause irreversible damage. "
+                f"Attempt logged to {LOG_FILE}."
+            ),
+        }
+        print(json.dumps(output))
+        sys.exit(0)
+
+    # Allow all other commands silently
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3

## What this adds

A Python `pre-tool-use` hook that intercepts dangerous bash commands before Claude executes them.

**Files:**
- `hooks/destructive-bash-hook/destructive_bash_hook.py` — the hook
- `hooks/destructive-bash-hook/README.md` — install in 2 commands

## Acceptance criteria

- [x] Follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `git push -f`, `TRUNCATE`, `DELETE FROM` without `WHERE`
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, project path
- [x] Returns a clear `decision: block` message explaining why
- [x] Passes through all non-matching commands silently (zero overhead)
- [x] Ignores non-Bash tool calls entirely
- [x] README with install in 2 commands

## Test evidence (8/8 cases passing in Docker)

| Command | Expected | Result |
|---|---|---|
| `rm -rf /tmp/foo` | BLOCK | ✅ |
| `psql -c "DROP TABLE users;"` | BLOCK | ✅ |
| `git push origin main --force` | BLOCK | ✅ |
| `TRUNCATE orders;` | BLOCK | ✅ |
| `DELETE FROM sessions;` | BLOCK | ✅ |
| `ls -la` | ALLOW | ✅ |
| `DELETE FROM sessions WHERE expired=true;` | ALLOW | ✅ |
| Read tool call (non-Bash) | ALLOW | ✅ |