### PR TITLE
feat: add generate-changelog skill

### DIFF
--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,108 @@
+# Generate CHANGELOG Skill
+
+> Automatically generate a structured CHANGELOG.md from git history
+
+A Claude Code skill that fetches commits since the last git tag and categorizes them into Added/Fixed/Changed/Removed sections following [Keep a Changelog](https://keepachangelog.com/) format.
+
+---
+
+## Quick Setup
+
+**1. Copy the skill to your Claude Code skills directory:**
+
+```bash
+cp -r skills/generate-changelog ~/.claude/skills/
+```
+
+**2. Use it in Claude Code:**
+
+```
+/generate-changelog
+```
+
+**3. Or run the script directly:**
+
+```bash
+bash skills/generate-changelog/scripts/generate-changelog.sh
+```
+
+That's it! ✅
+
+---
+
+## What It Does
+
+- Finds the most recent git tag (or uses all commits if no tags exist)
+- Fetches commits since that tag
+- Auto-categorizes by scanning commit messages for keywords:
+  - **Added:** `add`, `new`, `feature`, `implement`
+  - **Fixed:** `fix`, `bug`, `patch`, `resolve`
+  - **Changed:** `change`, `update`, `refactor`, `improve`
+  - **Removed:** `remove`, `delete`, `deprecate`
+- Generates a formatted `CHANGELOG.md`
+
+---
+
+## Example Output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased] - 2026-05-15
+
+_Generated from git history since v1.2.0._
+
+### Added
+- Add user authentication (a1b2c3d)
+- Implement dark mode (e4f5g6h)
+
+### Fixed
+- Fix memory leak in parser (i7j8k9l)
+- Resolve issue #42 (m0n1o2p)
+
+### Changed
+- Update dependencies (q3r4s5t)
+- Refactor API client (u6v7w8x)
+
+### Removed
+- Remove deprecated endpoints (y9z0a1b)
+```
+
+---
+
+## Options
+
+```bash
+# Preview without writing file
+bash scripts/generate-changelog.sh --dry-run
+
+# Specify output file
+bash scripts/generate-changelog.sh --output HISTORY.md
+
+# Show help
+bash scripts/generate-changelog.sh --help
+```
+
+---
+
+## Requirements
+
+- Git repository with commits
+- Bash 4.0+ (or compatible shell)
+- Standard Unix tools: `git`, `date`, `grep`, `sed`
+
+---
+
+## Sample Output
+
+See [samples/CHANGELOG-sample.md](samples/CHANGELOG-sample.md) for a real example generated from this repository.
+
+---
+
+## License
+
+MIT

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history. Fetches commits since the last git tag and auto-categorizes them into Added/Fixed/Changed/Removed sections following Keep a Changelog format.
+---
+
+# Generate CHANGELOG
+
+Automatically generate a structured CHANGELOG.md from your project's git history.
+
+## Quick Start
+
+Run the skill:
+
+```bash
+/generate-changelog
+```
+
+Or use the bundled script directly:
+
+```bash
+bash scripts/generate-changelog.sh
+```
+
+## What It Does
+
+1. Finds the most recent git tag in your repository
+2. Fetches all commits since that tag
+3. Categorizes commits by analyzing commit messages:
+   - **Added** — new features, implementations
+   - **Fixed** — bug fixes, patches
+   - **Changed** — updates, refactors, improvements
+   - **Removed** — deletions, deprecations
+4. Generates a formatted CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
+
+## Categorization Logic
+
+Commits are categorized by scanning for keywords in the commit message:
+
+- **Added:** `add`, `new`, `feature`, `implement`, `introduce`
+- **Fixed:** `fix`, `bug`, `patch`, `resolve`, `correct`
+- **Changed:** `change`, `update`, `refactor`, `improve`, `modify`, `enhance`
+- **Removed:** `remove`, `delete`, `deprecate`, `drop`
+
+If no keyword matches, the commit goes into **Changed** by default.
+
+## Output Format
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- New feature X
+- Implement Y
+
+### Fixed
+- Fix bug Z
+- Resolve issue #123
+
+### Changed
+- Update dependency A
+- Refactor module B
+
+### Removed
+- Remove deprecated API
+```
+
+## Requirements
+
+- Git repository with at least one tag
+- Bash 4.0+ (or compatible shell)
+- Standard Unix tools: `git`, `date`, `grep`, `sed`
+
+## Usage Examples
+
+### Generate changelog for current repo
+
+```bash
+/generate-changelog
+```
+
+### Preview without writing file
+
+```bash
+bash scripts/generate-changelog.sh --dry-run
+```
+
+### Specify output file
+
+```bash
+bash scripts/generate-changelog.sh --output HISTORY.md
+```
+
+## Troubleshooting
+
+**No tags found:**
+If your repo has no tags, the script will fetch all commits from the beginning. Consider creating a tag first:
+
+```bash
+git tag v0.1.0
+```
+
+**Empty changelog:**
+If no commits are found, check that you're in a git repository and have commits:
+
+```bash
+git log --oneline
+```
+
+## Bundled Script
+
+The skill includes `scripts/generate-changelog.sh` which can be used standalone or integrated into CI/CD pipelines.
+
+See [scripts/README.md](scripts/README.md) for advanced usage.

--- a/skills/generate-changelog/samples/CHANGELOG-sample.md
+++ b/skills/generate-changelog/samples/CHANGELOG-sample.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased] - 2026-05-15
+
+_Generated from git history from project start (no git tags found)._
+
+### Added
+
+- feat: initial README with bounty board (1aeae2a)

