### PR TITLE
Add changelog generation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ You're in the right place.
 
 ---
 
+## Included Builder Tool: Generate Changelog
+
+This repository includes a Claude Code skill and Bash script for bounty [#1](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1).
+
+1. Copy `SKILL.md` and `changelog.sh` into a Git repository.
+2. Run `bash changelog.sh`.
+3. Review the generated `CHANGELOG.md` before committing it.
+
+The script fetches tags when possible, reads commits since the latest tag, groups them into `Added`, `Fixed`, `Changed`, and `Removed`, and writes a ready-to-edit changelog draft. See [examples/CHANGELOG.sample.md](examples/CHANGELOG.sample.md) for sample output.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commits since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when the user asks for `/generate-changelog`, "generate a changelog", or a release note draft from the current repository history.
+
+## Workflow
+
+1. Run the repository-local script:
+
+   ```bash
+   bash changelog.sh
+   ```
+
+2. Review the generated `CHANGELOG.md` before committing it.
+
+3. If the project has no tags, the script falls back to all commits reachable from `HEAD`.
+
+## Output Format
+
+The script writes a Keep a Changelog-style draft with these sections:
+
+- `Added`
+- `Fixed`
+- `Changed`
+- `Removed`
+
+Commits are grouped from Conventional Commit prefixes and common release keywords. Uncategorized commits are placed under `Changed` so no work is silently dropped.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch --tags --quiet origin >/dev/null 2>&1 || true
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+range="HEAD"
+range_label="all commits"
+
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  range_label="commits since ${latest_tag}"
+fi
+
+commit_lines="$(git log "$range" --no-merges --pretty=format:'%s%x09%h' 2>/dev/null || true)"
+
+declare -a added=()
+declare -a fixed=()
+declare -a changed=()
+declare -a removed=()
+
+append_entry() {
+  local bucket="$1"
+  local subject="$2"
+  local short_sha="$3"
+  local entry="- ${subject} (${short_sha})"
+
+  case "$bucket" in
+    added) added+=("$entry") ;;
+    fixed) fixed+=("$entry") ;;
+    changed) changed+=("$entry") ;;
+    removed) removed+=("$entry") ;;
+  esac
+}
+
+categorize_subject() {
+  local subject="$1"
+  local lower
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$lower" in
+    feat:*|feat\(*|feature:*|add:*|added:*|create:*|implement:*|introduce:*) echo "added" ;;
+    fix:*|fix\(*|bugfix:*|hotfix:*|repair:*|resolve:*|patch:*) echo "fixed" ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|deprecate:*|deprecated:*) echo "removed" ;;
+    refactor:*|refactor\(*|change:*|changed:*|update:*|updated:*|docs:*|docs\(*|style:*|perf:*|test:*|chore:*) echo "changed" ;;
+    *)
+      if [[ "$lower" =~ (^|[[:space:]])(fix|fixed|bug|bugfix|resolve|resolved)([[:space:]]|:|$) ]]; then
+        echo "fixed"
+      elif [[ "$lower" =~ (^|[[:space:]])(remove|removed|delete|deleted|drop|dropped)([[:space:]]|:|$) ]]; then
+        echo "removed"
+      elif [[ "$lower" =~ (^|[[:space:]])(add|added|create|created|implement|implemented|introduce|introduced)([[:space:]]|:|$) ]]; then
+        echo "added"
+      else
+        echo "changed"
+      fi
+      ;;
+  esac
+}
+
+if [[ -n "$commit_lines" ]]; then
+  while IFS=$'\t' read -r subject short_sha; do
+    [[ -z "$subject" ]] && continue
+    append_entry "$(categorize_subject "$subject")" "$subject" "$short_sha"
+  done <<< "$commit_lines"
+fi
+
+write_section() {
+  local title="$1"
+  shift
+
+  printf '### %s\n\n' "$title"
+  if (($# == 0)); then
+    printf -- '- No changes.\n\n'
+    return
+  fi
+
+  printf '%s\n' "$@"
+  printf '\n'
+}
+
+write_bucket() {
+  local title="$1"
+  local bucket="$2"
+
+  case "$bucket" in
+    added)
+      if ((${#added[@]} == 0)); then write_section "$title"; else write_section "$title" "${added[@]}"; fi
+      ;;
+    fixed)
+      if ((${#fixed[@]} == 0)); then write_section "$title"; else write_section "$title" "${fixed[@]}"; fi
+      ;;
+    changed)
+      if ((${#changed[@]} == 0)); then write_section "$title"; else write_section "$title" "${changed[@]}"; fi
+      ;;
+    removed)
+      if ((${#removed[@]} == 0)); then write_section "$title"; else write_section "$title" "${removed[@]}"; fi
+      ;;
+  esac
+}
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated from %s on %s.\n\n' "$range_label" "$(date -u '+%Y-%m-%d')"
+  write_bucket "Added" added
+  write_bucket "Fixed" fixed
+  write_bucket "Changed" changed
+  write_bucket "Removed" removed
+} > "$output_file"
+
+echo "Wrote ${output_file} from ${range_label}."

--- a/examples/CHANGELOG.sample.md
+++ b/examples/CHANGELOG.sample.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Generated from all commits on 2026-05-15.
+
+### Added
+
+- feat: initial README with bounty board (1aeae2a)
+
+### Fixed
+
+- No changes.
+
+### Changed
+
+- Initial commit (a80a580)
+
+### Removed
+
+- No changes.


### PR DESCRIPTION
Closes #1

## Summary
- Add a native Claude Code `SKILL.md` for the `/generate-changelog` workflow.
- Add a zero-dependency `changelog.sh` that fetches tags when possible, reads commits since the latest tag, falls back to all commits when no tag exists, and writes `CHANGELOG.md`.
- Auto-categorize commits into `Added`, `Fixed`, `Changed`, and `Removed` using Conventional Commit prefixes plus keyword fallback.
- Add README setup instructions in 3 steps and a real-repo sample output in `examples/CHANGELOG.sample.md`.

## Verification
- `bash -n changelog.sh`
- `./changelog.sh /tmp/claude-builders-bounty-changelog-check.md`
- Tested on this real GitHub repo; sample output is committed in `examples/CHANGELOG.sample.md`.
- Tested on a synthetic tagged git repo with `feat`, `fix`, `docs`, and `remove` commits to confirm all four sections are populated correctly.
- `git diff --check HEAD~1..HEAD`