### PR TITLE
Add verified changelog generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ You're in the right place.
 
 ---
 
+## Changelog Generator
+
+This repository includes a submission for bounty [#1](../../issues/1): a
+zero-dependency Bash changelog generator plus a Claude Code skill wrapper.
+
+Setup and usage:
+
+1. Run `chmod +x changelog.sh`.
+2. Run `bash changelog.sh` from a git repository.
+3. Review the generated `CHANGELOG.md` before committing it.
+
+The script detects the latest git tag, reads commits from that tag through
+`HEAD`, categorizes them into `Added`, `Fixed`, `Changed`, and `Removed`, and
+writes a formatted changelog. See `samples/claude-builders-bounty-changelog.md`
+for output generated from this real GitHub repository.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bash changelog.sh [options]
+
+Generate CHANGELOG.md from git commits since the last tag.
+
+Options:
+  --repo PATH       Git repository to inspect. Default: current directory.
+  --output PATH     Output file. Default: CHANGELOG.md in the repo.
+  --from REF        Start ref. Default: latest reachable git tag.
+  --to REF          End ref. Default: HEAD.
+  --version NAME    Changelog version heading. Default: Unreleased.
+  --help            Show this help.
+
+Environment alternatives:
+  CHANGELOG_REPO, CHANGELOG_OUTPUT, CHANGELOG_FROM, CHANGELOG_TO, CHANGELOG_VERSION
+USAGE
+}
+
+repo="${CHANGELOG_REPO:-.}"
+output="${CHANGELOG_OUTPUT:-CHANGELOG.md}"
+from_ref="${CHANGELOG_FROM:-}"
+to_ref="${CHANGELOG_TO:-HEAD}"
+version="${CHANGELOG_VERSION:-Unreleased}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:?missing value for --repo}"
+      shift 2
+      ;;
+    --output)
+      output="${2:?missing value for --output}"
+      shift 2
+      ;;
+    --from)
+      from_ref="${2:?missing value for --from}"
+      shift 2
+      ;;
+    --to)
+      to_ref="${2:?missing value for --to}"
+      shift 2
+      ;;
+    --version)
+      version="${2:?missing value for --version}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$repo"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Not a git repository: $repo" >&2
+  exit 1
+fi
+
+if [[ -z "$from_ref" ]]; then
+  from_ref="$(git describe --tags --abbrev=0 "$to_ref" 2>/dev/null || true)"
+fi
+
+if [[ -n "$from_ref" ]]; then
+  commit_range="${from_ref}..${to_ref}"
+  range_label="${from_ref}..${to_ref}"
+else
+  commit_range="$to_ref"
+  range_label="repository start..${to_ref}"
+fi
+
+generated_at="$(date -u '+%Y-%m-%d')"
+added_entries=""
+fixed_entries=""
+changed_entries=""
+removed_entries=""
+
+category_for_subject() {
+  local subject_lc
+  subject_lc="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+
+  case "$subject_lc" in
+    feat:*|feat\(*|feature:*|add:*|added:*)
+      printf 'Added'
+      ;;
+    fix:*|fix\(*|bug:*|bugfix:*|hotfix:*)
+      printf 'Fixed'
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|deprecate:*|deprecated:*)
+      printf 'Removed'
+      ;;
+    *)
+      printf 'Changed'
+      ;;
+  esac
+}
+
+clean_subject() {
+  local subject="$1"
+  subject="$(printf '%s' "$subject" | sed -E 's/^[A-Za-z]+(\([^)]+\))?!?:[[:space:]]*//')"
+  subject="$(printf '%s' "$subject" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  if [[ -z "$subject" ]]; then
+    subject="Unspecified change"
+  fi
+  printf '%s' "$subject"
+}
+
+append_entry() {
+  local category="$1"
+  local entry="$2"
+  case "$category" in
+    Added)
+      added_entries+="${entry}"$'\n'
+      ;;
+    Fixed)
+      fixed_entries+="${entry}"$'\n'
+      ;;
+    Removed)
+      removed_entries+="${entry}"$'\n'
+      ;;
+    *)
+      changed_entries+="${entry}"$'\n'
+      ;;
+  esac
+}
+
+while IFS=$'\t' read -r hash date subject || [[ -n "${hash:-}" ]]; do
+  [[ -n "${hash:-}" ]] || continue
+  category="$(category_for_subject "$subject")"
+  clean="$(clean_subject "$subject")"
+  append_entry "$category" "- ${clean} (${hash}, ${date})"
+done < <(git log "$commit_range" --no-merges --pretty=format:'%h%x09%ad%x09%s' --date=short --reverse)
+
+write_section() {
+  local title="$1"
+  local entries="$2"
+  {
+    printf '### %s\n\n' "$title"
+    if [[ -n "$entries" ]]; then
+      printf '%s\n' "$entries"
+    else
+      printf -- '- No changes.\n\n'
+    fi
+  } >> "$tmp_file"
+}
+
+tmp_file="$(mktemp)"
+{
+  printf '# Changelog\n\n'
+  printf 'Generated from git history on %s.\n\n' "$generated_at"
+  printf '## [%s] - %s\n\n' "$version" "$generated_at"
+  printf 'Source range: `%s`\n\n' "$range_label"
+} > "$tmp_file"
+
+write_section "Added" "$added_entries"
+write_section "Fixed" "$fixed_entries"
+write_section "Changed" "$changed_entries"
+write_section "Removed" "$removed_entries"
+
+mkdir -p "$(dirname "$output")"
+mv "$tmp_file" "$output"
+printf 'Wrote %s\n' "$output"

