### PR TITLE
[BOUNTY #3] HOOK: Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/bash-blocker/README.md
+++ b/bash-blocker/README.md
@@ -1,0 +1,118 @@
+# Destructive Bash Command Blocker
+
+A Claude Code pre-tool-use hook that intercepts and blocks dangerous bash commands before execution.
+
+## What It Blocks
+
+- `rm -rf` / `rm -fr` recursive force deletion
+- `DROP TABLE` SQL statements
+- `git push --force`
+- `TRUNCATE` SQL statements
+- `DELETE FROM` without a `WHERE` clause
+
+## Installation
+
+```bash
+mkdir -p ~/.claude/hooks && cp pre-tool-use ~/.claude/hooks/pre-tool-use && chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+That's it. Claude Code will run the hook before tool use.
+
+## How It Works
+
+The hook intercepts bash/shell/exec/terminal tool calls before Claude Code executes them. If a dangerous pattern is detected:
+
+1. **Blocks execution** immediately with a non-zero exit code
+2. **Logs the attempt** to `~/.claude/hooks/blocked.log` with:
+   - Timestamp
+   - Project path
+   - Blocked reason
+   - Full attempted command
+3. **Notifies Claude** with a clear JSON message explaining why the command was blocked
+
+## Example Block Message
+
+```json
+{
+  "error": "Command blocked: rm -rf recursive force delete",
+  "message": "Claude Code safety hook blocked this Bash command because it matched: rm -rf recursive force delete.\n\nAttempted command:\nrm -rf /tmp/data\n\nThis can destroy files, rewrite remote history, or damage database data. If this action is truly intended, review it manually and run it outside Claude Code.\n\nBlocked attempt logged to: ~/.claude/hooks/blocked.log"
+}
+```
+
+## Log Format
+
+```text
+2026-05-19T12:05:00.000000 | /home/user/project | rm -rf recursive force delete | rm -rf /tmp/data
+2026-05-19T12:06:15.123456 | /home/user/project | DROP TABLE SQL statement | DROP TABLE users;
+```
+
+## Testing
+
+Run the included test suite:
+
+```bash
+python3 test_hook.py
+```
+
+Expected result:
+
+```text
+Results: 23 passed, 0 failed
+✅ All tests passed!
+```
+
+## Supported Hook Payloads
+
+The hook supports common Claude Code hook payload shapes:
+
+```json
+{
+  "tool": {
+    "name": "bash",
+    "input": { "command": "rm -rf /tmp/data" }
+  },
+  "project_path": "/home/user/project"
+}
+```
+
+It also supports `tool_name`, `tool_input`, `toolName`, `toolInput`, top-level `command` / `script`, and `cwd` variants for compatibility.
+
+## Safe Commands Are Allowed
+
+These commands are **not blocked**:
+
+```bash
+rm file.txt
+rm -f file.txt
+rm -r directory
+git push origin main
+git push --force-with-lease origin main
+DELETE FROM users WHERE id = 1
+echo 'DROP TABLE' > note.txt
+```
+
+## Disabling
+
+To temporarily disable:
+
+```bash
+mv ~/.claude/hooks/pre-tool-use ~/.claude/hooks/pre-tool-use.disabled
+```
+
+To re-enable:
+
+```bash
+mv ~/.claude/hooks/pre-tool-use.disabled ~/.claude/hooks/pre-tool-use
+```
+
+## Requirements
+
+- Python 3.6+
+- Claude Code with hooks support
+
+## Notes
+
+- Only bash-like tool calls are inspected
+- Non-bash tools are not affected
+- Hook errors fail open so malformed payloads do not break normal Claude Code usage
+- SQL checks ignore quoted strings to avoid false positives like `echo 'DROP TABLE' > note.txt`

--- a/bash-blocker/pre-tool-use
+++ b/bash-blocker/pre-tool-use
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook that blocks destructive bash commands.
+
+The hook reads Claude Code hook JSON from stdin, checks Bash commands for
+high-risk destructive patterns, logs blocked attempts, and exits non-zero to
+prevent execution.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+LOG_FILE = Path.home() / ".claude" / "hooks" / "blocked.log"
+BASH_TOOL_NAMES = {"bash", "shell", "exec", "terminal", "Bash"}
+
+
+def has_rm_rf(command: str) -> bool:
+    """Detect rm invocations with both recursive and force flags."""
+    # Match rm with optional sudo/doas prefix
+    for match in re.finditer(r"(?:^|[;&|`$()\n])\s*(?:sudo\s+|doas\s+)?rm\s+([^;&|`$()\n]+)", command, re.IGNORECASE):
+        args = match.group(1).split()
+        flags = "".join(arg[1:] for arg in args if arg.startswith("-") and not arg.startswith("--"))
+        long_flags = {arg for arg in args if arg.startswith("--")}
+        has_recursive = "r" in flags or "R" in flags or "--recursive" in long_flags
+        has_force = "f" in flags or "--force" in long_flags
+        if has_recursive and has_force:
+            return True
+    return False
+
+
+def has_sql_keyword_outside_quotes(command: str, keyword: str) -> bool:
+    """Check if SQL keyword appears outside of quoted strings."""
+    # Remove single-quoted strings
+    no_single = re.sub(r"'[^']*'", "", command)
+    # Remove double-quoted strings
+    no_quotes = re.sub(r'"[^"]*"', "", no_single)
+    # Now check for keyword
+    return bool(re.search(rf"\b{keyword}\b", no_quotes, re.IGNORECASE))
+
+
+def has_delete_without_where(command: str) -> bool:
+    """Detect DELETE FROM statements that do not contain WHERE before statement end."""
+    # Remove quoted strings first
+    no_single = re.sub(r"'[^']*'", "", command)
+    no_quotes = re.sub(r'"[^"]*"', "", no_single)
+    
+    for statement in re.split(r";|\n", no_quotes):
+        if re.search(r"\bDELETE\s+FROM\b", statement, re.IGNORECASE) and not re.search(
+            r"\bWHERE\b", statement, re.IGNORECASE
+        ):
+            return True
+    return False
+
+
+def check_command(command: str) -> tuple[bool, str]:
+    """Return (blocked, reason) for a command string."""
+    if has_rm_rf(command):
+        return True, "rm -rf recursive force delete"
+    if has_sql_keyword_outside_quotes(command, "DROP\\s+TABLE"):
+        return True, "DROP TABLE SQL statement"
+    if re.search(r"\bgit\s+push\b[^\n;|&]*\s--force(?:\s|$|=)", command, re.IGNORECASE):
+        return True, "git push --force"
+    if has_sql_keyword_outside_quotes(command, "TRUNCATE"):
+        return True, "TRUNCATE SQL statement"
+    if has_delete_without_where(command):
+        return True, "DELETE FROM without WHERE clause"
+    return False, ""
+
+
+def nested_get(data: dict[str, Any], *paths: tuple[str, ...], default: Any = None) -> Any:
+    for path in paths:
+        cur: Any = data
+        for key in path:
+            if not isinstance(cur, dict) or key not in cur:
+                break
+            cur = cur[key]
+        else:
+            return cur
+    return default
+
+
+def extract_tool_name(data: dict[str, Any]) -> str:
+    return str(
+        nested_get(
+            data,
+            ("tool", "name"),
+            ("tool_name",),
+            ("toolName",),
+            default="",
+        )
+    )
+
+
+def extract_command(data: dict[str, Any]) -> str:
+    return str(
+        nested_get(
+            data,
+            ("tool", "input", "command"),
+            ("tool", "input", "script"),
+            ("tool_input", "command"),
+            ("tool_input", "script"),
+            ("toolInput", "command"),
+            ("toolInput", "script"),
+            ("command",),
+            ("script",),
+            default="",
+        )
+    )
+
+
+def extract_project_path(data: dict[str, Any]) -> str:
+    return str(
+        nested_get(
+            data,
+            ("project_path",),
+            ("projectPath",),
+            ("cwd",),
+            ("tool", "input", "cwd"),
+            ("tool_input", "cwd"),
+            default="unknown",
+        )
+    )
+
+
+def log_blocked(command: str, reason: str, project_path: str) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().isoformat()
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp} | {project_path} | {reason} | {command}\n")
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return 0
+
+        data = json.loads(raw)
+        tool_name = extract_tool_name(data)
+        command = extract_command(data)
+
+        if tool_name and tool_name not in BASH_TOOL_NAMES:
+            return 0
+        if not command:
+            return 0
+
+        blocked, reason = check_command(command)
+        if not blocked:
+            return 0
+
+        project_path = extract_project_path(data)
+        log_blocked(command, reason, project_path)
+
+        print(
+            json.dumps(
+                {
+                    "error": f"Command blocked: {reason}",
+                    "message": (
+                        f"Claude Code safety hook blocked this Bash command because it matched: {reason}.\n\n"
+                        f"Attempted command:\n{command}\n\n"
+                        "This can destroy files, rewrite remote history, or damage database data. "
+                        "If this action is truly intended, review it manually and run it outside Claude Code.\n\n"
+                        f"Blocked attempt logged to: {LOG_FILE}"
+                    ),
+                }
+            )
+        )
+        return 1
+
+    except Exception as exc:
+        # Fail open so a malformed hook payload does not break normal Claude Code usage.
+        print(json.dumps({"warning": f"destructive-bash-blocker hook error: {exc}"}), file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bash-blocker/test_hook.py
+++ b/bash-blocker/test_hook.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Test suite for destructive bash command blocker hook.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).parent / "pre-tool-use"
+
+def test_hook(command: str, tool_name: str = "bash", should_block: bool = True) -> bool:
+    """Test hook with a command and return True if result matches expectation."""
+    payload = json.dumps({
+        "tool": {
+            "name": tool_name,
+            "input": {"command": command}
+        },
+        "project_path": "/test/project"
+    })
+    
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=5
+    )
+    
+    blocked = result.returncode != 0
+    
+    if blocked != should_block:
+        print(f"❌ FAIL: {command[:60]}")
+        print(f"   Expected: {'block' if should_block else 'allow'}, Got: {'block' if blocked else 'allow'}")
+        if blocked:
+            print(f"   Output: {result.stdout[:200]}")
+        return False
+    
+    print(f"✅ PASS: {command[:60]}")
+    return True
+
+
+def main():
+    print("Testing destructive bash command blocker...\n")
+    
+    tests = [
+        # Should block
+        ("rm -rf /tmp/data", "bash", True),
+        ("rm -rf .", "bash", True),
+        ("rm -fr /home/user", "bash", True),
+        ("sudo rm -rf /var/log", "bash", True),
+        ("DROP TABLE users", "bash", True),
+        ("DROP TABLE users;", "bash", True),
+        ("git push --force origin main", "bash", True),
+        ("git push origin main --force", "bash", True),
+        ("TRUNCATE TABLE logs", "bash", True),
+        ("DELETE FROM users", "bash", True),
+        ("DELETE FROM users;", "bash", True),
+        ("echo test && rm -rf /tmp && echo done", "bash", True),
+        
+        # Should allow
+        ("rm file.txt", "bash", False),
+        ("rm -f file.txt", "bash", False),
+        ("rm -r directory", "bash", False),
+        ("git push origin main", "bash", False),
+        ("git push --force-with-lease origin main", "bash", False),
+        ("DELETE FROM users WHERE id = 1", "bash", False),
+        ("SELECT * FROM users", "bash", False),
+        ("ls -la", "bash", False),
+        ("echo 'DROP TABLE' > file.txt", "bash", False),
+        
+        # Non-bash tools should always allow
+        ("rm -rf /", "file_editor", False),
+        ("DROP TABLE users", "python", False),
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for command, tool, should_block in tests:
+        if test_hook(command, tool, should_block):
+            passed += 1
+        else:
+            failed += 1
+    
+    print(f"\n{'='*60}")
+    print(f"Results: {passed} passed, {failed} failed")
+    
+    if failed > 0:
+        sys.exit(1)
+    
+    print("\n✅ All tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements a Claude Code pre-tool-use hook that intercepts and blocks dangerous bash commands before execution.

## Implementation

- Python hook script: `bash-blocker/pre-tool-use`
- Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- Logs all blocked attempts to `~/.claude/hooks/blocked.log`
- Returns clear error messages to Claude explaining why commands were blocked

## Acceptance Criteria

- ✅ Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- ✅ Blocks all required patterns:
  - `rm -rf` (including `sudo rm -rf`)
  - `DROP TABLE`
  - `git push --force`
  - `TRUNCATE`
  - `DELETE FROM` without WHERE clause
- ✅ Logs every blocked attempt with timestamp, command, and project path
- ✅ Displays clear message to Claude explaining why command was blocked
- ✅ Does not interfere with normal bash commands
- ✅ README with installation in 2 commands or fewer

## Testing

Includes comprehensive test suite (`test_hook.py`) with 23 test cases:
- 12 commands that should be blocked
- 11 commands that should be allowed

All tests pass:
```
Results: 23 passed, 0 failed
✅ All tests passed!
```

## Installation

```bash
mkdir -p ~/.claude/hooks && cp bash-blocker/pre-tool-use ~/.claude/hooks/pre-tool-use && chmod +x ~/.claude/hooks/pre-tool-use
```

## Features

- Smart pattern detection (ignores SQL keywords in quoted strings)
- Supports `sudo`/`doas` prefixes
- Fail-open on hook errors (doesn't break Claude Code)
- Compatible with multiple hook payload formats

Closes #3