### PR TITLE
Add changelog generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ You're in the right place.
 ---
 
 *Started by the Claude builder community · March 2026 · MIT License*
+
+## Changelog generator
+
+Small Bash changelog generator for bounty #1. It reads Git commit subjects since the latest tag, groups them into Added/Changed/Fixed/Removed sections, and writes Markdown.
+
+Setup in 3 steps:
+
+1. Make it executable: `chmod +x changelog.sh`
+2. Generate the file: `./changelog.sh --output CHANGELOG.md`
+3. Optional custom range: `./changelog.sh --since v1.0.0 --output CHANGELOG.md`
+
+If the repo has no tags, it uses all commits on `HEAD`. See `SAMPLE_CHANGELOG.md` for expected output.

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Changes in this repository.
+
+## Added
+
+- feat: initial README with bounty board
+
+## Changed
+
+- No entries.
+
+## Fixed
+
+- No entries.
+
+## Removed
+
+- No entries.
+

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out="CHANGELOG.md"
+since=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 2; }
+      out="$2"
+      shift 2
+      ;;
+    --since)
+      [[ $# -ge 2 ]] || { echo "Missing value for --since" >&2; exit 2; }
+      since="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [OUTPUT] [--output FILE] [--since REF]"
+      exit 0
+      ;;
+    *)
+      out="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$since" ]]; then
+  range="$since..HEAD"
+  summary="Changes since \`$since\`."
+else
+  last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+  if [[ -n "$last_tag" ]]; then
+    range="$last_tag..HEAD"
+    summary="Changes since \`$last_tag\`."
+  else
+    range="HEAD"
+    summary="Changes in this repository."
+  fi
+fi
+
+commits="$(git log --pretty=format:'%s' "$range")"
+write_section() {
+  local section="$1"
+  local matched=0
+  echo "## $section"
+  echo
+  while IFS= read -r msg; do
+    [[ -z "$msg" ]] && continue
+    local lower="${msg,,}"
+    case "$section:$lower" in
+      Added:*add*|Added:*feat*|Added:*create*) echo "- $msg"; matched=1 ;;
+      Changed:*change*|Changed:*update*|Changed:*refactor*|Changed:*improve*) echo "- $msg"; matched=1 ;;
+      Fixed:*fix*|Fixed:*bug*|Fixed:*patch*|Fixed:*repair*) echo "- $msg"; matched=1 ;;
+      Removed:*remove*|Removed:*delete*|Removed:*drop*) echo "- $msg"; matched=1 ;;
+    esac
+  done <<< "$commits"
+  [[ "$matched" -eq 0 ]] && echo "- No entries."
+  echo
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "$summary"
+  echo
+  write_section Added
+  write_section Changed
+  write_section Fixed
+  write_section Removed
+} > "$out"
+
+echo "Wrote $out"


### PR DESCRIPTION
Implements the changelog generator bounty.\n\nWhat changed:\n- Adds `changelog.sh` to generate Markdown changelogs from commit subjects.\n- Supports latest-tag default range plus `--since` and `--output`.\n- Adds README usage notes and a sample output file.\n\nValidation:\n- `chmod +x changelog.sh`\n- `./changelog.sh --output /tmp/CHANGELOG.test.md`\n- Compared generated output with `SAMPLE_CHANGELOG.md`.