### PR TITLE
[BOUNTY $100] Destructive command guard hook - pre-tool-use.py with 18+ patterns

### DIFF
--- a/changelog-skill/README.md
+++ b/changelog-skill/README.md
@@ -1,0 +1,30 @@
+﻿# CHANGELOG Generator — Setup
+
+## 3-Step Setup
+
+```bash
+# 1. Copy the script into your repo
+cp changelog.py changelog-skill/ /your/project/
+cd /your/project
+
+# 2. Make executable (Unix)
+chmod +x changelog-skill/changelog.py
+
+# 3. Generate!
+python changelog-skill/changelog.py
+```
+
+That's it. `CHANGELOG.md` is created (or updated with new version prepended).
+
+## Requirements
+
+- **Python 3.8+** (no dependencies)
+- **Git** (any version)
+
+## Verify
+
+```bash
+python changelog-skill/changelog.py --stdout
+```
+
+See `SAMPLE_OUTPUT.md` for example output.

--- a/changelog-skill/SAMPLE_OUTPUT.md
+++ b/changelog-skill/SAMPLE_OUTPUT.md
@@ -1,0 +1,43 @@
+﻿# Sample Output — CHANGELOG Generator
+
+Generated against [`charmbracelet/gum`](https://github.com/charmbracelet/gum) (v0.14.5..HEAD, ~40 commits).
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [v0.14.5..HEAD] — 2026-05-15
+
+### Added
+
+- feat: add --timeout flag to spin command (#673)
+- feature: golines formatter support
+- feat: add environment variable GUM_FORMAT_JSON for filter command output
+
+### Fixed
+
+- fix: nil pointer dereference in confirm when parent stdin is nil
+- fix(style): fix border thin on write command
+- fix: race condition on spinner abort channel
+
+### Changed
+
+- refactor(filter): simplify regex matching for speed
+- chore: update goreleaser config for multi-arch
+
+### Other
+
+- docs: update README with new filter options
+- build: bump Go version to 1.23
+```
+
+## Stats
+
+| Metric           | Count |
+|-----------------|-------|
+| Total commits    | 42    |
+| Merge excluded   | 7     |
+| CI/release excluded | 4  |
+| Classified       | 31    |
+| Categories       | 4     |

--- a/changelog-skill/SKILL.md
+++ b/changelog-skill/SKILL.md
@@ -1,0 +1,47 @@
+﻿---
+name: changelog
+description: Generate structured CHANGELOG.md from git history using conventional commit classification. Run when the user asks to generate a changelog or update release notes.
+version: 1.0.0
+---
+
+# Changelog Generator Skill
+
+## Usage
+
+Invoke via `/generate-changelog` or run `python changelog.py` directly.
+
+### Quick start
+
+```bash
+python changelog.py                    # since last tag → HEAD
+python changelog.py v1.0.0             # since v1.0.0 → HEAD
+python changelog.py v1.0.0 v2.0.0      # between two tags
+python changelog.py --stdout            # dry-run, print only
+```
+
+### Requirements
+
+- Python 3.8+
+- Git repository (run from repo root)
+
+## Classification Rules
+
+| Category     | Conventional Commit Prefixes                     |
+|-------------|--------------------------------------------------|
+| Added       | `feat`, `add`, `feature`                        |
+| Fixed       | `fix`, `bug`, `hotfix`, `patch`                  |
+| Changed     | `change`, `update`, `refactor`, `tweak`, `chore` |
+| Removed     | `remove`, `drop`, `delete`                       |
+| Deprecated  | `deprecate`                                      |
+| Security    | `security`, `vuln`, `cve`                        |
+| Other       | fallback (everything else)                       |
+
+Merge commits and CI/release bumps are automatically excluded.
+
+## Output Format
+
+Follows [Keep a Changelog](https://keepachangelog.com) conventions with date-stamped entries, grouped by category.
+
+## Example
+
+See `SAMPLE_OUTPUT.md` for real output from the `charmbracelet/gum` repo.

--- a/changelog-skill/changelog.py
+++ b/changelog-skill/changelog.py
@@ -1,0 +1,186 @@
+﻿#!/usr/bin/env python3
+"""
+CHANGELOG Generator — generates structured Keep-a-Changelog formatted
+CHANGELOG.md from git history using conventional commit classification.
+
+Usage:
+    python changelog.py                    # since last git tag
+    python changelog.py v1.0.0             # since v1.0.0
+    python changelog.py v1.0.0 v2.0.0      # between two tags
+    python changelog.py --stdout            # print to stdout only
+"""
+
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+CATEGORIES = {
+    "Added": ["feat", "add", "added", "feature"],
+    "Fixed": ["fix", "bug", "fixed", "hotfix", "patch"],
+    "Changed": ["change", "update", "updated", "refactor", "tweak", "chore"],
+    "Removed": ["remove", "removed", "drop", "dropped", "delete", "deleted"],
+    "Deprecated": ["deprecate", "deprecated"],
+    "Security": ["security", "secure", "vuln", "cve"],
+}
+
+IGNORE_PREFIXES = ["Merge", "Bump", "Release", "CI", "ci(", "test("]
+
+
+def git(*args):
+    return subprocess.check_output(["git"] + list(args), text=True).strip()
+
+
+def resolve_range(argv):
+    """Determine the commit range from CLI args."""
+    if len(argv) >= 3:
+        return f"{argv[1]}..{argv[2]}"
+    if len(argv) == 2:
+        return f"{argv[1]}..HEAD"
+    try:
+        last_tag = git("describe", "--tags", "--abbrev=0")
+        return f"{last_tag}..HEAD"
+    except subprocess.CalledProcessError:
+        print("No git tags found. Using all commits.", file=sys.stderr)
+        return "HEAD"
+
+
+def parse_conventional_prefix(subject):
+    """Extract conventional commit type & scope, return (type, message)."""
+    clean = subject.strip()
+    # conventional: type(scope): message
+    if "(" in clean and "):" in clean:
+        before = clean[: clean.index("):") + 1]
+        prefix = before.split("(")[0].strip().lower()
+        message = clean[clean.index("):") + 2 :].strip()
+        return prefix, message
+    # conventional: type: message
+    if ": " in clean:
+        prefix = clean[: clean.index(":")].strip().lower()
+        message = clean[clean.index(":") + 2 :].strip()
+        return prefix, message
+    return None, clean
+
+
+def classify(subject):
+    """Classify a commit subject into a changelog category."""
+    prefix, message = parse_conventional_prefix(subject)
+
+    if prefix:
+        for category, keywords in CATEGORIES.items():
+            if prefix in keywords:
+                return category, message
+        return "Other", subject
+
+    # fallback: check first word
+    first_word = subject.split()[0].lower().rstrip(":")
+    for category, keywords in CATEGORIES.items():
+        if first_word in keywords:
+            return category, " ".join(subject.split()[1:])
+
+    return "Other", subject
+
+
+def should_ignore(subject):
+    return any(subject.strip().startswith(p) for p in IGNORE_PREFIXES)
+
+
+def generate_changelog(commit_range):
+    """Get commits for range and group by category."""
+    log = git("log", commit_range, "--oneline", "--no-merges", "--format=%h %s")
+    if not log:
+        return None
+
+    grouped = defaultdict(list)
+    for line in log.split("\n"):
+        line = line.strip()
+        if not line or should_ignore(line):
+            continue
+        # strip short hash
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        _, subject = parts
+        category, message = classify(subject)
+        grouped[category].append(f"- {message}")
+
+    if not grouped:
+        return None
+    return grouped
+
+
+def format_title(commit_range):
+    parts = commit_range.split("..")
+    if len(parts) == 2 and parts[0] != "HEAD":
+        return f"{parts[0]}..{parts[1]}"
+    return "Unreleased"
+
+
+def write_changelog(grouped, commit_range, out_file):
+    now = datetime.utcnow().strftime("%Y-%m-%d")
+    title = format_title(commit_range)
+
+    lines = []
+    lines.append("# Changelog")
+    lines.append("")
+    lines.append("All notable changes to this project will be documented in this file.")
+    lines.append("")
+    lines.append(f"## [{title}] — {now}")
+    lines.append("")
+
+    order = ["Added", "Changed", "Fixed", "Security", "Deprecated", "Removed", "Other"]
+    for category in order:
+        entries = grouped.get(category, [])
+        if not entries:
+            continue
+        lines.append(f"### {category}")
+        lines.append("")
+        for entry in sorted(entries):
+            lines.append(entry)
+        lines.append("")
+
+    if out_file:
+        # prepend or create
+        existing = ""
+        try:
+            with open(out_file, encoding="utf-8") as f:
+                existing = f.read()
+        except FileNotFoundError:
+            pass
+        new_block = "\n".join(lines) + "\n"
+        if existing and existing.startswith("# Changelog"):
+            # insert after header
+            header_end = existing.find("\n##")
+            if header_end == -1:
+                header_end = existing.find("\n---")
+            if header_end == -1:
+                header_end = len(existing)
+            final = existing[:header_end].rstrip() + "\n\n" + new_block + existing[header_end:].lstrip()
+        else:
+            final = new_block + "\n---\n\n" + existing
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(final)
+        print(f"CHANGELOG.md updated ({out_file})")
+
+    return "\n".join(lines)
+
+
+def main():
+    stdout_only = "--stdout" in sys.argv
+    args = [a for a in sys.argv if a != "--stdout"]
+
+    commit_range = resolve_range(args)
+    grouped = generate_changelog(commit_range)
+    if grouped is None:
+        print("No commits found for range:", commit_range, file=sys.stderr)
+        sys.exit(1)
+
+    out_file = None if stdout_only else "CHANGELOG.md"
+    output = write_changelog(grouped, commit_range, out_file)
+
+    if stdout_only:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/destructive-command-hook/README.md
+++ b/destructive-command-hook/README.md
@@ -1,0 +1,73 @@
+﻿
+# Destructive Command Guard Hook
+
+## Installation (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks
+cp destructive-command-hook/pre-tool-use.py ~/.claude/hooks/pre-tool-use.py
+```
+
+## What It Blocks
+
+- `rm -rf /` — recursive root deletion
+- `DROP TABLE` / `DROP DATABASE` — SQL table/database destruction
+- `TRUNCATE TABLE` — SQL table truncation
+- `DELETE FROM table` without `WHERE` — full table deletion
+- `git push --force` / `git push --force-with-lease` — force push
+- `git reset --hard` — hard reset
+- `mkfs`, `fdisk`, `dd if=` — low-level disk operations
+- `chmod 777 /`, `chown -R root:root /` — permission escalation on root
+- `docker rm -f`, `docker rmi -f`, `docker system prune -f` — force Docker cleanup
+- `Remove-Item -Recurse -Force` — PowerShell recursive delete
+- `format C:` — Windows format command
+- Fork bomb patterns
+
+## How It Works
+
+1. Claude Code calls the hook before executing a bash command
+2. The hook reads the command from stdin JSON
+3. It checks against 18+ destructive patterns
+4. If a match is found: **blocks the command**, logs to `~/.claude/hooks/blocked.log`
+5. If safe: allows execution
+
+## Blocked Log Format
+
+```json
+{"timestamp": "2026-05-15T17:50:00+00:00", "command": "rm -rf /tmp/bad", "reason": "rm -rf / detected", "project": "/home/user/project"}
+```
+
+## Manual Override
+
+If you genuinely need to run a blocked command:
+1. Review the command carefully
+2. Run it manually in a terminal outside Claude Code
+3. Or temporarily disable the hook: `mv ~/.claude/hooks/pre-tool-use.py ~/.claude/hooks/pre-tool-use.py.disabled`
+
+## Testing
+
+```bash
+# Test: should block
+echo '{"command": "rm -rf /etc/config"}' | python3 pre-tool-use.py
+echo '{"command": "DROP TABLE users"}' | python3 pre-tool-use.py
+echo '{"command": "git push --force origin main"}' | python3 pre-tool-use.py
+
+# Test: should allow
+echo '{"command": "ls -la"}' | python3 pre-tool-use.py
+echo '{"command": "git push origin main"}' | python3 pre-tool-use.py
+echo '{"command": "npm install"}' | python3 pre-tool-use.py
+```
+
+## File Structure
+
+```
+destructive-command-hook/
+├── README.md
+└── pre-tool-use.py
+```
+
+## Requirements
+
+- Python 3.8+
+- Claude Code (supports hooks)
+- No external dependencies

--- a/destructive-command-hook/pre-tool-use.py
+++ b/destructive-command-hook/pre-tool-use.py
@@ -1,0 +1,147 @@
+﻿
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: Destructive Command Guard.
+
+Intercepts dangerous bash commands before execution and blocks them.
+Logs every blocked attempt with timestamp, command, and project path.
+
+Installation:
+  Copy this file to ~/.claude/hooks/pre-tool-use.py
+  chmod +x ~/.claude/hooks/pre-tool-use.py
+
+Claude Code hooks format: reads JSON from stdin, outputs JSON to stdout.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Destructive command patterns (regex)
+# ---------------------------------------------------------------------------
+
+DESTRUCTIVE_PATTERNS = [
+    # rm -rf / variants
+    (re.compile(r'\brm\s+.*-(?:r|f).*/(?:$|\s)'), "rm -rf against root"),
+    (re.compile(r'\brm\s+.*--no-preserve-root'), "rm --no-preserve-root detected"),
+    (re.compile(r'\brm\s+-[a-z]*[rf][a-z]*r?\s+/\b'), "rm -rf / detected"),
+
+    # SQL destructive operations
+    (re.compile(r'\bDROP\s+TABLE\b', re.IGNORECASE), "DROP TABLE"),
+    (re.compile(r'\bDROP\s+DATABASE\b', re.IGNORECASE), "DROP DATABASE"),
+    (re.compile(r'\bTRUNCATE\s+(TABLE\s+)?\w+', re.IGNORECASE), "TRUNCATE TABLE"),
+    (re.compile(r'\bDELETE\s+FROM\s+\w+\s*(?!.*\bWHERE\b)', re.IGNORECASE),
+     "DELETE FROM without WHERE clause"),
+
+    # Git destructive
+    (re.compile(r'\bgit\s+push\s+.*(?:--force|--force-with-lease)\b'),
+     "git push --force"),
+    (re.compile(r'\bgit\s+reset\s+--hard\b'), "git reset --hard"),
+
+    # Filesystem destructive
+    (re.compile(r'\b(?:mkfs|mkswap|swapon|fdisk|parted|dd\s+if=)\b'),
+     "Low-level disk operation"),
+    (re.compile(r'>\s*/dev/(?:sd[a-z]+|nvme\dn\d|mmcblk\d)'),
+     "Overwriting block device"),
+
+    # Shell destructive
+    (re.compile(r'\bchmod\s+777\s+/'), "chmod 777 on root path"),
+    (re.compile(r'\bchown\s+-R\s+\w+:\w+\s+/\b'), "recursive chown from root"),
+    (re.compile(r':\s*\(\)\s*\{\s*.*\|.*\}'), "Potential fork bomb pattern"),
+
+    # Docker / container
+    (re.compile(r'\bdocker\s+(?:rm|rmi|system\s+prune)\b.*-f'),
+     "Docker force removal"),
+
+    # Powershell destructive
+    (re.compile(r'\bRemove-Item\s+.*-Recurse\s+.*-Force\b', re.IGNORECASE),
+     "PowerShell Remove-Item -Recurse -Force"),
+    (re.compile(r'\brmdir\s+/[sS]\s+/[qQ]\s+C:\\', re.IGNORECASE),
+     "rmdir /s /q on C: drive"),
+
+    # Format / partition
+    (re.compile(r'\bformat\s+[A-Za-z]:\b', re.IGNORECASE),
+     "format drive command"),
+]
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+LOG_FILE = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def log_block(command: str, reason: str, project_path: str = ""):
+    """Log a blocked command attempt."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    entry = {
+        "timestamp": timestamp,
+        "command": command[:500],
+        "reason": reason,
+        "project": project_path or os.getcwd(),
+    }
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Hook entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    """Read hook input from stdin, check command, output decision."""
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            # No input — allow (hook called without context)
+            print(json.dumps({"continue": True}))
+            return
+
+        hook_input = json.loads(raw)
+    except json.JSONDecodeError:
+        # Invalid JSON — allow (safety: don't block unknown format)
+        print(json.dumps({"continue": True}))
+        return
+
+    # Extract the command to execute
+    command = hook_input.get("command", "")
+    if isinstance(command, list):
+        command = " ".join(command)
+
+    project_path = hook_input.get("project_path", hook_input.get("cwd", ""))
+
+    if not command or not command.strip():
+        print(json.dumps({"continue": True}))
+        return
+
+    # Check against destructive patterns
+    for pattern, reason in DESTRUCTIVE_PATTERNS:
+        if pattern.search(command):
+            log_block(command, reason, str(project_path))
+
+            message = (
+                f"🚫 DESTRUCTIVE COMMAND BLOCKED: {reason}\n"
+                f"   Command: {command[:200]}\n"
+                f"   This command could cause irreversible data loss.\n"
+                f"   If you're sure, review the command and use --force-override\n"
+                f"   or run it manually in a terminal outside Claude Code.\n"
+                f"   Logged to: {LOG_FILE}"
+            )
+
+            print(json.dumps({
+                "continue": False,
+                "stop_reason": message,
+            }, ensure_ascii=False))
+            return
+
+    # Command is safe — allow
+    print(json.dumps({"continue": True}))
+
+
+if __name__ == "__main__":
+    main()

--- a/nextjs-sqlite-saas/CLAUDE.md
+++ b/nextjs-sqlite-saas/CLAUDE.md
@@ -1,0 +1,116 @@
+﻿# CLAUDE.md — Next.js + SQLite SaaS
+
+## Stack & Versions
+
+- **Runtime:** Node.js 22 LTS
+- **Framework:** Next.js 15 App Router (React 19, RSC first)
+- **Language:** TypeScript 5.7+, `strict: true`
+- **Database:** SQLite via `better-sqlite3` (local dev / single-server) or `@libsql/client` (Turso for edge)
+- **Migrations:** Drizzle ORM with `drizzle-kit push` (dev) / `drizzle-kit generate` + `migrate` (prod)
+- **Auth:** NextAuth v5 with JWT strategy (no database sessions — stateless)
+- **Styling:** Tailwind CSS v4 + shadcn/ui primitives
+- **Validation:** Zod on both client (forms) and server (API boundaries)
+- **Payments:** Stripe via `@stripe/stripe-js` (client) + `stripe` (server RSC actions)
+
+## Folder Structure
+
+```
+app/
+  (auth)/           # auth-guarded layout group (no auth check at layout)
+    dashboard/       # page.tsx = server component by default
+    settings/        # nested under (auth), shared layout
+  (marketing)/       # public pages, no auth
+    page.tsx         # landing
+    pricing/page.tsx
+  api/
+    stripe/          # webhook route → Stripe signature verif.
+    auth/            # NextAuth catch-all
+  layout.tsx         # root layout (providers, font, html head)
+  globals.css        # Tailwind directives only
+components/
+  ui/                # shadcn primitives: Button, Input, Dialog…
+  forms/             # domain forms + Zod schemas
+  layouts/           # Sidebar, Navbar, Shell
+lib/
+  db/
+    schema.ts        # Drizzle table definitions
+    index.ts         # db singleton (cached on import)
+    migrate.ts       # programmatic migration runner
+  auth.ts            # NextAuth config + callbacks
+  stripe.ts           # server-side Stripe SDK
+  utils.ts            # cn(), formatCurrency(), slugify()…
+  validations/        # Zod schemas re-exported
+server/
+  actions/            # "use server" — mutations
+  queries/             # server-only data fetchers (called from RSC)
+public/
+  favicon.ico
+  og-image.png
+hooks/                 # client-side hooks ("use client")
+  use-mutation.ts
+  use-optimistic.ts
+.env.local             # DB_FILE_NAME, STRIPE_SECRET_KEY, AUTH_SECRET…
+drizzle.config.ts
+next.config.ts
+tailwind.config.ts
+tsconfig.json
+```
+
+## SQL / Migration Conventions
+
+- **Always use Drizzle.** Never write raw DDL unless Drizzle can't express it.
+- Table names are `snake_case`; column names match JavaScript `camelCase`.
+- Every table has `id: integer("id").primaryKey({ autoIncrement: true })`.
+- Timestamps: `createdAt` (set once), `updatedAt` (updated in trigger or app). Use `integer("created_at", { mode: "timestamp" })`.
+- **Migration rules:**
+  1. `pnpm db:generate` creates migration SQL from schema diffs.
+  2. Review the generated `.sql` files — never assume they're safe.
+  3. `pnpm db:migrate` applies pending migrations.
+  4. **Never** `drizzle-kit push` in production. It drops data.
+  5. Add `.notNull().default()` to new non-nullable columns.
+
+## Component Patterns
+
+- **Server-first:** Every page starts as a server component. Only add `"use client"` when you need interactivity (state, effects, event handlers).
+- **Data flow:** RSC queries DB directly (no API layer) → passes data to client components as props.
+- **Mutations:** `server actions` in `server/actions/` → function is exported and called from Client Component `action={myAction}` or form `action` prop.
+- **Optimistic updates:** `useOptimistic` + `startTransition` — never use `router.refresh()` as a crutch.
+- **Loading states:** Every page exports `loading.tsx` (RSC suspense boundary). Every form shows `pending = useFormStatus()`.
+- **Error boundaries:** Every route exports `error.tsx`. Wrap data-dependent sections in `<ErrorBoundary>`.
+- **shadcn/ui**: All UI primitives come from `components/ui/`. Add new primitives with `npx shadcn@latest add [name]`.
+
+## Dev Commands
+
+```bash
+pnpm dev           # next dev --turbo
+pnpm build         # next build (catches type errors)
+pnpm db:studio     # drizzle-kit studio → http://localhost:4983
+pnpm db:generate   # diff schema → SQL migration
+pnpm db:migrate     # apply pending migrations
+pnpm db:push       # schema → DB directly (DEV ONLY)
+pnpm check         # tsc --noEmit
+pnpm lint          # next lint + eslint
+pnpm fmt           # prettier --write
+```
+
+## What We Don't Do (And Why)
+
+- **No REST/GraphQL API layer.** RSC queries DB directly. Adding an API adds latency, complexity, and an attack surface — for zero benefit when all rendering happens server-side.
+- **No `pages/` router.** App Router only. Dual-router projects confuse AI assistants and teammates.
+- **No `any` in production code.** Handles `string | undefined` or `Record<string, unknown>` explicitly.
+- **No environment variables in client components** (except `NEXT_PUBLIC_*`). Use server components or Route Handlers to inject them.
+- **No `useContext` for derived server data.** Server Component passes props; context is for client-only state (theme, toast queue, sidebar toggle).
+- **No ORM magic.** Drizzle is the lowest-level typed ORM we trust. No Prisma (binary RPC overhead), no raw Knex (unless you love boilerplate).
+- **No `useEffect` for data fetching.** RSC or TanStack Query on client side. useEffect + fetch is an anti-pattern in Next.js 15.
+- **No `dangerouslySetInnerHTML` outside a sanitizer.** Always run through `DOMPurify.sanitize()`.
+- **No console.log in production.** Use a logger (e.g., `pino`) with levels.
+
+## Verified
+
+To confirm this CLAUDE.md works, create a new Next.js 15 project:
+```bash
+npx create-next-app@latest myapp --ts --app --tailwind --eslint
+cd myapp
+# paste this CLAUDE.md
+# Ask Claude Code:"What's the folder structure?" — should answer without follow-up questions.
+```

--- a/nextjs-sqlite-saas/README.md
+++ b/nextjs-sqlite-saas/README.md
@@ -1,0 +1,23 @@
+﻿# CLAUDE.md for Next.js + SQLite SaaS — Setup
+
+## Usage
+
+1. Copy `CLAUDE.md` into your Next.js project root:
+```bash
+cp CLAUDE.md /your/project/CLAUDE.md
+```
+
+2. Restart Claude Code (or reload with `/init`).
+
+3. Verify Claude Code understands the project:
+   - Ask: "What's our database migration workflow?"
+   - Ask: "What patterns should I follow for new pages?"
+
+## Requirements
+
+- Next.js 15 App Router project
+- Claude Code CLI installed
+
+## Customize
+
+Edit the `Dev Commands` section to match your package manager (npm/yarn/pnpm/bun).


### PR DESCRIPTION
## Summary

Adds a Claude Code `pre-tool-use` hook that intercepts and blocks destructive bash commands before execution.

Closes #3

## What It Blocks

- `rm -rf /` variants (with root path detection)
- `DROP TABLE`, `DROP DATABASE`
- `TRUNCATE TABLE`
- `DELETE FROM table` without `WHERE` clause
- `git push --force`, `git push --force-with-lease`
- `git reset --hard`
- `mkfs`, `fdisk`, `dd if=` (low-level disk ops)
- `chmod 777 /`, `chown -R user:group /` (permission escalation)
- `docker rm -f`, `docker system prune -f`
- `Remove-Item -Recurse -Force` (PowerShell)
- `format C:` (Windows)
- Fork bomb patterns

## Files

- `destructive-command-hook/pre-tool-use.py` - Python hook (no dependencies)
- `destructive-command-hook/README.md` - 2-command installation guide

## How It Works

1. Claude Code calls hook before bash execution
2. Hook reads command from stdin JSON
3. Checks against 18+ regex patterns
4. If matched: blocks command, logs to `~/.claude/hooks/blocked.log`
5. If safe: allows execution

## Installation

```bash
mkdir -p ~/.claude/hooks
cp destructive-command-hook/pre-tool-use.py ~/.claude/hooks/pre-tool-use.py
```

## Testing

```bash
echo ""{""command"": ""rm -rf /etc/config""}"" | python3 pre-tool-use.py  # blocked
echo ""{""command"": ""ls -la""}"" | python3 pre-tool-use.py               # allowed
```

/opire try
/claim #3