### PR TITLE
feat: add changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased - 2026-05-19
+
+Changes since the beginning of history.
+
+### Added
+
+- Initial README with bounty board ([1aeae2a](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/1aeae2a))
+
+### Changed
+
+- Initial commit ([a80a580](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/a80a580))

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ You're in the right place.
 
 ---
 
+## Generate a Changelog
+
+Use the included changelog generator to create a structured `CHANGELOG.md` from
+commits since the latest git tag.
+
+1. Run `bash changelog.sh`
+2. Review the generated `CHANGELOG.md`
+3. Commit the changelog when it looks correct
+
+The generator groups commits into `Added`, `Fixed`, `Changed`, and `Removed`
+based on common conventional commit prefixes.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## Unreleased - 2026-05-19
+
+Changes since v1.0.0.
+
+### Added
+
+- Add GitHub issue bounty board ([abc1234](https://github.com/example/repo/commit/abc1234))
+- Add README usage guide ([def5678](https://github.com/example/repo/commit/def5678))
+
+### Fixed
+
+- Fix broken bounty table link ([fed4321](https://github.com/example/repo/commit/fed4321))
+
+### Changed
+
+- Update community contact details ([987abcd](https://github.com/example/repo/commit/987abcd))
+
+### Removed
+
+- Remove deprecated setup note ([456efab](https://github.com/example/repo/commit/456efab))

--- a/changelog.py
+++ b/changelog.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORIES = {
+    "Added": ("feat", "add", "added", "new"),
+    "Fixed": ("fix", "bugfix", "bug", "hotfix", "repair"),
+    "Changed": ("change", "changed", "refactor", "perf", "style", "docs", "test", "build", "ci", "chore"),
+    "Removed": ("remove", "removed", "delete", "deleted", "drop", "dropped"),
+}
+
+
+@dataclass
+class Commit:
+    sha: str
+    subject: str
+
+
+def run_git(args: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError:
+        sys.exit("git is required but was not found on PATH")
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.stdout.strip() or "git command failed"
+        sys.exit(message)
+    return result.stdout.strip()
+
+
+def last_tag() -> str | None:
+    try:
+        tag = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+    return tag or None
+
+
+def commit_range(tag: str | None) -> str:
+    return f"{tag}..HEAD" if tag else "HEAD"
+
+
+def load_commits(rev_range: str) -> list[Commit]:
+    output = run_git(["log", rev_range, "--pretty=format:%h%x1f%s"])
+    if not output:
+        return []
+    commits: list[Commit] = []
+    for line in output.splitlines():
+        if "\x1f" not in line:
+            continue
+        sha, subject = line.split("\x1f", 1)
+        commits.append(Commit(sha=sha, subject=subject.strip()))
+    return commits
+
+
+def normalize_subject(subject: str) -> tuple[str, str]:
+    lowered = subject.lower()
+    prefix = lowered.split(":", 1)[0].split("(", 1)[0].strip()
+    cleaned = subject.split(":", 1)[1].strip() if ":" in subject else subject.strip()
+    return prefix, cleaned[:1].upper() + cleaned[1:] if cleaned else subject
+
+
+def category_for(subject: str) -> str:
+    prefix, _ = normalize_subject(subject)
+    for category, prefixes in CATEGORIES.items():
+        if prefix in prefixes:
+            return category
+    return "Changed"
+
+
+def render_changelog(commits: list[Commit], tag: str | None, repo: str | None) -> str:
+    today = dt.date.today().isoformat()
+    base = tag if tag else "the beginning of history"
+    title = f"## Unreleased - {today}"
+    lines = [
+        "# Changelog",
+        "",
+        title,
+        "",
+        f"Changes since {base}.",
+        "",
+    ]
+
+    grouped: dict[str, list[Commit]] = {name: [] for name in CATEGORIES}
+    for commit in commits:
+        grouped[category_for(commit.subject)].append(commit)
+
+    if not commits:
+        lines.extend(["No commits found for this range.", ""])
+        return "\n".join(lines)
+
+    for category in CATEGORIES:
+        items = grouped[category]
+        if not items:
+            continue
+        lines.extend([f"### {category}", ""])
+        for commit in items:
+            _, cleaned = normalize_subject(commit.subject)
+            ref = f" ([{commit.sha}]({repo}/commit/{commit.sha}))" if repo else f" ({commit.sha})"
+            lines.append(f"- {cleaned}{ref}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def remote_url() -> str | None:
+    try:
+        url = run_git(["config", "--get", "remote.origin.url"])
+    except SystemExit:
+        return None
+    if url.startswith("git@github.com:"):
+        return "https://github.com/" + url.removeprefix("git@github.com:").removesuffix(".git")
+    if url.startswith("https://github.com/"):
+        return url.removesuffix(".git")
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git commits since the last tag.")
+    parser.add_argument("-o", "--output", default="CHANGELOG.md", help="Output file path. Defaults to CHANGELOG.md.")
+    parser.add_argument("--stdout", action="store_true", help="Print changelog instead of writing a file.")
+    args = parser.parse_args()
+
+    tag = last_tag()
+    commits = load_commits(commit_range(tag))
+    changelog = render_changelog(commits, tag, remote_url())
+
+    if args.stdout:
+        print(changelog, end="")
+    else:
+        Path(args.output).write_text(changelog, encoding="utf-8")
+        print(f"Wrote {args.output} with {len(commits)} commits.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$(dirname "$0")/changelog.py" "$@"
+fi
+
+exec python "$(dirname "$0")/changelog.py" "$@"


### PR DESCRIPTION
## Summary
- Adds `changelog.py`, a standard-library generator for structured `CHANGELOG.md` output from git history.
- Adds `changelog.sh` so the bounty command path works via `bash changelog.sh`.
- Documents setup in three steps and includes generated/sample changelog output.

## Verification
- `python changelog.py --stdout`
- `python changelog.py`
- `python -m py_compile changelog.py`

## Sample output
See `CHANGELOG.md` generated from this repository and `SAMPLE_CHANGELOG.md` for a fuller category example.

/claim #1