--- a/skills/generate-changelog/scripts/generate-changelog.sh
+++ b/skills/generate-changelog/scripts/generate-changelog.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate a structured CHANGELOG.md from git history
+# Usage: bash scripts/generate-changelog.sh [--dry-run] [--output FILE]
+
+OUTPUT_FILE="CHANGELOG.md"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --output)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<HELP
+Generate a structured CHANGELOG.md from git history.
+
+Usage:
+  bash scripts/generate-changelog.sh [options]
+
+Options:
+  --dry-run        Print changelog to stdout instead of writing file
+  --output FILE    Write changelog to FILE (default: CHANGELOG.md)
+  -h, --help       Show this help message
+
+The script fetches commits since the last git tag and categorizes them into:
+Added, Fixed, Changed, and Removed.
+HELP
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: Not inside a git repository" >&2
+  exit 1
+fi
+
+# Get latest tag. If none exists, use all commits.
+LATEST_TAG=""
+if LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+  RANGE="${LATEST_TAG}..HEAD"
+  RANGE_LABEL="since ${LATEST_TAG}"
+else
+  RANGE="HEAD"
+  RANGE_LABEL="from project start (no git tags found)"
+fi
+
+# Get commits: hash + subject. Exclude merge commits for cleaner changelog.
+COMMITS=$(git log --no-merges --pretty=format:'%h%x09%s' "$RANGE" 2>/dev/null || true)
+
+TODAY=$(date +%Y-%m-%d)
+
+# Use temp files to avoid bash array portability issues.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+ADDED="$TMP_DIR/added"
+FIXED="$TMP_DIR/fixed"
+CHANGED="$TMP_DIR/changed"
+REMOVED="$TMP_DIR/removed"
+: > "$ADDED"
+: > "$FIXED"
+: > "$CHANGED"
+: > "$REMOVED"
+
+categorize_commit() {
+  local subject="$1"
+  local lower
+  lower=$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')
+
+  if printf '%s' "$lower" | grep -Eq '(^|[^a-z])(fix|fixed|bug|patch|resolve|resolved|correct|hotfix)([^a-z]|$)'; then
+    echo "fixed"
+  elif printf '%s' "$lower" | grep -Eq '(^|[^a-z])(remove|removed|delete|deleted|deprecate|deprecated|drop|dropped)([^a-z]|$)'; then
+    echo "removed"
+  elif printf '%s' "$lower" | grep -Eq '(^|[^a-z])(add|added|new|feature|feat|implement|implemented|introduce|introduced)([^a-z]|$)'; then
+    echo "added"
+  elif printf '%s' "$lower" | grep -Eq '(^|[^a-z])(change|changed|update|updated|refactor|refactored|improve|improved|modify|modified|enhance|enhanced)([^a-z]|$)'; then
+    echo "changed"
+  else
+    echo "changed"
+  fi
+}
+
+if [[ -n "$COMMITS" ]]; then
+  while IFS=$'\t' read -r hash subject; do
+    [[ -z "${subject:-}" ]] && continue
+    entry="- ${subject} (${hash})"
+    case "$(categorize_commit "$subject")" in
+      added) echo "$entry" >> "$ADDED" ;;
+      fixed) echo "$entry" >> "$FIXED" ;;
+      removed) echo "$entry" >> "$REMOVED" ;;
+      changed) echo "$entry" >> "$CHANGED" ;;
+    esac
+  done <<< "$COMMITS"
+fi
+
+append_section() {
+  local title="$1"
+  local file="$2"
+  if [[ -s "$file" ]]; then
+    printf '\n### %s\n\n' "$title"
+    cat "$file"
+  fi
+}
+
+CHANGELOG_CONTENT=$(
+  cat <<HEADER
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased] - ${TODAY}
+
+_Generated from git history ${RANGE_LABEL}._
+HEADER
+
+  if [[ -z "$COMMITS" ]]; then
+    printf '\nNo commits found %s.\n' "$RANGE_LABEL"
+  else
+    append_section "Added" "$ADDED"
+    append_section "Fixed" "$FIXED"
+    append_section "Changed" "$CHANGED"
+    append_section "Removed" "$REMOVED"
+  fi
+)
+
+if [[ "$DRY_RUN" == true ]]; then
+  printf '%s\n' "$CHANGELOG_CONTENT"
+else
+  printf '%s\n' "$CHANGELOG_CONTENT" > "$OUTPUT_FILE"
+  echo "Generated ${OUTPUT_FILE} from git history ${RANGE_LABEL}."
+fi

