### PR TITLE
feat: add PR review sub-agent for bounty #4 ($150)

### DIFF
--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -1,0 +1,62 @@
+---
+name: pr-review
+description: Reviews a GitHub PR diff and posts a structured Markdown review comment. Use when the user wants to review a pull request.
+tools: Bash, Read, WebFetch
+model: sonnet
+---
+
+You are a senior code reviewer. Your task is to review a GitHub pull request and produce a structured Markdown review comment.
+
+## Input
+
+You will receive a PR URL or `owner/repo#number` reference.
+
+## Steps
+
+1. **Fetch the PR diff** using the GitHub CLI:
+   ```bash
+   gh pr view <owner/repo#number> --json title,body,files,additions,deletions
+   gh pr diff <owner/repo#number>
+   ```
+
+2. **Analyze the diff** for:
+   - Code correctness and logic errors
+   - Security vulnerabilities (SQL injection, XSS, auth bypass, etc.)
+   - Performance concerns (N+1 queries, missing indexes, memory leaks)
+   - Code style and best practices
+   - Missing tests or documentation
+   - Edge cases not handled
+
+3. **Produce structured Markdown output** in this exact format:
+
+   ```markdown
+   ## PR Review: <PR Title>
+
+   ### Summary
+   <2-3 sentence summary of what this PR does>
+
+   ### Risks
+   - <risk 1>
+   - <risk 2>
+   ...
+
+   ### Improvement Suggestions
+   - <suggestion 1>
+   - <suggestion 2>
+   ...
+
+   ### Verdict
+   <APPROVE / REQUEST_CHANGES / COMMENT with brief justification>
+   ```
+
+4. **Post the review** as a PR comment:
+   ```bash
+   gh pr comment <owner/repo#number> --body "<the structured markdown>"
+   ```
+
+## Guidelines
+
+- Be constructive and specific. Point to exact line numbers when possible.
+- Distinguish between blocking issues (security, correctness) and nice-to-haves.
+- If the PR is small and clean, say so. Don't invent problems.
+- If you cannot fetch the PR (e.g., private repo, no auth), output the review to stdout and inform the user they need to post it manually.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,26 +33,29 @@ jobs:
             echo "url=${{ github.event.issue.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Fetch PR info
-        id: info
+      - name: Fetch PR info and diff
+        id: fetch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_DATA=$(gh pr view "${{ steps.pr.outputs.url }}" \
-            --json title,body,files,additions,deletions,headRefName \
-            --jq '{title: .title, body: .body, files: .files, additions: .additions, deletions: .deletions, branch: .headRefName}')
-          echo "data=$PR_DATA" >> "$GITHUB_OUTPUT"
+          PR_URL="${{ steps.pr.outputs.url }}"
+          TITLE=$(gh pr view "$PR_URL" --json title -q '.title')
+          BODY=$(gh pr view "$PR_URL" --json body -q '.body')
+          FILES=$(gh pr view "$PR_URL" --json files -q '.files | length')
+          ADDITIONS=$(gh pr view "$PR_URL" --json additions -q '.additions')
+          DELETIONS=$(gh pr view "$PR_URL" --json deletions -q '.deletions')
+          DIFF=$(gh pr diff "$PR_URL")
 
-      - name: Fetch PR diff
-        id: diff
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          DIFF=$(gh pr diff "${{ steps.pr.outputs.url }}")
-          # Escape for JSON
-          echo "content<<EOF" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "body<<BODY_EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "BODY_EOF" >> "$GITHUB_OUTPUT"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "additions=$ADDITIONS" >> "$GITHUB_OUTPUT"
+          echo "deletions=$DELETIONS" >> "$GITHUB_OUTPUT"
+          echo "diff<<DIFF_EOF" >> "$GITHUB_OUTPUT"
           echo "$DIFF" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "DIFF_EOF" >> "$GITHUB_OUTPUT"
 
       - name: Review with Claude
         id: review
@@ -62,15 +65,15 @@ jobs:
           prompt: |
             You are a senior code reviewer. Review the following pull request and produce a structured Markdown review comment.
 
-            ## PR: ${{ fromJson(steps.info.outputs.data).title }}
+            ## PR: ${{ steps.fetch.outputs.title }}
 
-            ${{ fromJson(steps.info.outputs.data).body }}
+            ${{ steps.fetch.outputs.body }}
 
-            ## Changed Files: ${{ fromJson(steps.info.outputs.data).files }} (+${{ fromJson(steps.info.outputs.data).additions }}, -${{ fromJson(steps.info.outputs.data).deletions }})
+            ## Changed Files: ${{ steps.fetch.outputs.files }} (+${{ steps.fetch.outputs.additions }}, -${{ steps.fetch.outputs.deletions }})
 
             ## Diff
             ```
-            ${{ steps.diff.outputs.content }}
+            ${{ steps.fetch.outputs.diff }}
             ```
 
             Produce a structured review with:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,89 @@
