### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-destructive-bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,25 @@
+# Destructive Bash guard for Claude Code
+
+A `PreToolUse` hook that blocks dangerous Bash commands before Claude Code runs them.
+
+It blocks:
+- `rm -rf` / `rm -fr` / separate recursive+force flags such as `rm -r -f`
+- `DROP TABLE`
+- `git push --force` / `git push --force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM` statements that do not include a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` with a timestamp, attempted command, project path, and block reason.
+
+## Install
+
+```bash
+python3 hooks/install.py
+```
+
+The installer copies the hook to `~/.claude/hooks/block-destructive-bash.py`, makes it executable, and idempotently adds the Bash `PreToolUse` matcher to `~/.claude/settings.json`.
+
+Run Claude Code normally. Safe Bash commands pass through silently; blocked commands return a `permissionDecision: deny` response with a clear reason Claude can act on.
+
+
+SQL safeguards are scoped to direct SQL commands or common SQL clients (`psql`, `mysql`, `mariadb`, `sqlite3`, `sqlcmd`) to avoid blocking harmless shell text such as `echo "DROP TABLE"`.

--- a/hooks/block-destructive-bash.py
+++ b/hooks/block-destructive-bash.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+Reads the PreToolUse JSON payload from stdin. If the tool call is a Bash
+command matching a destructive pattern, writes a denial decision to stdout and
+logs the blocked attempt to ~/.claude/hooks/blocked.log.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+SQL_CLIENTS = {"psql", "mysql", "mariadb", "sqlite3", "sqlcmd"}
+DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+TRUNCATE_TABLE_RE = re.compile(r"\btruncate\s+(?:table\s+)?[\w.\"`]+", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bwhere\b", re.IGNORECASE)
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    return str(
+        payload.get("cwd")
+        or payload.get("project_dir")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+
+
+def shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def is_sql_command(command: str, words: list[str]) -> bool:
+    return any(Path(word).name.lower() in SQL_CLIENTS for word in words) or command.lstrip().lower().startswith(
+        ("drop table", "truncate", "delete from")
+    )
+
+
+def has_forced_recursive_rm(words: list[str]) -> bool:
+    for index, word in enumerate(words):
+        if Path(word).name != "rm":
+            continue
+
+        flags = words[index + 1 :]
+        has_recursive = False
+        has_force = False
+        for flag in flags:
+            if flag == "--":
+                break
+            if not flag.startswith("-"):
+                break
+            if flag in {"--recursive", "--dir"}:
+                has_recursive = True
+            elif flag == "--force":
+                has_force = True
+            elif flag.startswith("--"):
+                continue
+            else:
+                has_recursive = has_recursive or "r" in flag or "R" in flag
+                has_force = has_force or "f" in flag
+        if has_recursive and has_force:
+            return True
+    return False
+
+
+def has_forced_git_push(words: list[str]) -> bool:
+    for index in range(len(words) - 1):
+        if Path(words[index]).name != "git" or words[index + 1] != "push":
+            continue
+        args = words[index + 2 :]
+        return any(
+            arg in {"-f", "--force", "--force-with-lease"}
+            or arg.startswith("--force=")
+            or arg.startswith("--force-with-lease=")
+            for arg in args
+        )
+    return False
+
+
+def sql_statements(command: str) -> list[str]:
+    return [part.strip() for part in re.split(r";|\n", command) if part.strip()]
+
+
+def delete_without_where(command: str) -> bool:
+    """Return True for DELETE FROM statements with no WHERE before statement end."""
+    return any(DELETE_FROM_RE.search(statement) and not WHERE_RE.search(statement) for statement in sql_statements(command))
+
+
+def blocked_reason(command: str) -> str | None:
+    words = shell_words(command)
+
+    if has_forced_recursive_rm(words):
+        return "Recursive forced deletion is blocked. Matched pattern: rm with recursive and force flags."
+
+    if has_forced_git_push(words):
+        return "Forced git push is blocked. Matched pattern: git push with force flag."
+
+    if is_sql_command(command, words):
+        if DROP_TABLE_RE.search(command):
+            return "DROP TABLE is blocked. Matched SQL pattern: DROP TABLE."
+        if TRUNCATE_TABLE_RE.search(command):
+            return "TRUNCATE is blocked. Matched SQL pattern: TRUNCATE TABLE."
+        if delete_without_where(command):
+            return "DELETE FROM without a WHERE clause is blocked. Matched SQL pattern: DELETE FROM without WHERE."
+
+    return None
+
+
+def log_block(command: str, path: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(f"{timestamp}\tproject={path}\treason={reason}\tcommand={safe_command}\n")
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    reason = blocked_reason(command)
+    if reason is None:
+        return 0
+
+    path = project_path(payload)
+    log_block(command, path, reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/install.py
+++ b/hooks/install.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash guard hook for Claude Code."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+HOOK_NAME = "block-destructive-bash.py"
+SOURCE = Path(__file__).with_name(HOOK_NAME)
+HOOK_DIR = Path.home() / ".claude" / "hooks"
+TARGET = HOOK_DIR / HOOK_NAME
+SETTINGS = Path.home() / ".claude" / "settings.json"
+ENTRY = {
+    "matcher": "Bash",
+    "hooks": [{"type": "command", "command": str(TARGET)}],
+}
+
+
+def load_settings() -> dict:
+    if not SETTINGS.exists() or not SETTINGS.read_text(encoding="utf-8").strip():
+        return {}
+    return json.loads(SETTINGS.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    HOOK_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE, TARGET)
+    TARGET.chmod(0o755)
+
+    data = load_settings()
+    pre_tool_use = data.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    if ENTRY not in pre_tool_use:
+        pre_tool_use.append(ENTRY)
+    SETTINGS.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Installed {TARGET}")
+    print(f"Updated {SETTINGS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,94 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block-destructive-bash.py"
+
+
+def run_hook(command, home):
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": "/repo"}
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class DestructiveBashHookTests(unittest.TestCase):
+    def assert_denied(self, command):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hook(command, Path(tmp))
+            self.assertEqual(result.returncode, 0)
+            response = json.loads(result.stdout)
+            output = response["hookSpecificOutput"]
+            self.assertEqual(output["hookEventName"], "PreToolUse")
+            self.assertEqual(output["permissionDecision"], "deny")
+            log = Path(tmp) / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log.exists())
+            self.assertIn(command.replace("\n", "\\n"), log.read_text())
+
+    def assert_allowed(self, command):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hook(command, Path(tmp))
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((Path(tmp) / ".claude" / "hooks" / "blocked.log").exists())
+
+    def test_all_required_patterns_are_blocked(self):
+        for command in [
+            "rm -rf build",
+            "rm -r -f build",
+            "rm -f -R build",
+            "rm --recursive --force build",
+            "sudo rm -fr /tmp/app",
+            "psql -c 'DROP TABLE users'",
+            "git push origin main --force",
+            "git push --force-with-lease origin main",
+            "git push --force-with-lease=refs/heads/main origin main",
+            "sqlite3 app.db 'TRUNCATE sessions'",
+            "psql -c 'DELETE FROM users'",
+        ]:
+            with self.subTest(command=command):
+                self.assert_denied(command)
+
+    def test_safe_commands_are_allowed(self):
+        for command in [
+            "psql -c 'DELETE FROM users WHERE id = 1'",
+            "npm test",
+            "truncate -s 0 file.log",
+            "echo 'how to DROP TABLE safely'",
+            "echo 'DELETE FROM users'",
+            "git push --force-if-includes origin main",
+        ]:
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+    def test_non_bash_tool_is_ignored(self):
+        payload = {"tool_name": "Read", "tool_input": {"file_path": "README.md"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env["HOME"] = tmp
+            result = subprocess.run(
+                [sys.executable, str(HOOK)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a Claude Code `PreToolUse` Bash hook for #3 that denies destructive shell/database commands before Claude Code executes them.

## What it blocks

- Recursive forced deletion: `rm -rf`, `rm -fr`, `rm -r -f`, `rm -R -f`, `rm --recursive --force`
- Forced Git pushes: `git push --force`, `git push -f`, `git push --force-with-lease`, including `--force-with-lease=...`
- Destructive SQL through direct SQL or common SQL clients (`psql`, `mysql`, `mariadb`, `sqlite3`, `sqlcmd`):
  - `DROP TABLE`
  - `TRUNCATE`
  - `DELETE FROM` without a `WHERE` clause

## Maintainer-facing details

- One-command install: `python3 hooks/install.py`
- Installer copies the hook to `~/.claude/hooks/`, makes it executable, and idempotently updates `~/.claude/settings.json`
- Uses Claude Code's protocol-correct `hookSpecificOutput.permissionDecision = "deny"` response for `PreToolUse`
- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, project path, and reason
- Uses only Python stdlib; no runtime dependency or package install required
- SQL checks are scoped to direct SQL/common SQL clients to avoid false positives like `echo "DROP TABLE"` or POSIX `truncate -s 0 file.log`
- Safe commands pass through silently with exit code `0`

## Files

- `hooks/block-destructive-bash.py` — hook implementation
- `hooks/install.py` — idempotent one-command installer
- `hooks/README.md` — install/usage notes
- `.claude/settings.example.json` — example Claude Code hook config
- `tests/test_block_destructive_bash.py` — stdlib unit tests covering blocked and allowed cases

## Verification

- `python3 -m unittest discover -s tests -v`
- Smoke-tested `hooks/install.py` under a temporary `HOME` so it did not mutate the real Claude config

Closes #3