--- a/skills/generate-changelog/tests.sh
+++ b/skills/generate-changelog/tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="skills/generate-changelog/scripts/generate-changelog.sh"
+
+if [[ ! -x "$SCRIPT" ]]; then
+  echo "FAIL: script is not executable"
+  exit 1
+fi
+
+OUTPUT=$(bash "$SCRIPT" --dry-run)
+
+printf '%s' "$OUTPUT" | grep -q "# Changelog" || { echo "FAIL: missing title"; exit 1; }
+printf '%s' "$OUTPUT" | grep -q "## \[Unreleased\]" || { echo "FAIL: missing Unreleased section"; exit 1; }
+printf '%s' "$OUTPUT" | grep -Eq "### (Added|Fixed|Changed|Removed)|No commits found" || { echo "FAIL: missing category or empty notice"; exit 1; }
+
+tmp=$(mktemp)
+bash "$SCRIPT" --output "$tmp" >/dev/null
+test -s "$tmp" || { echo "FAIL: output file empty"; exit 1; }
+rm -f "$tmp"
+
+echo "PASS: generate-changelog tests passed"


### PR DESCRIPTION
Closes #1

Adds a Claude Code skill and standalone bash script to generate a structured `CHANGELOG.md` from git history.

## What changed
- Added `skills/generate-changelog/SKILL.md`
- Added `scripts/generate-changelog.sh`
- Categorizes commits into Added / Fixed / Changed / Removed
- Generates Keep a Changelog-style output
- Includes sample output from a real repo run
- README setup instructions in 3 steps

## Test
```bash
bash skills/generate-changelog/tests.sh
```

Result:
```text
PASS: generate-changelog tests passed
```