+name: PR Review Agent
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: "PR URL to review"
+        required: true
+        type: string
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'issue_comment' &&
+       github.event.comment.body =~ '/review' &&
+       github.event.issue.pull_request) ||
+      github.event_name == 'workflow_dispatch'
+
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Determine PR URL
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "url=${{ inputs.pr_url }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=${{ github.event.issue.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch PR info
+        id: info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_DATA=$(gh pr view "${{ steps.pr.outputs.url }}" \
+            --json title,body,files,additions,deletions,headRefName \
+            --jq '{title: .title, body: .body, files: .files, additions: .additions, deletions: .deletions, branch: .headRefName}')
+          echo "data=$PR_DATA" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch PR diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DIFF=$(gh pr diff "${{ steps.pr.outputs.url }}")
+          # Escape for JSON
+          echo "content<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$DIFF" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Review with Claude
+        id: review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are a senior code reviewer. Review the following pull request and produce a structured Markdown review comment.
+
+            ## PR: ${{ fromJson(steps.info.outputs.data).title }}
+
+            ${{ fromJson(steps.info.outputs.data).body }}
+
+            ## Changed Files: ${{ fromJson(steps.info.outputs.data).files }} (+${{ fromJson(steps.info.outputs.data).additions }}, -${{ fromJson(steps.info.outputs.data).deletions }})
+
+            ## Diff
+            ```
+            ${{ steps.diff.outputs.content }}
+            ```
+
+            Produce a structured review with:
+            1. **Summary** (2-3 sentences of what this PR does)
+            2. **Risks** (list of identified risks — security, correctness, performance)
+            3. **Improvement Suggestions** (list of suggestions)
+            4. **Verdict** (APPROVE / REQUEST_CHANGES / COMMENT with brief justification)
+
+            Output ONLY the Markdown review, no preamble or explanation.
+
+      - name: Post review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ steps.pr.outputs.url }}" \
+            --body "${{ steps.review.outputs.result }}"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'issue_comment' &&
-       github.event.comment.body =~ '/review' &&
+       contains(github.event.comment.body, '/review') &&
        github.event.issue.pull_request) ||
       github.event_name == 'workflow_dispatch'
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
 
     steps:
       - name: Determine PR URL

--- a/examples/sample-review.md
+++ b/examples/sample-review.md
@@ -1,0 +1,19 @@
+### Summary
+
+This PR adds 10 new nuclei vulnerability detection templates for CISA Known Exploited Vulnerabilities (KEV), targeting Pulse Secure/Ivanti VPN appliances, Cisco IP Phones, SAP CRM, Telerik UI, Array Networks, Apache Struts, and Cisco IOS XE. All templates use detection-only matchers without exploitation payloads.
+
+### Risk Assessment
+
+- **False positive risk in CVE-2017-9248**: The matcher checks for a generic .NET error message that could appear on any misconfigured ASP.NET application
+- **Version detection gap in CVE-2020-8218 and CVE-2020-8260**: Both Pulse Secure templates detect the product but do not verify whether the installed version is actually vulnerable
+- **Missing `max-redirects`**: Several templates follow redirect chains which could lead to matcher issues on misconfigured servers
+
+### Suggestions
+
+1. Consider adding a `Server` header check to reduce false positives on CVE-2017-9248
+2. Add `max-redirects: 0` to templates that should not follow redirects
+3. Add version extraction logic to CVE-2020-8218 and CVE-2020-8260 for more precise detection
+
+### Confidence
+
+**Score: High** 鈥?Well-structured YAML templates following established conventions with clear best practices to evaluate against.

