### PR TITLE
feat: add Claude PR review agent CLI (Bounty #4)

### DIFF
--- a/agents/pr-review/README.md
+++ b/agents/pr-review/README.md
@@ -1,0 +1,54 @@
+# Claude PR Review Agent
+
+A CLI tool that takes a GitHub PR, analyzes the diff with Claude, and returns a structured Markdown review.
+
+## Setup
+
+```bash
+# 1. Install dependencies (none! pure Python stdlib)
+chmod +x claude-review
+
+# 2. Set environment variables
+export GITHUB_TOKEN=ghp_your_token
+export ANTHROPIC_API_KEY=sk-ant-your_key
+```
+
+## Usage
+
+```bash
+# Review a PR (print to stdout)
+python claude-review --pr https://github.com/owner/repo/pull/123
+
+# Post review as a PR comment
+python claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+
+# Save review to file
+python claude-review --pr owner/repo/123 --output review.md
+
+# Shorthand
+python claude-review --pr owner/repo/123
+```
+
+## Output Format
+
+```markdown
+## Summary
+Brief 2-3 sentence summary of the changes.
+
+## Risks
+- Risk 1
+- Risk 2
+
+## Suggestions
+- Suggestion 1
+- Suggestion 2
+
+## Confidence: Medium
+```
+
+## Requirements
+- Python 3.7+
+- GitHub token
+- Anthropic API key
+
+Zero external dependencies — uses only Python stdlib.

--- a/agents/pr-review/claude-review
+++ b/agents/pr-review/claude-review
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Claude PR Review Agent — Reviews a GitHub PR and posts a structured comment.
+
+Usage:
+  python claude-review --pr https://github.com/owner/repo/pull/123
+  python claude-review --pr owner/repo/123
+  python claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+
+Requirements:
+  - GitHub token (GITHUB_TOKEN env var or --token flag)
+  - Claude API key (ANTHROPIC_API_KEY env var)
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+def parse_pr_url(url):
+    """Parse PR URL or shorthand into owner, repo, number."""
+    url = url.strip().rstrip('/')
+    if 'github.com' in url:
+        parts = url.split('/')
+        idx = parts.index('github.com')
+        return parts[idx+1], parts[idx+2], parts[idx+4]
+    # shorthand: owner/repo/123
+    parts = url.split('/')
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    raise ValueError(f"Cannot parse PR: {url}")
+
+def github_api(path, token):
+    """Call GitHub API."""
+    req = urllib.request.Request(f"https://api.github.com{path}")
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github.v3+json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        print(f"GitHub API error: {e.code} {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+
+def get_pr_diff(owner, repo, number, token):
+    """Get the PR diff."""
+    req = urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}")
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github.v3.diff")
+    with urllib.request.urlopen(req) as resp:
+        return resp.read().decode('utf-8', errors='replace')
+
+def get_pr_info(owner, repo, number, token):
+    """Get PR metadata."""
+    return github_api(f"/repos/{owner}/{repo}/pulls/{number}", token)
+
+def review_with_claude(diff, pr_info):
+    """Send diff to Claude for review."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("Error: ANTHROPIC_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+    
+    prompt = f"""Review this pull request diff and provide a structured analysis.
+
+PR Title: {pr_info.get('title', 'N/A')}
+PR Author: {pr_info.get('user', {}).get('login', 'N/A')}
+Base: {pr_info.get('base', {}).get('ref', 'N/A')} ← Head: {pr_info.get('head', {}).get('ref', 'N/A')}
+Files changed: {pr_info.get('changed_files', 'N/A')}
+Additions: +{pr_info.get('additions', 'N/A')} Deletions: -{pr_info.get('deletions', 'N/A')}
+
+Diff:
+{diff[:50000]}
+
+Respond with EXACTLY this Markdown format:
+
+## Summary
+[2-3 sentence summary of changes]
+
+## Risks
+- [risk 1]
+- [risk 2]
+- ...
+
+## Suggestions
+- [suggestion 1]
+- [suggestion 2]
+- ...
+
+## Confidence: [Low/Medium/High]
+"""
+
+    body = json.dumps({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 2000,
+        "messages": [{"role": "user", "content": prompt}]
+    }).encode()
+    
+    req = urllib.request.Request("https://api.anthropic.com/v1/messages", body, method="POST")
+    req.add_header("x-api-key", api_key)
+    req.add_header("content-type", "application/json")
+    req.add_header("anthropic-version", "2023-06-01")
+    
+    with urllib.request.urlopen(req) as resp:
+        result = json.loads(resp.read())
+        return result["content"][0]["text"]
+
+def post_comment(owner, repo, number, body, token):
+    """Post review comment on PR."""
+    data = json.dumps({"body": body}).encode()
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{owner}/{repo}/issues/{number}/comments",
+        data, method="POST"
+    )
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github.v3+json")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req) as resp:
+        result = json.loads(resp.read())
+        print(f"Comment posted: {result.get('html_url', 'OK')}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Claude PR Review Agent")
+    parser.add_argument("--pr", required=True, help="PR URL or owner/repo/number")
+    parser.add_argument("--token", help="GitHub token (or GITHUB_TOKEN env)")
+    parser.add_argument("--post-comment", action="store_true", help="Post review as PR comment")
+    parser.add_argument("--output", help="Save review to file")
+    args = parser.parse_args()
+    
+    token = args.token or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("Error: GitHub token required (--token or GITHUB_TOKEN)", file=sys.stderr)
+        sys.exit(1)
+    
+    owner, repo, number = parse_pr_url(args.pr)
+    print(f"Reviewing {owner}/{repo}#{number}...")
+    
+    # Fetch PR info and diff
+    pr_info = get_pr_info(owner, repo, number, token)
+    diff = get_pr_diff(owner, repo, number, token)
+    
+    if not diff:
+        print("No diff found (empty PR?)")
+        sys.exit(1)
+    
+    print(f"Got diff: {len(diff)} chars, {pr_info.get('changed_files')} files")
+    
+    # Review
+    review = review_with_claude(diff, pr_info)
+    
+    # Output
+    print("\n" + "="*60)
+    print(review)
+    print("="*60)
+    
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(review)
+        print(f"Saved to {args.output}")
+    
+    if args.post_comment:
+        header = f"## 🤖 Automated PR Review\n\n"
+        post_comment(owner, repo, number, header + review, token)
+
+if __name__ == "__main__":
+    main()

--- a/agents/pr-review/sample-reviews/review-example-1.md
+++ b/agents/pr-review/sample-reviews/review-example-1.md
@@ -1,0 +1,15 @@
+## Summary
+This PR adds a user authentication module with JWT-based login, registration, and token refresh endpoints. It includes password hashing with bcrypt and middleware for route protection.
+
+## Risks
+- JWT secret is read from env but no rotation mechanism is documented
+- Password reset endpoint lacks rate limiting — vulnerable to abuse
+- Token refresh doesn't invalidate old tokens (token replay possible)
+
+## Suggestions
+- Add rate limiting to /auth/login and /auth/register endpoints
+- Implement token blacklisting for logout functionality
+- Add input validation with a schema library (zod/joi) for all auth payloads
+- Consider adding a password strength requirement
+
+## Confidence: Medium


### PR DESCRIPTION
## Claude PR Review Agent

Closes #4

### What's included
- `agents/pr-review/claude-review` — CLI tool for automated PR review
- `agents/pr-review/README.md` — Setup and usage instructions
- `agents/pr-review/sample-reviews/review-example-1.md` — Sample review output

### Acceptance Criteria Met
- [x] Works via CLI: `python claude-review --pr https://github.com/owner/repo/pull/123`
- [x] Structured Markdown output with Summary, Risks, Suggestions, Confidence
- [x] `--post-comment` flag posts review as PR comment
- [x] Sample output included
- [x] README with setup and usage instructions
- [x] Zero external dependencies (pure Python stdlib)

### Tested On
- Real PRs on GitHub with various diff sizes
- Produces structured reviews with proper categorization

Wallet: zp6