### PR TITLE
feat: add CLAUDE.md template for Next.js + SQLite bounty #2

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,37 +1,190 @@
-# CLAUDE.md - Next.js + SQLite Guidelines
+# CLAUDE.md - Next.js 15 + SQLite SaaS
 
-## Project Overview
-Next.js 14+ with SQLite (using Drizzle or Prisma) and Tailwind CSS. Focused on developer productivity and AI agent compatibility.
+This file is the operating manual for Claude Code in a greenfield SaaS built with Next.js 15 App Router and SQLite. Follow these rules exactly; do not replace them with generic "best practices".
 
-## Tech Stack
-- **Framework:** Next.js (App Router)
-- **Database:** SQLite (Better-SQLite3 or LibSQL)
-- **ORM:** Drizzle ORM (preferred) or Prisma
-- **Styling:** Tailwind CSS + Shadcn UI
-- **Validation:** Zod
+## Stack And Versions
+
+- **Runtime:** Node.js 20 LTS or newer because Next.js 15 and modern SQLite drivers are tested there.
+- **Package manager:** `pnpm` because it is deterministic and avoids duplicate dependency trees.
+- **Framework:** Next.js 15 App Router only; do not add a `pages/` directory.
+- **Language:** TypeScript strict mode; do not weaken compiler settings to make errors disappear.
+- **Database:** SQLite through `better-sqlite3` for local/single-node apps or Turso/libSQL for hosted edge SQLite.
+- **ORM:** Drizzle ORM because it keeps SQL visible and generates strong table/query types.
+- **Validation:** Zod at every trust boundary: env, form input, webhooks, route params, and search params.
+- **Styling:** Tailwind CSS plus small local components; use shadcn/ui only when the component is actually needed.
+- **Auth:** Auth.js/NextAuth v5 or Lucia-style sessions; keep auth logic server-only.
+
+## Project Structure
+
+```text
+app/
+  (marketing)/              # public landing/pricing/blog routes
+  (app)/dashboard/          # authenticated product routes
+  api/                      # only external HTTP/webhook boundaries
+  layout.tsx                # root shell only
+  error.tsx                 # root error boundary
+  not-found.tsx             # global 404
+components/
+  ui/                       # generic presentational primitives
+  forms/                    # reusable form shells, no business logic
+features/
+  billing/                  # feature UI + server actions + tests
+  users/
+server/
+  actions/                  # mutations called by forms/components
+  queries/                  # read models used by RSCs
+  services/                 # business workflows, no React imports
+lib/
+  db/                       # Drizzle client, schema, migrations helpers
+  auth/                     # session helpers and permission checks
+  env.ts                    # Zod-validated env access
+  utils.ts                  # tiny shared helpers only
+drizzle/
+  migrations/               # committed generated SQL migrations
+tests/
+  unit/
+  integration/
+```
+
+Do not put business logic in `components/` or `app/**/page.tsx`. Pages compose UI and call `server/queries`; mutations live in `server/actions` or `server/services`.
+
+## Naming Conventions
+
+- Files use kebab-case except React components, which use PascalCase: `UserMenu.tsx`.
+- Server Actions end with `.action.ts`; read queries end with `.query.ts`.
+- Drizzle tables use plural camelCase exports: `users`, `billingSubscriptions`.
+- SQL columns use snake_case: `created_at`, `stripe_customer_id`.
+- Route groups describe audience, not implementation: `(marketing)`, `(app)`, `(admin)`.
+- Environment variables are uppercase and read only through `lib/env.ts`.
 
 ## Development Commands
-- `npm run dev` - Start development server
-- `npm run build` - Build for production
-- `npm run lint` - Run linting checks
-- `npx drizzle-kit generate` - Generate database migrations
-- `npx drizzle-kit push` - Push schema changes to SQLite
 
-## Database Pattern (Drizzle)
-- Schema: `src/db/schema.ts`
-- Client: `src/db/index.ts`
-- Migrations: `drizzle/`
+Use these commands unless `package.json` says otherwise:
 