--- a/scripts/review-pr.py
+++ b/scripts/review-pr.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+review-pr.py - Review a GitHub PR via the GitHub API.
+
+Usage:
+    python scripts/review-pr.py <PR_URL or owner/repo#number>
+
+Requirements:
+    pip install anthropic requests
+
+Environment:
+    GITHUB_TOKEN - GitHub personal access token
+    ANTHROPIC_API_KEY - Anthropic API key
+"""
+
+import sys
+import os
+import re
+import json
+import urllib.request
+import urllib.error
+
+# Fix Windows console encoding
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+
+def api_get(url, token):
+    """Make an authenticated GET request to the GitHub API."""
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "pr-review-agent/1.0",
+    })
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def api_post(url, token, body):
+    """Make an authenticated POST request to the GitHub API."""
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, headers={
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+        "User-Agent": "pr-review-agent/1.0",
+    }, method="POST")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def normalize_pr_ref(ref):
+    """Convert PR URL to API endpoint."""
+    if ref.startswith("http"):
+        m = re.match(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", ref)
+        if m:
+            return m.group(1), m.group(2), int(m.group(3))
+        raise ValueError(f"Invalid PR URL: {ref}")
+    m = re.match(r"([^/]+)/([^#]+)#(\d+)", ref)
+    if m:
+        return m.group(1), m.group(2), int(m.group(3))
+    raise ValueError(f"Invalid PR reference: {ref}. Use owner/repo#number or full URL.")
+
+
+def fetch_pr(owner, repo, number, token):
+    """Fetch PR details and diff from GitHub."""
+    pr = api_get(f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}", token)
+    files = api_get(f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}/files?per_page=100", token)
+
+    diff_parts = []
+    for f in files:
+        if f.get("patch"):
+            diff_parts.append(f"--- {f['filename']} (+{f['additions']}/-{f['deletions']}) ---\n{f['patch']}")
+
+    return {
+        "title": pr["title"],
+        "body": pr.get("body", "") or "",
+        "url": pr["html_url"],
+        "author": pr["user"]["login"],
+        "files_changed": len(files),
+        "additions": pr["additions"],
+        "deletions": pr["deletions"],
+        "diff": "\n\n".join(diff_parts),
+    }
+
+
+def review_with_claude(pr_data):
+    """Send PR data to Claude for review."""
+    try:
+        import anthropic
+    except ImportError:
+        print("[ERROR] anthropic package not installed. Run: pip install anthropic")
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+    prompt = f"""You are a senior software engineer conducting a thorough code review.
+
+## PR: {pr_data['title']}
+
+**Author:** {pr_data['author']}
+**Files changed:** {pr_data['files_changed']} (+{pr_data['additions']}/-{pr_data['deletions']})
+
+### Description
+{pr_data['body']}
+
+### Diff
+```
+{pr_data['diff'][:8000]}
+```
+
+Provide a structured review with these exact sections:
+
+## Summary
+(2-3 sentences summarizing what this PR does)
+
+## Risks
+- (List specific risks: security, correctness, performance, edge cases)
+(If no significant risks, write "No significant risks identified.")
+
+## Improvement Suggestions
+- (List specific, actionable suggestions)
+(If the code is clean, write "Code looks clean. No major suggestions.")
+
+## Verdict
+(APPROVE / REQUEST_CHANGES / COMMENT with one-line justification)
+
+Keep each section concise. Be specific — reference exact code patterns when possible."""
+
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=2048,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    return message.content[0].text
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <PR_URL or owner/repo#number>")
+        sys.exit(1)
+
+    gh_token = os.environ.get("GITHUB_TOKEN")
+    if not gh_token:
+        print("[ERROR] GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
+    # Check for dry-run mode (no API key needed)
+    dry_run = os.environ.get("ANTHROPIC_API_KEY") is None
+
+    ref = sys.argv[1]
+    try:
+        owner, repo, number = normalize_pr_ref(ref)
+    except ValueError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
+
+    print(f"🔍 Fetching PR #{number} from {owner}/{repo}...")
+    pr = fetch_pr(owner, repo, number, gh_token)
+    print(f"   Title: {pr['title']}")
+    print(f"   Files: {pr['files_changed']} (+{pr['additions']}/-{pr['deletions']})")
+
+    if dry_run:
+        print("\n⚠️  No ANTHROPIC_API_KEY set — outputting prompt only:")
+        print(f"\nPR: {pr['title']}\n{pr['body']}\n\nDiff:\n{pr['diff'][:2000]}...")
+        sys.exit(0)
+
+    print("\n🤖 Running Claude review...")
+    review = review_with_claude(pr)
+
+    print("\n" + "=" * 60)
+    print(review)
+    print("=" * 60)
+
+    # Post review as PR comment
+    print(f"\n📤 Posting review to {pr['url']}...")
+    try:
+        api_post(
+            f"https://api.github.com/repos/{owner}/{repo}/issues/{number}/comments",
+            gh_token,
+            {"body": review},
+        )
+        print("✅ Review posted successfully!")
+    except Exception as e:
+        print(f"⚠️  Could not post comment: {e}")
+        print("   Review output above can be posted manually.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# review-pr.sh - CLI tool to review a GitHub PR using Claude Code
+# Usage: ./scripts/review-pr.sh <PR_URL or owner/repo#number>
+#
+# Requirements: gh (GitHub CLI), claude (Claude Code CLI)
+# Environment: ANTHROPIC_API_KEY must be set
+
+set -euo pipefail
+
+PR_REF="${1:?Usage: review-pr.sh <PR_URL or owner/repo#number>}"
+
+# Normalize PR reference to owner/repo#number format
+if [[ "$PR_REF" == http* ]]; then
+  # Extract from URL: https://github.com/owner/repo/pull/123
+  PR_REF=$(echo "$PR_REF" | sed -E 's|https://github.com/([^/]+)/([^/]+)/pull/([0-9]+)|\1/\2#\3|')
+fi
+
+echo "🔍 Fetching PR: $PR_REF"
+
+# Fetch PR info
+PR_INFO=$(gh pr view "$PR_REF" --json title,body,files,additions,deletions,url 2>/dev/null) || {
+  echo "❌ Could not fetch PR. Check that the repo is public and gh is authenticated."
+  exit 1
+}
+
+PR_TITLE=$(echo "$PR_INFO" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).title))")
+PR_URL=$(echo "$PR_INFO" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).url))")
+PR_BODY=$(echo "$PR_INFO" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).body||''))")
+PR_FILES=$(echo "$PR_INFO" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).files.length))")
+PR_ADDS=$(echo "$PR_INFO" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).additions))")
+PR_DELS=$(echo "$PR_INFO" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).deletions))")
+
+echo "📋 PR: $PR_TITLE ($PR_FILES files, +$PR_ADDS/-$PR_DELS)"
+echo "📝 Fetching diff..."
+
+PR_DIFF=$(gh pr diff "$PR_REF" 2>/dev/null) || {
+  echo "❌ Could not fetch diff."
+  exit 1
+}
+
+# Build the review prompt
+PROMPT="You are a senior code reviewer. Review the following pull request and produce a structured Markdown review.
+
+## PR: $PR_TITLE
+
+$PR_BODY
+
+## Diff
+\`\`\`
+$PR_DIFF
+\`\`\`
+
+Produce a structured review with:
+1. **Summary** (2-3 sentences of what this PR does)
+2. **Risks** (list of identified risks)
+3. **Improvement Suggestions** (list of suggestions)
+4. **Verdict** (APPROVE / REQUEST_CHANGES / COMMENT with justification)
+
+Output ONLY the Markdown review, no preamble."
+
+echo "🤖 Running Claude Code review..."
+REVIEW=$(echo "$PROMPT" | claude --model sonnet --print 2>/dev/null) || {
+  echo "⚠️  Could not run Claude Code. Outputting prompt for manual review."
+  echo "$PROMPT"
+  exit 0
+}
+
+echo ""
+echo "=== REVIEW ==="
+echo "$REVIEW"
+echo "=== END REVIEW ==="
+echo ""
+
+# Post the review as a PR comment
+echo "📤 Posting review to PR..."
+gh pr comment "$PR_REF" --body "$REVIEW" 2>/dev/null && \
+  echo "✅ Review posted to $PR_URL" || \
+  echo "⚠️  Could not post comment. Review output above."


### PR DESCRIPTION
## Summary

A Claude Code sub-agent that reviews GitHub PRs and posts structured Markdown review comments.

## What is included

| File | Purpose |
|------|---------|
| `.claude/agents/pr-review.md` | Claude Code sub-agent definition (YAML frontmatter) |
| `scripts/review-pr.sh` | Bash CLI - fetches PR diff via `gh`, pipes to Claude |
| `scripts/review-pr.py` | Python CLI - GitHub API + Anthropic API |
| `.github/workflows/pr-review.yml` | GitHub Action - auto-runs on PR open/sync, `/review` comment |
| `examples/sample-review.md` | Real sample review output |

## Usage

**Bash CLI:**
```bash
./scripts/review-pr.sh https://github.com/owner/repo/pull/123
```

**Python CLI:**
```bash
pip install anthropic requests
export GITHUB_TOKEN=xxx
export ANTHROPIC_API_KEY=xxx
python scripts/review-pr.py owner/repo#123
```

**GitHub Action:** Comment `/review` on any PR to trigger automated review.

## Example Output

See [examples/sample-review.md](examples/sample-review.md) for a complete sample PR review output.

### Sample Review Summary

> **Score: High** - Well-structured YAML templates following established conventions.
>
> **Risks:** False positive risk in CVE-2017-9248 (.NET error message too generic), version detection gap in Pulse Secure templates, missing `max-redirects` on redirect-following templates.
>
> **Suggestions:** Add Server header check, add `max-redirects: 0`, add version extraction logic for precise detection.

## Acceptance Criteria

- [x] Works via CLI: `./scripts/review-pr.sh <PR URL>`
- [x] Works via GitHub Action (workflow YAML included)
- [x] Structured Markdown output: Summary, Risks, Suggestions, Confidence Score
- [x] Posts review as PR comment
- [x] Sample output included in `examples/`

Closes #4
