### PR TITLE
Add changelog generation skill and script

### DIFF
--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## Unreleased - 2026-05-19
+
+_Generated from git history from repository start._
+
+### Added
+- feat: initial README with bounty board
+
+### Fixed
+- None
+
+### Changed
+- None
+
+### Removed
+- None
+

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,11 @@
+# Generate Changelog
+
+Create a structured `CHANGELOG.md` from commits since the latest git tag.
+
+## Setup
+
+1. Copy `generate-changelog/changelog.sh` into any git repo.
+2. Run `bash generate-changelog/changelog.sh`.
+3. Review the generated `CHANGELOG.md` before release.
+
+Categories: `Added`, `Fixed`, `Changed`, `Removed`.

--- a/generate-changelog/SKILL.md
+++ b/generate-changelog/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the latest tag.
+---
+
+# Generate Changelog
+
+Run this skill when the user asks to create or refresh a changelog from commit history.
+
+## Steps
+
+1. From the target repository root, run:
+
+```bash
+bash generate-changelog/changelog.sh
+```
+
+2. Inspect `CHANGELOG.md`.
+3. Ask for release-specific wording only if the generated categories need editorial cleanup.

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out="${1:-CHANGELOG.md}"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+cd "$repo_root"
+
+last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [ -n "$last_tag" ]; then
+  range="$last_tag..HEAD"
+  since="since $last_tag"
+else
+  range="HEAD"
+  since="from repository start"
+fi
+
+version="Unreleased"
+date_utc="$(date -u +%Y-%m-%d)"
+
+commits="$(git log --no-merges --pretty=format:'%s' "$range" 2>/dev/null || true)"
+
+bucket() {
+  local name="$1" pattern="$2"
+  printf '### %s\n' "$name"
+  local lines
+  lines="$(printf '%s\n' "$commits" | grep -Eis "$pattern" || true)"
+  if [ -z "$lines" ]; then
+    printf -- '- None\n\n'
+  else
+    printf '%s\n' "$lines" | sed -E 's/^[[:space:]]+//; s/^/- /'
+    printf '\n'
+  fi
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## %s - %s\n\n' "$version" "$date_utc"
+  printf '_Generated from git history %s._\n\n' "$since"
+  bucket 'Added' '^(feat|feature|add|added)(\(.+\))?:|add(ed)? '
+  bucket 'Fixed' '^(fix|bugfix|hotfix|repair)(\(.+\))?:|fix(ed|es)? |bug'
+  bucket 'Changed' '^(change|changed|refactor|perf|docs|style|test|chore|build|ci)(\(.+\))?:|update(d)? |improve(d)? |refactor'
+  bucket 'Removed' '^(remove|removed|delete|deleted|drop|dropped)(\(.+\))?:|remove(d)? |delete(d)? |drop(ped)?'
+} > "$out"
+
+printf 'Wrote %s using commits %s\n' "$out" "$since"


### PR DESCRIPTION
Implements #1.\n\nIncludes:\n- `generate-changelog/changelog.sh` runnable via `bash generate-changelog/changelog.sh`\n- `generate-changelog/SKILL.md` for Claude Code skill usage\n- 3-step README\n- `SAMPLE_CHANGELOG.md` generated from this repo history\n\nTested locally on this repository with:\n\n```bash\nbash generate-changelog/changelog.sh SAMPLE_CHANGELOG.md\n```