### PR TITLE
[Hook] Pre-tool-use: block destructive bash commands

### DIFF
--- a/hooks/destructive-guard/README.md
+++ b/hooks/destructive-guard/README.md
@@ -1,0 +1,40 @@
+# Claude Code — Destructive Bash Guard
+
+A `pre-tool-use` hook for Claude Code that blocks dangerous bash commands before they execute.
+
+## What it blocks
+
+| Pattern | Example |
+|---|---|
+| `rm -rf` | `rm -rf /important/folder` |
+| `git push --force` / `-f` | `git push --force origin main` |
+| `DROP TABLE` | `DROP TABLE users;` |
+| `TRUNCATE` | `TRUNCATE orders;` |
+| `DELETE FROM` without `WHERE` | `DELETE FROM sessions;` |
+
+Every blocked attempt is logged to `~/.claude/hooks/blocked.log` with timestamp, command, and project path.
+
+## Install (2 commands)
+
+```bash
+git clone https://github.com/LozzKappa/claude-destructive-guard && cd claude-destructive-guard
+bash install.sh
+```
+
+Then restart Claude Code.
+
+## How it works
+
+The hook reads the tool invocation from stdin as JSON, checks the `command` field against dangerous patterns, and exits with code `2` to block execution if a match is found. Legitimate bash commands pass through unaffected.
+
+## Log format
+
+```
+[2026-05-16T10:23:45] BLOCKED: rm -rf
+  command: 'rm -rf /tmp/myproject'
+  project: /home/user/myproject
+```
+
+## Uninstall
+
+Remove the hook entry from `~/.claude/settings.json` under `hooks.PreToolUse` and delete `~/.claude/hooks/pre_tool_use.py`.

--- a/hooks/destructive-guard/install.sh
+++ b/hooks/destructive-guard/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+HOOK_DIR="$HOME/.claude/hooks"
+SETTINGS="$HOME/.claude/settings.json"
+
+mkdir -p "$HOOK_DIR"
+cp pre_tool_use.py "$HOOK_DIR/pre_tool_use.py"
+chmod +x "$HOOK_DIR/pre_tool_use.py"
+
+python3 - <<'EOF'
+import json, os, sys
+
+path = os.path.expanduser("~/.claude/settings.json")
+settings = {}
+if os.path.exists(path):
+    with open(path) as f:
+        settings = json.load(f)
+
+hook_entry = {
+    "matcher": "Bash",
+    "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/pre_tool_use.py"}]
+}
+
+pre = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+# avoid duplicates
+if not any(h.get("matcher") == "Bash" and
+           any("pre_tool_use.py" in h2.get("command","") for h2 in h.get("hooks",[]))
+           for h in pre):
+    pre.append(hook_entry)
+
+with open(path, "w") as f:
+    json.dump(settings, f, indent=2)
+
+print("✅ Hook installed. Restart Claude Code to activate.")
+EOF

--- a/hooks/destructive-guard/pre_tool_use.py
+++ b/hooks/destructive-guard/pre_tool_use.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: blocks destructive bash commands.
+Logs every blocked attempt to ~/.claude/hooks/blocked.log
+"""
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+BLOCKED_PATTERNS = [
+    (r'\brm\s+-rf\b', 'rm -rf'),
+    (r'\bgit\s+push\s+(--force|-f)\b', 'git push --force'),
+    (r'\bDROP\s+TABLE\b', 'DROP TABLE'),
+    (r'\bTRUNCATE\b', 'TRUNCATE'),
+]
+
+LOG_FILE = Path.home() / '.claude' / 'hooks' / 'blocked.log'
+
+
+def is_delete_without_where(command: str) -> bool:
+    if re.search(r'\bDELETE\s+FROM\b', command, re.IGNORECASE):
+        return not re.search(r'\bWHERE\b', command, re.IGNORECASE)
+    return False
+
+
+def check_command(command: str) -> str | None:
+    for pattern, label in BLOCKED_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return label
+    if is_delete_without_where(command):
+        return 'DELETE FROM without WHERE clause'
+    return None
+
+
+def log_blocked(command: str, project_path: str, reason: str) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().isoformat(timespec='seconds')
+    entry = f"[{ts}] BLOCKED: {reason}\n  command: {command!r}\n  project: {project_path}\n\n"
+    with open(LOG_FILE, 'a') as f:
+        f.write(entry)
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    if data.get('tool_name') != 'Bash':
+        sys.exit(0)
+
+    command = data.get('tool_input', {}).get('command', '')
+    project_path = os.getcwd()
+
+    reason = check_command(command)
+    if reason:
+        log_blocked(command, project_path, reason)
+        print(
+            f"\n🚫 Blocked: '{reason}' detected in command.\n"
+            f"   This operation was not executed. Check ~/.claude/hooks/blocked.log for details.\n",
+            file=sys.stderr
+        )
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What this does

A `pre-tool-use` hook for Claude Code that intercepts and blocks destructive bash commands **before they execute**.

## Patterns blocked

| Pattern | Reason |
|---|---|
| `rm -rf` | Irreversible recursive deletion |
| `git push --force` / `-f` | Overwrites remote history |
| `DROP TABLE` | Destroys database table |
| `TRUNCATE` | Wipes all table rows |
| `DELETE FROM` without `WHERE` | Deletes entire table contents |

Every blocked attempt is logged to `~/.claude/hooks/blocked.log` with timestamp, command, and project path.

## Install (2 commands)

```bash
git clone https://github.com/LozzKappa/claude-builders-bounty && cd claude-builders-bounty/hooks/destructive-guard
bash install.sh
```

## How it works

The hook reads the tool invocation JSON from stdin, checks the `command` field against regex patterns, and exits with code `2` to block execution on match. Safe commands pass through with exit code `0`.

## Tests

All acceptance criteria verified:
- ✅ `rm -rf /tmp/test` → blocked (exit 2)
- ✅ `git push --force origin main` → blocked (exit 2)
- ✅ `DROP TABLE users;` → blocked (exit 2)
- ✅ `TRUNCATE orders;` → blocked (exit 2)
- ✅ `DELETE FROM sessions;` → blocked (exit 2)
- ✅ `DELETE FROM sessions WHERE id=1;` → allowed (exit 0)
- ✅ `ls -la` → allowed (exit 0)
- ✅ Non-Bash tools (Read, Write) → always allowed (exit 0)
- ✅ Log entries written correctly with timestamp + project path
