### PR TITLE
Add destructive command guard hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/hooks/destructive-command-guard/README.md
+++ b/hooks/destructive-command-guard/README.md
@@ -1,0 +1,55 @@
+# Destructive Command Guard
+
+Claude Code `PreToolUse` hook for Bash commands. It blocks destructive shell or SQL
+operations before they run and records each block in `~/.claude/hooks/blocked.log`.
+
+## Install
+
+```bash
+python3 hooks/destructive-command-guard/install.py
+```
+
+Restart Claude Code after installation so the updated `~/.claude/settings.json`
+is loaded.
+
+## What It Blocks
+
+- `rm -rf` and equivalent recursive + force flag combinations, because a typo can
+  remove more than the intended directory.
+- `DROP TABLE`, because schema deletion should be an explicit database migration,
+  not an incidental shell command.
+- `git push --force`, `git push -f`, and `git push --force-with-lease`, because
+  rewriting remote history can erase collaborators' work.
+- `TRUNCATE`, because it removes table or file contents without row-level review.
+- `DELETE FROM` statements without a `WHERE` clause, because they delete every row.
+
+Safe commands such as `ls`, `git push origin main`, `rm file.txt`, and
+`DELETE FROM sessions WHERE id = ?` are allowed.
+
+## Hook Configuration
+
+The installer copies the hook to `~/.claude/hooks/pre-tool-use-block-destructive.py`
+and adds this Claude Code settings entry:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/pre-tool-use-block-destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Claude Code passes hook input as JSON on stdin. When the command is blocked, the
+hook returns a `PreToolUse` `permissionDecision: deny` response with a clear reason
+for Claude and writes a JSON line containing timestamp, attempted command,
+blocked pattern, reason, and project path to `blocked.log`.

