### PR TITLE
Add changelog generator skill and script

### DIFF
--- a/README-changelog-generator.md
+++ b/README-changelog-generator.md
@@ -1,0 +1,23 @@
+# Changelog Generator
+
+Generate a structured `CHANGELOG.md` from git history.
+
+## Setup in 3 steps
+
+1. Copy `scripts/changelog.sh` and `skills/generate-changelog/SKILL.md` into your repo.
+2. Run `bash scripts/changelog.sh` from the repo root.
+3. Review `CHANGELOG.md`, then commit it.
+
+## What it does
+
+- Uses commits since the latest git tag (`latest-tag..HEAD`).
+- Falls back to all reachable commits when the repo has no tags.
+- Groups entries into `Added`, `Fixed`, `Changed`, and `Removed`.
+
+## Examples
+
+```bash
+bash scripts/changelog.sh
+bash scripts/changelog.sh docs/CHANGELOG.md
+CHANGELOG_RANGE=v1.0.0..HEAD bash scripts/changelog.sh
+```

--- a/samples/CHANGELOG.sample.md
+++ b/samples/CHANGELOG.sample.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased - 2026-05-16
+
+### Added
+- changelog generator skill and script (sample)
+
+### Fixed
+- typo in README setup instructions (sample)
+
+### Changed
+- update command docs for custom ranges (sample)
+
+### Removed
+- deprecated manual changelog note (sample)

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT=${1:-CHANGELOG.md}
+RANGE=${CHANGELOG_RANGE:-}
+if [ -z "$RANGE" ]; then
+  last_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -n "$last_tag" ]; then
+    RANGE="$last_tag..HEAD"
+  else
+    RANGE="HEAD"
+  fi
+fi
+
+mapfile -t commits < <(git log --no-merges --pretty=format:'%s%x09%h' "$RANGE" 2>/dev/null || true)
+today=$(date +%Y-%m-%d)
+
+category_for() {
+  subject=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$subject" in
+    feat:*|feat\(*|add:*|add\(*|*add*|*introduce*) echo Added ;;
+    fix:*|fix\(*|bug:*|bug\(*|*fix*|*bug*) echo Fixed ;;
+    remove:*|remove\(*|delete:*|delete\(*|drop:*|drop\(*|*remove*|*delete*) echo Removed ;;
+    *) echo Changed ;;
+  esac
+}
+
+clean_subject() {
+  printf '%s' "$1" | sed -E 's/^[a-zA-Z]+(\([^)]*\))?!?:[[:space:]]*//'
+}
+
+{
+  echo '# Changelog'
+  echo
+  echo "## Unreleased - $today"
+  echo
+  for section in Added Fixed Changed Removed; do
+    echo "### $section"
+    matched=0
+    for line in "${commits[@]}"; do
+      [ -n "$line" ] || continue
+      subject=${line%$'\t'*}
+      hash=${line##*$'\t'}
+      if [ "$(category_for "$subject")" = "$section" ]; then
+        printf -- '- %s (%s)\n' "$(clean_subject "$subject")" "$hash"
+        matched=1
+      fi
+    done
+    [ "$matched" = 1 ] || echo '- No changes.'
+    echo
+  done
+} > "$OUT"
+
+echo "Wrote $OUT from range: $RANGE"

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commits since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when the user asks Claude Code to create or refresh a changelog from git history.
+
+## Command
+
+```bash
+bash scripts/changelog.sh
+```
+
+Optional output path:
+
+```bash
+bash scripts/changelog.sh docs/CHANGELOG.md
+```
+
+Optional custom range:
+
+```bash
+CHANGELOG_RANGE=v1.2.0..HEAD bash scripts/changelog.sh
+```
+
+## Behavior
+
+- Finds the latest git tag with `git describe --tags --abbrev=0`.
+- Reads non-merge commits from `latest-tag..HEAD`.
+- If no tag exists, reads reachable commits from `HEAD`.
+- Writes `CHANGELOG.md` with `Added`, `Fixed`, `Changed`, and `Removed` sections.
+- Classifies common Conventional Commit prefixes plus natural words like add, fix, update, remove.
+
+## Review Checklist
+
+1. Run `bash scripts/changelog.sh` at the repo root.
+2. Open `CHANGELOG.md` and verify every recent user-facing commit appears once.
+3. Move any ambiguous item manually if the commit subject was unclear.


### PR DESCRIPTION
Closes #1

## Summary
- Add `scripts/changelog.sh` to generate `CHANGELOG.md` from commits since the latest git tag.
- Add native Claude Code skill at `skills/generate-changelog/SKILL.md`.
- Add 3-step setup README and sample changelog output.

## Test
- Ran `./scripts/changelog.sh /tmp/generated-changelog.md` on this repo.
- Output grouped the current git history into Added / Fixed / Changed / Removed.
