### PR TITLE
Add git changelog generator

### DIFF
--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,20 @@
+# Git Changelog Generator
+
+Generate a structured `CHANGELOG.md` from commits since the latest git tag.
+
+## Usage
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `bash changelog.sh` (or `bash changelog.sh docs/CHANGELOG.md`).
+3. Review the generated Added / Fixed / Changed / Removed sections before release.
+
+## Categorization
+
+Commits are grouped by conventional prefixes:
+
+- `feat`, `feature`, `add`, `added` → Added
+- `fix`, `fixed`, `bugfix`, `hotfix` → Fixed
+- `change`, `update`, `refactor`, `perf`, `docs`, `test`, `ci`, `build`, `chore` → Changed
+- `remove`, `delete`, `drop` → Removed
+
+If a repository has tags, only commits after the latest tag are included. Without tags, the full history is used.

--- a/generate-changelog/SAMPLE_CHANGELOG.md
+++ b/generate-changelog/SAMPLE_CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+Generated from git history since v0.1.0 on 2026-05-16.
+
+### Added
+- feat: add login flow (67bd8eb, 2026-05-16)
+
+### Fixed
+- fix: handle empty token (8322e7f, 2026-05-16)
+
+### Changed
+- docs: update setup guide (740b986, 2026-05-16)
+
+### Removed
+- remove: drop legacy config (585ce67, 2026-05-16)
+

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=${1:-CHANGELOG.md}
+repo_url=$(git config --get remote.origin.url 2>/dev/null || printf '')
+repo_url=${repo_url%.git}
+repo_url=${repo_url/git@github.com:/https://github.com/}
+
+last_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [[ -n "$last_tag" ]]; then
+  range="$last_tag..HEAD"
+  since="since $last_tag"
+else
+  range="HEAD"
+  since="from project start"
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+git log --reverse --no-merges --date=short --pretty=format:'%h%x09%ad%x09%s' $range > "$tmp"
+
+section() {
+  local title=$1 pattern=$2 found=0
+  printf '### %s\n' "$title"
+  while IFS=$'\t' read -r hash date subject || [[ -n "${hash:-}" ]]; do
+    if [[ "$subject" =~ $pattern ]]; then
+      found=1
+      if [[ -n "$repo_url" && "$repo_url" == https://github.com/* ]]; then
+        printf -- '- %s ([%s](%s/commit/%s), %s)\n' "$subject" "$hash" "$repo_url" "$hash" "$date"
+      else
+        printf -- '- %s (%s, %s)\n' "$subject" "$hash" "$date"
+      fi
+    fi
+  done < "$tmp"
+  if [[ "$found" -eq 0 ]]; then
+    printf -- '- None\n'
+  fi
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated from git history %s on %s.\n\n' "$since" "$(date -u +%Y-%m-%d)"
+  if [[ ! -s "$tmp" ]]; then
+    printf 'No commits found for this range.\n'
+    exit 0
+  fi
+  section Added '^(feat|feature|add|added)(\(.+\))?[: ]'
+  section Fixed '^(fix|fixed|bugfix|hotfix)(\(.+\))?[: ]'
+  section Changed '^(change|changed|update|updated|refactor|perf|docs|test|ci|build|chore)(\(.+\))?[: ]'
+  section Removed '^(remove|removed|delete|deleted|drop|dropped)(\(.+\))?[: ]'
+} > "$out"
+
+printf 'Wrote %s\n' "$out"


### PR DESCRIPTION
Closes #1

Adds `generate-changelog/changelog.sh`, a bash changelog generator that:

- finds commits since the latest git tag
- categorizes commits into Added / Fixed / Changed / Removed
- writes a formatted CHANGELOG.md
- includes a tested sample output
- includes setup instructions in 3 steps

Tested on a temporary git repository with tag `v0.1.0` and conventional commits. Sample output is in `generate-changelog/SAMPLE_CHANGELOG.md`.