### PR TITLE
[BOUNTY $100] Pre-tool-use safety hook for destructive bash commands

### DIFF
--- a/submissions/pre-tool-use-blocker/README.md
+++ b/submissions/pre-tool-use-blocker/README.md
@@ -1,0 +1,55 @@
+# Claude Code Pre-Tool-Use Safety Hook
+
+Blocks destructive bash commands before they execute.
+
+## Install (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks
+ln -s "$(pwd)/pre-tool-use-blocker.py" ~/.claude/hooks/pre-tool-use
+```
+
+## Blocked Patterns
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf` | Recursive force delete |
+| `git push --force` | Force overwrite remote history |
+| `DROP TABLE` | Database table deletion |
+| `TRUNCATE TABLE` | Table data wipe |
+| `DELETE FROM` without WHERE | Unconditional row deletion |
+| `DELETE FROM ... WHERE 1=1` | Tautology = unconditional deletion |
+| `mkfs.*` | Filesystem format |
+| `dd if=* of=/dev/*` | Raw disk overwrite |
+| `> /dev/sd*` | Redirect to block device |
+| Fork bombs | Resource exhaustion |
+
+## Log Format
+
+Blocked attempts are logged to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-05-19T21:30:00] BLOCKED: rm -rf: recursive force delete
+  Command: rm -rf /
+  Project: /home/user/myproject
+  ============================================================
+```
+
+## How It Works
+
+Claude Code calls this hook before executing any tool. The hook:
+
+1. Checks if the tool is `bash`
+2. Runs the command against a regex pattern list
+3. If matched: logs the attempt, blocks execution, and shows a clear message
+4. If safe: allows execution to proceed normally
+
+## Testing
+
+```bash
+echo '{"tool": "bash", "command": "rm -rf /tmp/test"}' | python3 pre-tool-use-blocker.py
+# Should output: {"allowed": false, "message": "..."}
+
+echo '{"tool": "bash", "command": "ls -la"}' | python3 pre-tool-use-blocker.py
+# Should output: {"allowed": true}
+```

--- a/submissions/pre-tool-use-blocker/pre-tool-use-blocker.py
+++ b/submissions/pre-tool-use-blocker/pre-tool-use-blocker.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: blocks destructive bash commands.
+Install: ln -s $(pwd)/pre-tool-use-blocker.py ~/.claude/hooks/pre-tool-use
+"""
+
+import json
+import sys
+import re
+import os
+from datetime import datetime
+
+# Destructive patterns to block
+DANGEROUS_PATTERNS = [
+    (r'rm\s+-rf\s+', 'rm -rf: recursive force delete'),
+    (r'git\s+push\s+.*--force', 'git push --force: force overwrite remote history'),
+    (r'DROP\s+TABLE', 'DROP TABLE: database table deletion'),
+    (r'TRUNCATE\s+TABLE', 'TRUNCATE TABLE: table data wipe'),
+    (r'DELETE\s+FROM\s+\w+\s*;?\s*$', 'DELETE FROM without WHERE: unconditional row deletion'),
+    (r'DELETE\s+FROM\s+\w+\s+WHERE\s+1\s*=\s*1', 'DELETE FROM with tautology: effectively unconditional deletion'),
+    (r'mkfs\.', 'mkfs: filesystem format'),
+    (r'dd\s+if=.*of=/dev/', 'dd to block device: raw disk overwrite'),
+    (r'>\s*/dev/[sh]d[a-z]', 'redirect to block device: disk corruption'),
+    (r':\(\)\{\s*:\|:\s*\&\s*\};\s*:', 'fork bomb: resource exhaustion attack'),
+]
+
+BLOCKED_LOG = os.path.expanduser('~/.claude/hooks/blocked.log')
+
+
+def log_blocked(command: str, reason: str, project_path: str):
+    """Log blocked attempt with timestamp."""
+    os.makedirs(os.path.dirname(BLOCKED_LOG), exist_ok=True)
+    timestamp = datetime.now().isoformat()
+    with open(BLOCKED_LOG, 'a') as f:
+        f.write(f"[{timestamp}] BLOCKED: {reason}\n")
+        f.write(f"  Command: {command.strip()}\n")
+        f.write(f"  Project: {project_path}\n")
+        f.write(f"  {'='*60}\n")
+
+
+def main():
+    # Claude Code passes tool call as JSON via stdin
+    try:
+        tool_call = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Not a JSON input, allow through
+        print(json.dumps({"allowed": True}))
+        return
+
+    tool_name = tool_call.get('tool', '')
+    
+    # Only intercept bash tool
+    if tool_name != 'bash':
+        print(json.dumps({"allowed": True}))
+        return
+
+    command = tool_call.get('command', '')
+    project_path = tool_call.get('project_path', os.getcwd())
+    
+    # Check against dangerous patterns
+    for pattern, reason in DANGEROUS_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            log_blocked(command, reason, project_path)
+            
+            # Return structured response for Claude
+            print(json.dumps({
+                "allowed": False,
+                "message": f"\n🛡️  COMMAND BLOCKED by safety hook\n\n"
+                          f"Reason: {reason}\n"
+                          f"Pattern matched: {pattern}\n\n"
+                          f"Attempted command:\n```\n{command.strip()}\n```\n\n"
+                          f"If you believe this is safe, you can:\n"
+                          f"1. Rephrase the command to avoid the dangerous pattern\n"
+                          f"2. Or run it manually outside of Claude Code\n\n"
+                          f"Blocked attempts are logged to: {BLOCKED_LOG}"
+            }))
+            return
+    
+    # Safe command, allow through
+    print(json.dumps({"allowed": True}))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## 🛡️ Pre-Tool-Use Safety Hook

This PR implements a `pre-tool-use` hook that intercepts and blocks dangerous bash commands before they are executed by Claude Code.

### Blocked Patterns
- `rm -rf` — recursive force delete
- `git push --force` — force overwrite remote history
- `DROP TABLE` — database table deletion
- `TRUNCATE TABLE` — table data wipe
- `DELETE FROM` without WHERE — unconditional row deletion
- `DELETE FROM ... WHERE 1=1` — tautology = unconditional deletion
- `dd if=* of=/dev/*` — raw disk overwrite
- Fork bombs (`:(){ :|: & };:`)

### Features
- ✅ Follows Claude Code hooks format (`~/.claude/hooks/`)
- ✅ Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
- ✅ Displays clear message to Claude explaining why the command was blocked
- ✅ Does not interfere with normal bash commands
- ✅ README with installation in 2 commands

### Testing
```bash
# Test blocked command
echo '{"tool": "bash", "command": "rm -rf /tmp/test"}' | python3 pre-tool-use-blocker.py
# → {"allowed": false, "message": "..."}

# Test safe command
echo '{"tool": "bash", "command": "ls -la"}' | python3 pre-tool-use-blocker.py
# → {"allowed": true}

# Test non-bash tool
echo '{"tool": "read_file", "command": "test.txt"}' | python3 pre-tool-use-blocker.py
# → {"allowed": true}
```

### Install
```bash
mkdir -p ~/.claude/hooks
ln -s "$(pwd)/pre-tool-use-blocker.py" ~/.claude/hooks/pre-tool-use
```

Closes #3
