### PR TITLE
feat: generate-changelog skill — structured CHANGELOG from git history (#1 $50 bounty)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commit history. Use when the user asks to generate a changelog, update release notes, or document recent changes.
+---
+
+# Generate Changelog Skill
+
+Generate a structured `CHANGELOG.md` from the project's git history.
+
+## Trigger
+
+When the user says any of:
+- "generate changelog"
+- "update changelog"  
+- "create release notes"
+- "what's changed since last release"
+- `/generate-changelog`
+
+## Workflow
+
+### Step 1: Determine version range
+
+Run the following to find the latest git tag and collect commits since:
+
+```bash
+# Get latest tag
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+# If no tags exist, use all commits
+if [ -z "$LATEST_TAG" ]; then
+  RANGE="HEAD"
+  VERSION="Unreleased"
+else
+  RANGE="${LATEST_TAG}..HEAD"
+  VERSION="Unreleased (since ${LATEST_TAG})"
+fi
+
+# Get commits in range
+COMMITS=$(git log --oneline --no-merges $RANGE 2>/dev/null)
+```
+
+### Step 2: Categorize commits
+
+Categorize each commit into one of four sections by scanning the commit message prefix:
+
+| Prefix Pattern | Category |
+|---------------|----------|
+| `feat:` `add:` `added:` `new:` | **Added** |
+| `fix:` `bug:` `patch:` `hotfix:` `resolve:` | **Fixed** |
+| `change:` `update:` `refactor:` `perf:` `style:` `improve:` `tweak:` | **Changed** |
+| `remove:` `delete:` `drop:` `deprecate:` `revert:` | **Removed** |
+
+Unrecognized commits go under **Changed** with a `[misc]` tag.
+
+### Step 3: Generate CHANGELOG.md
+
+Write `CHANGELOG.md` to the project root using this template:
+
+```markdown
+# Changelog
+
+## {{VERSION}} — {{DATE}}
+
+### Added
+{{list of "Added" commits, one per line: "- commit message (hash)"}}
+{{or "_None_" if empty}}
+
+### Fixed
+{{list of "Fixed" commits, one per line: "- commit message (hash)"}}
+{{or "_None_" if empty}}
+
+### Changed
+{{list of "Changed" commits, one per line: "- commit message (hash)"}}
+{{or "_None_" if empty}}
+
+### Removed
+{{list of "Removed" commits, one per line: "- commit message (hash)"}}
+{{or "_None_" if empty}}
+```
+
+### Step 4: Report
+
+After generating, tell the user:
+- How many commits were included
+- The version range
+- The output file path
+- A preview of the first 5 entries
+
+## Edge Cases
+
+- **No commits since last tag**: Write "No changes since {{LATEST_TAG}}" and exit cleanly
+- **No tags exist**: Use "Unreleased" as the version header
+- **Existing CHANGELOG.md**: Prepend the new entry above existing content (don't overwrite)
+- **Merge commits**: Always skip merge commits (`--no-merges`)
+- **Empty repository**: Exit with a helpful message: "No commits found. Make your first commit first!"

--- a/SKILL_README.md
+++ b/SKILL_README.md
@@ -1,0 +1,68 @@
+# Generate Changelog — Claude Code Skill
+
+Generate a structured `CHANGELOG.md` from git history in one command.
+
+## Setup (3 steps)
+
+```bash
+# 1. Copy the skill to your project
+cp SKILL.md .claude/skills/generate-changelog.md
+cp changelog.sh scripts/changelog.sh
+chmod +x scripts/changelog.sh
+
+# 2. (Optional) Add to .gitignore if you don't want the script tracked
+# echo "scripts/changelog.sh" >> .gitignore
+
+# 3. Run it
+bash scripts/changelog.sh
+```
+
+Or via Claude Code: just type `/generate-changelog`
+
+## What it does
+
+- 🔍 Fetches commits since the **latest git tag**
+- 🏷️ Auto-categorizes into: **Added** / **Fixed** / **Changed** / **Removed**
+- 📝 Outputs a properly formatted `CHANGELOG.md`
+- 🔄 Prepends new entries (won't overwrite existing changelog)
+- ⏭️ Skips merge commits automatically
+
+## Example output
+
+```markdown
+# Changelog
+
+## Unreleased (since v1.2.0) — 2026-05-19
+
+### Added
+- Dark mode toggle in settings (a1b2c3d)
+- Export to PDF feature (e4f5g6h)
+
+### Fixed
+- Login redirect loop on Safari (i7j8k9l)
+- Memory leak in WebSocket handler (m0n1o2p)
+
+### Changed
+- Updated dependencies to latest versions (q3r4s5t)
+
+### Removed
+- Deprecated /v1 API endpoint (u6v7w8x)
+```
+
+## Requirements
+
+- `git` installed
+- Bash 4.0+ (macOS / Linux / WSL)
+- No external dependencies
+
+## Dry run
+
+```bash
+bash changelog.sh --dry-run
+```
+
+Print the changelog to stdout without writing any files.
+
+---
+
+Part of the [Claude Builders Bounty](https://github.com/claude-builders-bounty) program.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# ============================================================
+# changelog.sh — Structured CHANGELOG generator from git history
+# Part of the `generate-changelog` Claude Code skill
+# ============================================================
+set -euo pipefail
+
+OUTPUT_FILE="${1:-CHANGELOG.md}"
+DRY_RUN="${2:-false}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[✓]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[!]${NC} $1"; }
+log_error() { echo -e "${RED}[✗]${NC} $1"; }
+
+# -----------------------------------------------------------
+# Check prerequisites
+# -----------------------------------------------------------
+if ! command -v git &> /dev/null; then
+    log_error "Git is not installed. Please install git first."
+    exit 1
+fi
+
+if ! git rev-parse --git-dir &> /dev/null; then
+    log_error "Not a git repository. Run this script inside a git project."
+    exit 1
+fi
+
+# -----------------------------------------------------------
+# Determine version range
+# -----------------------------------------------------------
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [ -z "$LATEST_TAG" ]; then
+    RANGE=""
+    VERSION="Unreleased"
+    log_warn "No git tags found. Generating changelog from all commits."
+else
+    # Check if there are commits after the latest tag
+    COMMIT_COUNT=$(git rev-list --count "${LATEST_TAG}..HEAD" 2>/dev/null || echo "0")
+    if [ "$COMMIT_COUNT" -eq 0 ]; then
+        log_info "No changes since $LATEST_TAG"
+        exit 0
+    fi
+    RANGE="${LATEST_TAG}..HEAD"
+    VERSION="Unreleased (since ${LATEST_TAG})"
+fi
+
+# -----------------------------------------------------------
+# Collect commits (skip merges)
+# -----------------------------------------------------------
+COMMITS=$(git log --oneline --no-merges $RANGE 2>/dev/null || echo "")
+
+if [ -z "$COMMITS" ]; then
+    log_info "No commits found. Make your first commit first!"
+    exit 0
+fi
+
+TOTAL=$(echo "$COMMITS" | wc -l | tr -d ' ')
+log_info "Found $TOTAL commits to process"
+
+# -----------------------------------------------------------
+# Categorize commits
+# -----------------------------------------------------------
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+
+    HASH=$(echo "$line" | awk '{print $1}')
+    MSG=$(echo "$line" | cut -d' ' -f2-)
+
+    # Lowercase prefix for case-insensitive matching
+    PREFIX=$(echo "$MSG" | awk -F':' '{print tolower($1)}')
+
+    case "$PREFIX" in
+        feat|add|added|new)
+            ADDED="${ADDED}- ${MSG#*: } (${HASH})\n"
+            ;;
+        fix|bug|patch|hotfix|resolve)
+            FIXED="${FIXED}- ${MSG#*: } (${HASH})\n"
+            ;;
+        remove|delete|drop|deprecate|revert)
+            REMOVED="${REMOVED}- ${MSG#*: } (${HASH})\n"
+            ;;
+        *)
+            # Strip conventional commit prefix if present
+            if echo "$MSG" | grep -q ':'; then
+                CHANGED="${CHANGED}- ${MSG#*: } (${HASH})\n"
+            else
+                CHANGED="${CHANGED}- ${MSG} (${HASH})\n"
+            fi
+            ;;
+    esac
+done <<< "$COMMITS"
+
+# -----------------------------------------------------------
+# Generate changelog entry
+# -----------------------------------------------------------
+DATE=$(date +%Y-%m-%d)
+
+# Build the new entry
+ENTRY="## ${VERSION} — ${DATE}
+
+### Added
+"
+if [ -n "$ADDED" ]; then
+    ENTRY+=$(echo -e "$ADDED")
+else
+    ENTRY+="_None_"
+fi
+
+ENTRY+="
+### Fixed
+"
+if [ -n "$FIXED" ]; then
+    ENTRY+=$(echo -e "$FIXED")
+else
+    ENTRY+="_None_"
+fi
+
+ENTRY+="
+### Changed
+"
+if [ -n "$CHANGED" ]; then
+    ENTRY+=$(echo -e "$CHANGED")
+else
+    ENTRY+="_None_"
+fi
+
+ENTRY+="
+### Removed
+"
+if [ -n "$REMOVED" ]; then
+    ENTRY+=$(echo -e "$REMOVED")
+else
+    ENTRY+="_None_"
+fi
+
+# -----------------------------------------------------------
+# Write output (prepend to existing CHANGELOG)
+# -----------------------------------------------------------
+if [ "$DRY_RUN" = "--dry-run" ] || [ "$DRY_RUN" = "-n" ]; then
+    echo -e "$ENTRY"
+    echo ""
+    log_info "Dry run complete. Use 'bash changelog.sh' to write the file."
+    exit 0
+fi
+
+if [ -f "$OUTPUT_FILE" ]; then
+    # Prepend: keep existing content below the new entry
+    EXISTING=$(cat "$OUTPUT_FILE")
+    # Check if it already has a header
+    if echo "$EXISTING" | head -1 | grep -q "^# Changelog"; then
+        # Has header — insert new entry after the header line
+        HEADER=$(echo "$EXISTING" | head -1)
+        BODY=$(echo "$EXISTING" | tail -n +2)
+        echo -e "$HEADER\n\n$ENTRY\n$BODY" > "$OUTPUT_FILE"
+    else
+        # No header — wrap everything
+        echo -e "# Changelog\n\n$ENTRY\n$EXISTING" > "$OUTPUT_FILE"
+    fi
+else
+    echo -e "# Changelog\n\n$ENTRY" > "$OUTPUT_FILE"
+fi
+
+# -----------------------------------------------------------
+# Report
+# -----------------------------------------------------------
+log_info "Changelog written to $OUTPUT_FILE"
+log_info "Version: $VERSION"
+log_info "Commits: $TOTAL"
+
+echo ""
+echo "Preview (first 5 entries):"
+echo "--------------------------"
+echo -e "$ENTRY" | grep "^- " | head -5 || echo "  (no categorized commits)"
+
+exit 0

--- a/sample_CHANGELOG.md
+++ b/sample_CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased (since v1.0.0) — 2026-05-19
+
+### Added
+- dark mode support (83a1176)
+### Fixed
+- memory leak in websocket (1b46515)
+### Changed
+- apply eslint rules (6800f0e)
+- just a plain commit message (e9eee41)
+- update API reference (42c141d)
+- default sort to 'recent' (5573008)
+### Removed
+- deprecated GraphQL schema (dcbf664)


### PR DESCRIPTION
## Description
Claude Code skill that generates a structured `CHANGELOG.md` from git history.

### How it works
- Skill triggers on `/generate-changelog` command
- Bash script (`changelog.sh`) does the heavy lifting
- Fetches commits since the latest git tag
- Auto-categorizes into: **Added** / **Fixed** / **Changed** / **Removed**
- Prepends new entries to existing CHANGELOG.md

### Acceptance criteria
- [x] Works via `/generate-changelog` AND `bash changelog.sh`
- [x] Fetches commits since the last git tag
- [x] Auto-categorizes into Added / Fixed / Changed / Removed
- [x] Outputs properly formatted CHANGELOG.md
- [x] Tested on a real git repo (sample output included in PR)
- [x] README with setup instructions in 3 steps