### PR TITLE
Add structured changelog generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@ You're in the right place.
 
 ---
 
+## Changelog generator bounty submission
+
+This repository includes a portable changelog generator:
+
+```bash
+bash changelog.sh
+```
+
+Setup in 3 steps:
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `bash changelog.sh` from the repo root.
+3. Review and commit the generated `CHANGELOG.md`.
+
+Optional:
+
+```bash
+bash changelog.sh --since v1.0.0 --output CHANGELOG.md
+```
+
+The script reads commits since the latest tag, or all history when no tag exists, then groups non-merge commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+
+See `changelog-skill/SKILL.md` for the Claude Code skill wrapper.
+
+---
+
 ## How it works
 
 **To post a bounty**

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Generated on 2026-05-18 from commits from repository history.
+
+## Added
+
+- feat: initial README with bounty board (1aeae2a, 2026-03-27)
+
+## Fixed
+
+- No entries.
+
+## Changed
+
+- No entries.
+
+## Removed
+
+- No entries.
+

--- a/changelog-skill/SKILL.md
+++ b/changelog-skill/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the last tag.
+---
+
+# Generate Changelog
+
+Use this skill when a user asks to generate or refresh a changelog from a git repository.
+
+## Command
+
+```bash
+bash changelog.sh
+```
+
+Optional args:
+
+```bash
+bash changelog.sh --since v1.2.3 --output CHANGELOG.md
+```
+
+## Behavior
+
+- Detects the latest git tag with `git describe --tags --abbrev=0`.
+- Uses all commits when no tag exists.
+- Ignores merge commits.
+- Categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed` using commit subject keywords.
+- Writes a Markdown `CHANGELOG.md` with commit hash and date.
+
+## Setup
+
+1. Copy `changelog.sh` into a git repo.
+2. Run `bash changelog.sh`.
+3. Commit the generated `CHANGELOG.md` after review.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bash changelog.sh [--since <ref>] [--output <file>]
+
+Generate a structured CHANGELOG.md from git commits since the last tag.
+Categories: Added, Fixed, Changed, Removed.
+EOF
+}
+
+output="CHANGELOG.md"
+since=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) since="${2:-}"; shift 2 ;;
+    --output|-o) output="${2:-}"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: run inside a git repository" >&2
+  exit 1
+fi
+
+if [[ -z "$since" ]]; then
+  since="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+fi
+
+if [[ -n "$since" ]]; then
+  range="$since..HEAD"
+  title_range="since $since"
+else
+  range="HEAD"
+  title_range="from repository history"
+fi
+
+mapfile -t commits < <(git log --no-merges --date=short --pretty=format:'%h%x09%ad%x09%s' "$range" 2>/dev/null || true)
+
+declare -a added fixed changed removed
+add_line() {
+  local bucket="$1" line="$2"
+  case "$bucket" in
+    Added) added+=("$line") ;;
+    Fixed) fixed+=("$line") ;;
+    Changed) changed+=("$line") ;;
+    Removed) removed+=("$line") ;;
+  esac
+}
+
+for row in "${commits[@]}"; do
+  IFS=$'\t' read -r hash date subject <<< "$row"
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  line="- $subject ($hash, $date)"
+  case "$lower" in
+    feat:*|feat\(*|add:*|added:*|*' add '*|*' adds '*|*' new '*) add_line Added "$line" ;;
+    fix:*|fix\(*|bug:*|*fix*|*bug*|*patch*) add_line Fixed "$line" ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|*remove*|*delete*|*deprecat*) add_line Removed "$line" ;;
+    *) add_line Changed "$line" ;;
+  esac
+done
+
+{
+  echo "# Changelog"
+  echo
+  echo "Generated on $(date -u +%Y-%m-%d) from commits $title_range."
+  echo
+  for section in Added Fixed Changed Removed; do
+    echo "## $section"
+    echo
+    case "$section" in
+      Added) arr=("${added[@]:-}") ;;
+      Fixed) arr=("${fixed[@]:-}") ;;
+      Changed) arr=("${changed[@]:-}") ;;
+      Removed) arr=("${removed[@]:-}") ;;
+    esac
+    if [[ ${#arr[@]} -eq 0 || -z "${arr[0]:-}" ]]; then
+      echo "- No entries."
+    else
+      printf '%s\n' "${arr[@]}"
+    fi
+    echo
+  done
+} > "$output"
+
+echo "Wrote $output (${#commits[@]} commits)."


### PR DESCRIPTION
Solves #1.\n\n## What\n- Adds `changelog.sh` portable Bash generator.\n- Adds Claude Code skill wrapper in `changelog-skill/SKILL.md`.\n- Adds `SAMPLE_CHANGELOG.md` generated from this repo.\n- Documents setup in 3 steps in README.\n\n## Test\n```bash\nbash changelog.sh --output SAMPLE_CHANGELOG.md\nbash changelog.sh --help\n```