--- a/hooks/destructive-command-guard/install.py
+++ b/hooks/destructive-command-guard/install.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Install the destructive command guard into the current user's Claude settings."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import stat
+from pathlib import Path
+from typing import Any
+
+
+HOOK_NAME = "pre-tool-use-block-destructive.py"
+COMMAND = f"python3 ~/.claude/hooks/{HOOK_NAME}"
+
+
+def load_settings(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        backup = path.with_suffix(path.suffix + ".bak")
+        shutil.copy2(path, backup)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def ensure_hook(settings: dict[str, Any]) -> None:
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    entry = {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": COMMAND,
+            }
+        ],
+    }
+    for existing in pre_tool_use:
+        if not isinstance(existing, dict):
+            continue
+        for hook in existing.get("hooks") or []:
+            if isinstance(hook, dict) and hook.get("command") == COMMAND:
+                return
+    pre_tool_use.append(entry)
+
+
+def main() -> int:
+    source = Path(__file__).resolve().with_name(HOOK_NAME)
+    claude_dir = Path.home() / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    target = hooks_dir / HOOK_NAME
+    shutil.copy2(source, target)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    settings_path = claude_dir / "settings.json"
+    settings = load_settings(settings_path)
+    ensure_hook(settings)
+    settings_path.write_text(json.dumps(settings, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"Installed {target}")
+    print(f"Updated {settings_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-guard/pre-tool-use-block-destructive.py
+++ b/hooks/destructive-command-guard/pre-tool-use-block-destructive.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def read_event() -> dict[str, Any]:
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def split_statements(command: str) -> list[str]:
+    return [part.strip() for part in re.split(r"[;\n]", command) if part.strip()]
+
+
+def has_rm_rf(command: str) -> bool:
+    for statement in split_statements(command):
+        words = shell_words(statement)
+        if not words or words[0] != "rm":
+            continue
+
+        short_flags = "".join(word[1:] for word in words[1:] if re.fullmatch(r"-[A-Za-z]+", word))
+        long_flags = {word for word in words[1:] if word.startswith("--")}
+        has_recursive = "r" in short_flags or "R" in short_flags or "--recursive" in long_flags
+        has_force = "f" in short_flags or "--force" in long_flags
+        if has_recursive and has_force:
+            return True
+
+    return re.search(r"(?i)(?:^|[;&|]\s*)rm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b", command) is not None
+
+
+def has_force_push(command: str) -> bool:
+    return (
+        re.search(r"(?i)(?:^|[;&|]\s*)git\s+push\b[^\n;&|]*\s(?:--force(?:-with-lease)?|-f)\b", command)
+        is not None
+    )
+
+
+def has_drop_table(command: str) -> bool:
+    return re.search(r"(?is)\bdrop\s+table\b", command) is not None
+
+
+def has_truncate(command: str) -> bool:
+    return re.search(r"(?is)(?:^|[;&|]\s*)truncate\b|\btruncate\s+(?:table\s+)?[A-Za-z_]", command) is not None
+
+
+def has_delete_without_where(command: str) -> bool:
+    for statement in split_statements(command):
+        if re.search(r"(?is)\bdelete\s+from\b", statement) and not re.search(r"(?is)\bwhere\b", statement):
+            return True
+    return False
+
+
+CHECKS = (
+    ("rm -rf", has_rm_rf, "recursive forced deletion can irreversibly remove project or system files"),
+    ("DROP TABLE", has_drop_table, "DROP TABLE can destroy database schema and data"),
+    ("git push --force", has_force_push, "force-pushing can overwrite shared Git history"),
+    ("TRUNCATE", has_truncate, "TRUNCATE can erase table or file contents without row-level review"),
+    ("DELETE FROM without WHERE", has_delete_without_where, "DELETE FROM without WHERE can remove every row"),
+)
+
+
+def blocked_reason(command: str) -> tuple[str, str] | None:
+    for pattern, check, reason in CHECKS:
+        if check(command):
+            return pattern, reason
+    return None
+
+
+def project_path(event: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path"):
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def log_block(event: dict[str, Any], command: str, pattern: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "attempted_command": command,
+        "blocked_pattern": pattern,
+        "reason": reason,
+        "project_path": project_path(event),
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def deny(pattern: str, reason: str, command: str) -> None:
+    message = (
+        f"Blocked destructive Bash command: matched {pattern}. {reason}. "
+        "Choose a safer command or ask the user for explicit recovery steps."
+    )
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": message,
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    event = read_event()
+    if event.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else {}
+    command = str(tool_input.get("command") or "")
+    if not command.strip():
+        return 0
+
+    match = blocked_reason(command)
+    if match is None:
+        return 0
+
+    pattern, reason = match
+    log_block(event, command, pattern, reason)
+    deny(pattern, reason, command)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_destructive_command_guard.py
+++ b/tests/test_destructive_command_guard.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Regression tests for the destructive command guard hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "destructive-command-guard" / "pre-tool-use-block-destructive.py"
+INSTALLER = ROOT / "hooks" / "destructive-command-guard" / "install.py"
+
+
+def run_hook(command: str, home: Path, tool_name: str = "Bash") -> subprocess.CompletedProcess[str]:
+    event = {
+        "tool_name": tool_name,
+        "hook_event_name": "PreToolUse",
+        "cwd": "/workspace/example",
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(event),
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "HOME": str(home)},
+    )
+
+
+def assert_blocked(command: str, expected_pattern: str, home: Path) -> None:
+    completed = run_hook(command, home)
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    output = payload["hookSpecificOutput"]
+    assert output["hookEventName"] == "PreToolUse"
+    assert output["permissionDecision"] == "deny"
+    assert expected_pattern in output["permissionDecisionReason"]
+
+    log_path = home / ".claude" / "hooks" / "blocked.log"
+    records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert records[-1]["attempted_command"] == command
+    assert records[-1]["blocked_pattern"] == expected_pattern
+    assert records[-1]["project_path"] == "/workspace/example"
+    assert "timestamp" in records[-1]
+
+
+def assert_allowed(command: str, home: Path, tool_name: str = "Bash") -> None:
+    completed = run_hook(command, home, tool_name=tool_name)
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+
+
+def test_required_destructive_patterns_are_blocked() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        home = Path(tmp)
+        cases = [
+            ("rm -rf build", "rm -rf"),
+            ("rm -fr build", "rm -rf"),
+            ("rm --recursive --force build", "rm -rf"),
+            ("psql -c 'DROP TABLE users'", "DROP TABLE"),
+            ("git push origin main --force", "git push --force"),
+            ("git push -f origin main", "git push --force"),
+            ("sqlite3 app.db 'TRUNCATE TABLE sessions'", "TRUNCATE"),
+            ("sqlite3 app.db 'DELETE FROM sessions'", "DELETE FROM without WHERE"),
+        ]
+        for command, pattern in cases:
+            assert_blocked(command, pattern, home)
+
+
+def test_normal_commands_are_allowed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        home = Path(tmp)
+        for command in [
+            "ls -la",
+            "rm file.txt",
+            "git push origin main",
+            "sqlite3 app.db 'DELETE FROM sessions WHERE id = 1'",
+            "python3 -m pytest",
+        ]:
+            assert_allowed(command, home)
+        assert_allowed("rm -rf build", home, tool_name="Read")
+
+
+def test_installer_copies_hook_and_merges_settings() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        home = Path(tmp)
+        completed = subprocess.run(
+            [sys.executable, str(INSTALLER)],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={**os.environ, "HOME": str(home)},
+        )
+        assert completed.returncode == 0, completed.stderr
+
+        installed_hook = home / ".claude" / "hooks" / "pre-tool-use-block-destructive.py"
+        assert installed_hook.exists()
+        assert os.access(installed_hook, os.X_OK)
+
+        settings = json.loads((home / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        pre_tool_use = settings["hooks"]["PreToolUse"]
+        assert pre_tool_use[0]["matcher"] == "Bash"
+        assert pre_tool_use[0]["hooks"][0]["command"] == "python3 ~/.claude/hooks/pre-tool-use-block-destructive.py"
+
+
+if __name__ == "__main__":
+    test_required_destructive_patterns_are_blocked()
+    test_normal_commands_are_allowed()
+    test_installer_copies_hook_and_merges_settings()
+    print("destructive command guard tests passed")


### PR DESCRIPTION
/claim #3

## Summary
- Add a Claude Code `PreToolUse` Bash hook that denies destructive commands before execution.
- Add a one-command installer that copies the hook to `~/.claude/hooks/` and merges `~/.claude/settings.json`.
- Add README documentation and stdlib regression tests for required block/allow behavior and `blocked.log` records.

## Acceptance Criteria
- Hook follows Claude Code `PreToolUse` format with `matcher: Bash` and `permissionDecision: deny`.
- Blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without `WHERE`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, blocked pattern, reason, and project path.
- Returns a clear denial reason to Claude.
- Allows normal Bash commands such as `ls`, `rm file.txt`, `git push origin main`, and `DELETE FROM ... WHERE ...`.
- README installation is one command.

## Validation
- `python3 -m py_compile hooks/destructive-command-guard/pre-tool-use-block-destructive.py hooks/destructive-command-guard/install.py tests/test_destructive_command_guard.py`
- `python3 tests/test_destructive_command_guard.py`
- `git diff --check`