--- a/samples/claude-builders-bounty-changelog.md
+++ b/samples/claude-builders-bounty-changelog.md
@@ -1,0 +1,23 @@
+# Changelog
+
+Generated from git history on 2026-05-19.
+
+## [Sample] - 2026-05-19
+
+Source range: `repository start..HEAD`
+
+### Added
+
+- initial README with bounty board (1aeae2a, 2026-03-27)
+
+### Fixed
+
+- No changes.
+
+### Changed
+
+- No changes.
+
+### Removed
+
+- No changes.

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,29 @@
+# Generate Changelog
+
+Use this skill when the user asks to create, refresh, or inspect a `CHANGELOG.md`
+from the current repository's git history.
+
+## Command
+
+Run the repository script from the project root:
+
+```bash
+bash changelog.sh
+```
+
+## Behavior
+
+- Detects the latest reachable git tag with `git describe --tags --abbrev=0`.
+- Reads commits from that tag through `HEAD`; if no tag exists, reads all commits.
+- Categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a complete `CHANGELOG.md` with the source range and generation date.
+
+## Options
+
+```bash
+bash changelog.sh --repo /path/to/repo --output CHANGELOG.md --version 1.2.3
+bash changelog.sh --from v1.0.0 --to HEAD
+```
+
+Before committing the generated changelog, inspect the diff and adjust wording if
+the commit subjects are too terse for release notes.

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+git -C "$tmp_dir" init -q
+git -C "$tmp_dir" config user.email "test@example.com"
+git -C "$tmp_dir" config user.name "Test User"
+
+printf 'initial\n' > "$tmp_dir/file.txt"
+git -C "$tmp_dir" add file.txt
+git -C "$tmp_dir" commit -q -m "chore: initial release"
+git -C "$tmp_dir" tag v1.0.0
+
+printf 'feature\n' >> "$tmp_dir/file.txt"
+git -C "$tmp_dir" commit -am "feat: add export button" -q
+
+printf 'fix\n' >> "$tmp_dir/file.txt"
+git -C "$tmp_dir" commit -am "fix: correct empty state" -q
+
+printf 'change\n' >> "$tmp_dir/file.txt"
+git -C "$tmp_dir" commit -am "refactor: simplify parser" -q
+
+printf 'remove\n' >> "$tmp_dir/file.txt"
+git -C "$tmp_dir" commit -am "remove: legacy flag" -q
+
+output="$tmp_dir/CHANGELOG.md"
+bash "$repo_root/changelog.sh" --repo "$tmp_dir" --output "$output" --version "Test"
+
+grep -q 'Source range: `v1.0.0..HEAD`' "$output"
+grep -q '### Added' "$output"
+grep -q 'add export button' "$output"
+grep -q '### Fixed' "$output"
+grep -q 'correct empty state' "$output"
+grep -q '### Changed' "$output"
+grep -q 'simplify parser' "$output"
+grep -q '### Removed' "$output"
+grep -q 'legacy flag' "$output"
+if grep -q 'initial release' "$output"; then
+  echo "included commits before the latest tag" >&2
+  exit 1
+fi
+
+echo "changelog generator test passed"


### PR DESCRIPTION
/claim #1

## Summary
- Add zero-dependency `changelog.sh` that detects the latest tag and writes `CHANGELOG.md`.
- Add a Claude Code skill wrapper for changelog generation.
- Add a regression test and sample output generated from this repository.

## Acceptance Criteria
- Supports `bash changelog.sh`.
- Fetches commits since the latest reachable git tag, with all-history fallback when no tag exists.
- Categorizes commits into Added, Fixed, Changed, and Removed.
- Outputs a formatted changelog.
- Includes sample output at `samples/claude-builders-bounty-changelog.md`.
- Documents setup and usage in 3 steps.

## Validation
- `bash -n changelog.sh tests/test_changelog.sh`
- `bash tests/test_changelog.sh`
- `git diff --check`