### PR TITLE
feat: add changelog generation script for bounty #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] - 2026-05-19
+
+### Added
+- add changelog generation script for bounty #1
+
+### Fixed
+- No fixes found.
+
+### Changed
+- No changed items found.
+
+### Removed
+- No removed items found.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from git commits since the latest tag.
+
+## Setup and usage
+
+1. Run `bash scripts/generate_changelog.sh` from the repository root.
+2. Optionally pass a range: `bash scripts/generate_changelog.sh v1.0.0 HEAD`.
+3. Commit the generated `CHANGELOG.md` after reviewing the output.
+
+The script categorizes conventional commit subjects into `Added`, `Fixed`, `Changed`, and `Removed` sections. If no tag exists, it uses the first commit as the starting point.
+
+## Sample output
+
+```md
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] - 2026-05-19
+
+### Added
+- add changelog generation script for bounty #1
+
+### Fixed
+- No fixes found.
+
+### Changed
+- No changed items found.
+
+### Removed
+- No removed items found.
+```

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,34 +1,57 @@
-#!/bin/bash
-# scripts/generate_changelog.sh
-# Usage: ./generate_changelog.sh [from_tag] [to_tag]
+#!/usr/bin/env bash
+set -euo pipefail
 
-FROM_TAG=$1
-TO_TAG=$2
+# Generate a Keep a Changelog-style CHANGELOG.md from commits since the last tag.
+# Usage: bash scripts/generate_changelog.sh [from_ref] [to_ref]
 
-if [ -z "$FROM_TAG" ]; then
-    FROM_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+FROM_REF="${1:-}"
+TO_REF="${2:-HEAD}"
+OUT_FILE="CHANGELOG.md"
+
+if [[ -z "$FROM_REF" ]]; then
+  FROM_REF="$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)"
 fi
 
-if [ -z "$TO_TAG" ]; then
-    TO_TAG="HEAD"
-fi
+range="$FROM_REF..$TO_REF"
+today="$(date +%Y-%m-%d)"
 
-echo "# CHANGELOG"
-echo ""
-echo "## [Unreleased] - $(date +%Y-%m-%d)"
-echo ""
+collect() {
+  local pattern="$1"
+  git log "$range" --reverse --pretty=format:'%s' --grep="$pattern" -E |
+    sed -E "s/^(${pattern})!?(:|\([^)]+\):)[[:space:]]*//I" |
+    sed '/^[[:space:]]*$/d' |
+    sed 's/^/- /'
+}
 
-echo "### Features"
-git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --grep="feat:" | sed 's/feat: //'
-echo ""
+added="$(collect 'feat')"
+fixed="$(collect 'fix')"
+changed="$(git log "$range" --reverse --pretty=format:'%s' --grep='^(refactor|perf|build|ci|chore)' -E |
+  sed -E 's/^(refactor|perf|build|ci|chore)!?(\([^)]+\))?:[[:space:]]*//I' |
+  sed '/^[[:space:]]*$/d' |
+  sed 's/^/- /')"
+removed="$(git log "$range" --reverse --pretty=format:'%s' --grep='^(remove|removed|delete|deleted)' -E |
+  sed -E 's/^(remove|removed|delete|deleted)!?(\([^)]+\))?:[[:space:]]*//I' |
+  sed '/^[[:space:]]*$/d' |
+  sed 's/^/- /')"
 
-echo "### Fixes"
-git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --grep="fix:" | sed 's/fix: //'
-echo ""
+{
+  echo '# Changelog'
+  echo
+  echo 'All notable changes to this project will be documented in this file.'
+  echo
+  echo "## [Unreleased] - $today"
+  echo
+  echo '### Added'
+  [[ -n "$added" ]] && echo "$added" || echo '- No added changes found.'
+  echo
+  echo '### Fixed'
+  [[ -n "$fixed" ]] && echo "$fixed" || echo '- No fixes found.'
+  echo
+  echo '### Changed'
+  [[ -n "$changed" ]] && echo "$changed" || echo '- No changed items found.'
+  echo
+  echo '### Removed'
+  [[ -n "$removed" ]] && echo "$removed" || echo '- No removed items found.'
+} > "$OUT_FILE"
 
-echo "### Documentation"
-git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --grep="docs:" | sed 's/docs: //'
-echo ""
-
-echo "### Others"
-git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --invert-grep --grep="feat:\|fix:\|docs:"
+printf 'Generated %s from %s\n' "$OUT_FILE" "$range"

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# scripts/generate_changelog.sh
+# Usage: ./generate_changelog.sh [from_tag] [to_tag]
+
+FROM_TAG=$1
+TO_TAG=$2
+
+if [ -z "$FROM_TAG" ]; then
+    FROM_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+fi
+
+if [ -z "$TO_TAG" ]; then
+    TO_TAG="HEAD"
+fi
+
+echo "# CHANGELOG"
+echo ""
+echo "## [Unreleased] - $(date +%Y-%m-%d)"
+echo ""
+
+echo "### Features"
+git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --grep="feat:" | sed 's/feat: //'
+echo ""
+
+echo "### Fixes"
+git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --grep="fix:" | sed 's/fix: //'
+echo ""
+
+echo "### Documentation"
+git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --grep="docs:" | sed 's/docs: //'
+echo ""
+
+echo "### Others"
+git log "$FROM_TAG..$TO_TAG" --oneline --pretty=format:"* %s" --invert-grep --grep="feat:\|fix:\|docs:"


### PR DESCRIPTION
Closes #1

## Summary
- Add `scripts/generate_changelog.sh` for generating a structured `CHANGELOG.md` from git history.
- Detect commits since the latest tag, or the first commit when no tag exists.
- Categorize conventional commits into `Added`, `Fixed`, `Changed`, and `Removed`.
- Add a generated sample `CHANGELOG.md` and concise setup instructions.

## Validation
```bash
bash scripts/generate_changelog.sh main HEAD
```