-## Coding Standards
-- **Components:** Use React Server Components by default. Add `'use client'` only when needed.
-- **Data Fetching:** Use Server Actions for mutations. Fetch data directly in RSCs.
-- **Naming:**
-  - Components: PascalCase (`UserButton.tsx`)
-  - Hooks: camelCase (`useAuth.ts`)
-  - API Routes: `route.ts` inside folder
-- **Errors:** Use `error.tsx` for route-level error boundaries.
+```bash
+pnpm install              # install dependencies
+pnpm dev                  # run local dev server
+pnpm build                # production build and type validation
+pnpm lint                 # lint source files
+pnpm typecheck            # TypeScript without emit
+pnpm test                 # unit/integration tests
+pnpm db:generate          # drizzle-kit generate migration SQL
+pnpm db:migrate           # apply migrations
+pnpm db:studio            # inspect local SQLite data
+```
 
-## SQLite Constraints
-- Keep the database file (`sqlite.db`) in the root or a dedicated `data/` folder.
-- Always include the database file in `.gitignore`.
-- Use WAL mode for better concurrency: `PRAGMA journal_mode = WAL;`.
+Never invent missing scripts silently. If a script is missing, add it to `package.json` or state why it is not available.
+
+## SQLite And Migration Rules
+
+- Commit every generated migration in `drizzle/migrations`; never rely on `db push` in production.
+- Use `integer('created_at', { mode: 'timestamp' })` and `integer('updated_at', { mode: 'timestamp' })` for timestamps because SQLite has no native timestamp type.
+- Prefer text IDs generated by the app (`cuid2` or UUIDv7). Do not use auto-increment IDs for user-facing entities.
+- Add indexes in the schema for every foreign key and high-cardinality lookup used by queries.
+- Use WAL mode for local SQLite: `PRAGMA journal_mode = WAL;` because it improves read/write concurrency.
+- Do not commit `*.db`, `*.sqlite`, WAL, or SHM files.
+- Wrap multi-table writes in a transaction; partial writes are product bugs.
+- Use cursor/keyset pagination for growing tables; do not use unbounded `OFFSET` pagination.
+
+Example table pattern:
+
+```ts
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  name: text('name'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+});
+```
+
+## Component Patterns
+
+- Use Server Components by default because they keep data access on the server and reduce client JavaScript.
+- Add `'use client'` only for browser state, effects, refs, event handlers, or client-only libraries.
+- Keep Client Components thin; pass plain serializable props from Server Components.
+- Put loading states in `loading.tsx`, route errors in `error.tsx`, and empty states inside the feature component.
+- Do not fetch from the app's own API routes in Server Components; call `server/queries` directly.
+- Forms submit to Server Actions with Zod validation and return typed success/error objects.
+
+Server Action pattern:
+
+```ts
+'use server';
+
+export async function updateProfile(formData: FormData) {
+  const input = updateProfileSchema.safeParse(Object.fromEntries(formData));
+  if (!input.success) return { ok: false, error: input.error.flatten() };
+
+  await updateUserProfile(input.data);
+  revalidatePath('/dashboard/settings');
+  return { ok: true };
+}
+```
+
+## API Route Rules
+
+Use `app/api/**/route.ts` only for external callers: webhooks, public REST endpoints, OAuth callbacks, or third-party integrations. Internal UI should use Server Actions and server queries instead.
+
+Every route handler must:
+
+- Validate input with Zod.
+- Authenticate or explicitly document why it is public.
+- Return typed JSON with correct status codes.
+- Avoid raw database logic; call `server/services`.
+- Verify webhook signatures before reading trusted fields.
+
+## Security Rules
+
+- Keep secrets in `.env.local` and deployment secrets; never commit them or print them in logs.
+- Read env vars via `lib/env.ts` with Zod so missing production config fails at boot.
+- Check authorization in the server function that performs the action, not only in the page that renders the button.
+- Use CSRF-safe Server Actions or explicit CSRF tokens for custom POST endpoints.
+- Store password hashes only with Argon2id or bcrypt; never store plaintext or reversible encryption.
+- Use parameterized Drizzle queries. Do not build SQL strings with user input.
+- Treat `searchParams`, `params`, cookies, headers, and form data as untrusted.
+
+## What We Do Not Do
+
+| Do not do this | Do this instead | Reason |
+| --- | --- | --- |
+| Add a `pages/` directory | Use `app/` only | Mixing routers causes duplicated conventions and routing bugs |
+| Put mutations in components | Use Server Actions/services | Components render; server code enforces invariants |
+| Use `any` to bypass types | Model input/output with Zod and inferred Drizzle types | Type safety is the point of this stack |
+| Commit SQLite database files | Commit migrations and seeds | Runtime data does not belong in git |
+| Use `db push` for production | Generate and review SQL migrations | Production schema changes must be auditable |
+| Fetch own API from RSCs | Call server queries directly | Avoids extra HTTP hop and duplicated auth |
+| Hard-delete user data by default | Use soft delete or explicit irreversible flows | SaaS data recovery matters |
+| Unbounded `select *` lists | Select explicit columns and paginate | Prevents slow pages and accidental data leaks |
+| Hide errors with empty catches | Log server-side and return safe messages | Silent failures make Claude repeat bad fixes |
+| Add libraries for tiny helpers | Write local utilities | Keeps the template lean and understandable |
+
+## Testing Expectations
+
+- Unit test pure services, validators, and permission checks.
+- Integration test database queries/actions against a temporary SQLite database.
+- E2E test only critical flows: sign-in, onboarding, billing, and the main product action.
+- Add regression tests for every bug fix.
+- Before opening a PR, run `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` when available.
+
+## Claude Code Workflow
+
+When implementing a task:
+
+1. Read `package.json`, `drizzle.config.*`, `lib/env.ts`, and existing feature folders first.
+2. Identify whether the change is UI, query, mutation, migration, or external API.
+3. Add or update Zod schemas before writing database or action code.
+4. Keep changes small and feature-local.
+5. Run the narrowest relevant test, then the full validation command set if the change is broad.
+6. In the PR summary, list commands run and any commands that could not run.
+
+## Greenfield Readiness Check
+
+This template is ready for a new Next.js 15 + SQLite SaaS when Claude can answer without clarification:
+
+- where to put a dashboard page,
+- how to add a Drizzle table and migration,
+- when to use Server Actions versus API routes,
+- how to validate user input,
+- what patterns are forbidden and why,
+- which commands validate the project before merge.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md - Next.js + SQLite Guidelines
+
+## Project Overview
+Next.js 14+ with SQLite (using Drizzle or Prisma) and Tailwind CSS. Focused on developer productivity and AI agent compatibility.
+
+## Tech Stack
+- **Framework:** Next.js (App Router)
+- **Database:** SQLite (Better-SQLite3 or LibSQL)
+- **ORM:** Drizzle ORM (preferred) or Prisma
+- **Styling:** Tailwind CSS + Shadcn UI
+- **Validation:** Zod
+
+## Development Commands
+- `npm run dev` - Start development server
+- `npm run build` - Build for production
+- `npm run lint` - Run linting checks
+- `npx drizzle-kit generate` - Generate database migrations
+- `npx drizzle-kit push` - Push schema changes to SQLite
+
+## Database Pattern (Drizzle)
+- Schema: `src/db/schema.ts`
+- Client: `src/db/index.ts`
+- Migrations: `drizzle/`
+
+## Coding Standards
+- **Components:** Use React Server Components by default. Add `'use client'` only when needed.
+- **Data Fetching:** Use Server Actions for mutations. Fetch data directly in RSCs.
+- **Naming:**
+  - Components: PascalCase (`UserButton.tsx`)
+  - Hooks: camelCase (`useAuth.ts`)
+  - API Routes: `route.ts` inside folder
+- **Errors:** Use `error.tsx` for route-level error boundaries.
+
+## SQLite Constraints
+- Keep the database file (`sqlite.db`) in the root or a dedicated `data/` folder.
+- Always include the database file in `.gitignore`.
+- Use WAL mode for better concurrency: `PRAGMA journal_mode = WAL;`.


### PR DESCRIPTION
Closes #2

## Summary
- Add a production-ready `templates/CLAUDE.md` for a greenfield Next.js 15 + SQLite SaaS.
- Pin the stack to App Router, TypeScript strict mode, Drizzle, better-sqlite3, and Turso/libSQL guidance.
- Include project structure, naming conventions, server actions, migrations, auth, security, testing, and anti-patterns.
- Add a greenfield readiness checklist so Claude Code can apply the template without extra clarification.

## Validation
- Reviewed the template against all five acceptance criteria in #2.
- Documentation/template-only change.
