### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/hooks/pre-tool-use/README.md
+++ b/hooks/pre-tool-use/README.md
@@ -1,0 +1,38 @@
+# Destructive Bash Guard
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## Installation
+
+```bash
+git clone https://github.com/claude-builders-bounty/claude-builders-bounty.git
+python3 claude-builders-bounty/hooks/pre-tool-use/install.py
+```
+
+The installer copies `destructive-bash-guard.py` to `~/.claude/hooks/` and adds a `PreToolUse` matcher for the `Bash` tool in `~/.claude/settings.json`.
+
+## Blocked Commands
+
+- Recursive forced removal, including `rm -rf`, `rm -fr`, and `rm --recursive --force`
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- SQL run through common SQL clients that contains `DROP TABLE`, `TRUNCATE`, or `DELETE FROM` without a `WHERE` clause
+
+Blocked attempts are appended as JSON lines to `~/.claude/hooks/blocked.log` with a UTC timestamp, attempted command, project path, matched pattern, and reason.
+
+Safe commands produce no output and do not interfere with normal Bash execution.
+
+## Hook Response
+
+The hook uses Claude Code's structured `PreToolUse` response:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "..."
+  }
+}
+```
+
+This blocks only the dangerous Bash tool call and gives Claude a clear reason to choose a safer command.

--- a/hooks/pre-tool-use/destructive-bash-guard.py
+++ b/hooks/pre-tool-use/destructive-bash-guard.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 
 LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
-SEPARATORS = {";", "&&", "||", "|"}
+SEPARATORS = {";", "&", "&&", "||", "|"}
 WRAPPERS = {"sudo", "command", "builtin", "time", "noglob"}
 SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
 SQL_CLIENTS = {"psql", "mysql", "mariadb", "sqlite3", "sqlcmd", "duckdb", "cockroach"}
@@ -401,11 +401,14 @@ def deny(decision: BlockDecision) -> None:
 
 def main() -> int:
     payload = read_payload()
-    if payload.get("hook_event_name") not in {None, "PreToolUse"}:
+    hook_event_name = payload.get("hook_event_name", payload.get("hookEventName"))
+    if hook_event_name not in {None, "PreToolUse"}:
         return 0
-    if payload.get("tool_name") not in {None, "Bash"}:
+    tool_name = payload.get("tool_name", payload.get("toolName"))
+    if tool_name not in {None, "Bash"}:
         return 0
-    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    raw_tool_input = payload.get("tool_input", payload.get("toolInput"))
+    tool_input = raw_tool_input if isinstance(raw_tool_input, dict) else {}
     command = tool_input.get("command") or payload.get("command") or ""
     if not isinstance(command, str) or not command.strip():
         return 0

--- a/hooks/pre-tool-use/destructive-bash-guard.py
+++ b/hooks/pre-tool-use/destructive-bash-guard.py
@@ -51,9 +51,18 @@ def strip_shell_comments(command: str) -> str:
     result: list[str] = []
     quote: str | None = None
     escaped = False
+    in_comment = False
+    at_word_start = True
     for char in command:
+        if in_comment:
+            if char in {"\n", "\r"}:
+                result.append(char)
+                in_comment = False
+                at_word_start = True
+            continue
         if escaped:
             result.append(char)
+            at_word_start = False
             escaped = False
             continue
         if char == "\\" and quote != "'":
@@ -63,11 +72,16 @@ def strip_shell_comments(command: str) -> str:
         if char in {"'", '"'}:
             quote = None if quote == char else char if quote is None else quote
             result.append(char)
+            at_word_start = False
             continue
-        if char == "#" and quote is None:
-            result.append("\n")
+        if char == "#" and quote is None and at_word_start:
+            in_comment = True
             continue
         result.append(char)
+        if quote is None:
+            at_word_start = char.isspace() or char in {";", "&", "|", "(", ")"}
+        else:
+            at_word_start = False
     return "".join(result)
 
 

--- a/hooks/pre-tool-use/destructive-bash-guard.py
+++ b/hooks/pre-tool-use/destructive-bash-guard.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+SEPARATORS = {";", "&&", "||", "|"}
+WRAPPERS = {"sudo", "command", "builtin", "time", "noglob"}
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
+SQL_CLIENTS = {"psql", "mysql", "mariadb", "sqlite3", "sqlcmd", "duckdb", "cockroach"}
+
+
+@dataclass(frozen=True)
+class BlockDecision:
+    pattern: str
+    reason: str
+
+
+def read_payload() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def shell_tokens(command: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
+    except ValueError:
+        return command.split()
+
+
+def strip_shell_comments(command: str) -> str:
+    result: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for char in command:
+        if escaped:
+            result.append(char)
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            result.append(char)
+            escaped = True
+            continue
+        if char in {"'", '"'}:
+            quote = None if quote == char else char if quote is None else quote
+            result.append(char)
+            continue
+        if char == "#" and quote is None:
+            result.append("\n")
+            continue
+        result.append(char)
+    return "".join(result)
+
+
+def strip_sql_comments_and_literals(sql: str) -> str:
+    sql = re.sub(r"/\*.*?\*/", " ", sql, flags=re.DOTALL)
+    sql = re.sub(r"--[^\n\r]*", " ", sql)
+    sql = re.sub(r"'(?:''|[^'])*'", "''", sql)
+    sql = re.sub(r'"(?:""|[^"])*"', '""', sql)
+    return sql
+
+
+def command_segments(tokens: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in SEPARATORS:
+            if current:
+                segments.append(current)
+                current = []
+            segments.append([token])
+            continue
+        current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def basename(token: str) -> str:
+    return Path(token).name
+
+
+def executable_index(segment: list[str]) -> int | None:
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        name = basename(token)
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token):
+            index += 1
+            continue
+        if name in WRAPPERS:
+            index += 1
+            continue
+        if name == "env":
+            index += 1
+            while index < len(segment) and (
+                segment[index].startswith("-")
+                or re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", segment[index])
+            ):
+                index += 1
+            continue
+        if name == "timeout":
+            index += 1
+            while index < len(segment) and segment[index].startswith("-"):
+                index += 1
+            if index < len(segment) and re.match(r"^\d+(\.\d+)?[smhd]?$", segment[index]):
+                index += 1
+            continue
+        return index
+    return None
+
+
+def is_xargs_command_position(segment: list[str], index: int) -> bool:
+    exec_index = executable_index(segment)
+    if exec_index is None or basename(segment[exec_index]) != "xargs" or index <= exec_index:
+        return False
+
+    option_value_flags = {"-E", "-I", "-L", "-n", "-P", "-s"}
+    command_index = exec_index + 1
+    while command_index < len(segment):
+        arg = segment[command_index]
+        if arg == "--":
+            command_index += 1
+            break
+        if not arg.startswith("-") or arg == "-":
+            break
+        if arg in option_value_flags and command_index + 1 < len(segment):
+            command_index += 2
+            continue
+        command_index += 1
+    return command_index == index
+
+
+def is_execution_position(segment: list[str], index: int) -> bool:
+    exec_index = executable_index(segment)
+    if exec_index == index:
+        return True
+    if is_xargs_command_position(segment, index):
+        return True
+    return index > 0 and segment[index - 1] in {"-exec", "-execdir"}
+
+
+def has_destructive_rm(tokens: list[str]) -> bool:
+    for segment in command_segments(tokens):
+        if segment in (["|"], [";"], ["&&"], ["||"]):
+            continue
+        for index, token in enumerate(segment):
+            if basename(token) != "rm" or not is_execution_position(segment, index):
+                continue
+            has_force = False
+            has_recursive = False
+            for arg in segment[index + 1 :]:
+                if arg == "--":
+                    break
+                if not arg.startswith("-"):
+                    continue
+                if arg in {"--force", "--interactive=never"}:
+                    has_force = True
+                elif arg in {"--recursive", "--dir"}:
+                    has_recursive = True
+                elif arg.startswith("-") and not arg.startswith("--"):
+                    flags = arg.lstrip("-")
+                    has_force = has_force or "f" in flags
+                    has_recursive = has_recursive or "r" in flags or "R" in flags
+            if has_force and has_recursive:
+                return True
+    return False
+
+
+def has_forced_git_push(tokens: list[str]) -> bool:
+    for segment in command_segments(tokens):
+        if segment in (["|"], [";"], ["&&"], ["||"]):
+            continue
+        for index, token in enumerate(segment):
+            if basename(token) != "git" or not is_execution_position(segment, index):
+                continue
+            rest = segment[index + 1 :]
+            push_index = None
+            skip_next = False
+            for offset, arg in enumerate(rest):
+                if skip_next:
+                    skip_next = False
+                    continue
+                if arg in {"-C", "-c", "--git-dir", "--work-tree"}:
+                    skip_next = True
+                    continue
+                if arg == "push":
+                    push_index = offset
+                    break
+            if push_index is None:
+                continue
+            for arg in rest[push_index + 1 :]:
+                if arg in {"-f", "--force", "--force-with-lease"}:
+                    return True
+                if arg.startswith("--force=") or arg.startswith("--force-with-lease="):
+                    return True
+                if arg.startswith("+") and len(arg) > 1:
+                    return True
+    return False
+
+
+def is_sql_segment(segment: list[str]) -> bool:
+    exec_index = executable_index(segment)
+    return exec_index is not None and basename(segment[exec_index]) in SQL_CLIENTS
+
+
+def extract_option_value(args: list[str], option_names: set[str]) -> list[str]:
+    values: list[str] = []
+    short_options = {option[1:] for option in option_names if re.fullmatch(r"-[A-Za-z]", option)}
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in option_names and index + 1 < len(args):
+            values.append(args[index + 1])
+            index += 2
+            continue
+        for option_name in option_names:
+            if arg.startswith(f"{option_name}="):
+                values.append(arg.split("=", 1)[1])
+        if arg.startswith("-") and not arg.startswith("--"):
+            cluster = arg[1:]
+            for short_option in short_options:
+                position = cluster.find(short_option)
+                if position == -1:
+                    continue
+                inline_value = cluster[position + 1 :]
+                if inline_value:
+                    values.append(inline_value)
+                elif index + 1 < len(args):
+                    values.append(args[index + 1])
+                break
+        index += 1
+    return values
+
+
+def piped_sql_text(segments: list[list[str]], sql_index: int) -> list[str]:
+    if sql_index < 2 or segments[sql_index - 1] != ["|"]:
+        return []
+    producer = segments[sql_index - 2]
+    exec_index = executable_index(producer)
+    if exec_index is None:
+        return []
+    producer_name = basename(producer[exec_index])
+    if producer_name in {"echo", "printf"}:
+        return [arg for arg in producer[exec_index + 1 :] if not arg.startswith("-")]
+    return []
+
+
+def extract_sql_texts(tokens: list[str]) -> list[str]:
+    segments = command_segments(tokens)
+    sql_texts: list[str] = []
+    for segment_index, segment in enumerate(segments):
+        if segment in (["|"], [";"], ["&&"], ["||"]) or not is_sql_segment(segment):
+            continue
+        exec_index = executable_index(segment)
+        if exec_index is None:
+            continue
+        client_name = basename(segment[exec_index])
+        args = segment[exec_index + 1 :]
+        if client_name in {"psql", "cockroach"}:
+            sql_texts.extend(extract_option_value(args, {"-c", "--command"}))
+        elif client_name in {"mysql", "mariadb"}:
+            sql_texts.extend(extract_option_value(args, {"-e", "--execute"}))
+        elif client_name == "sqlcmd":
+            sql_texts.extend(extract_option_value(args, {"-Q", "-q"}))
+        elif client_name in {"sqlite3", "duckdb"}:
+            sql_texts.extend(arg for arg in args if re.search(r"\b(DROP|TRUNCATE|DELETE)\b", arg, re.IGNORECASE))
+        sql_texts.extend(piped_sql_text(segments, segment_index))
+    return sql_texts
+
+
+def has_sql_drop_or_truncate(sql: str) -> BlockDecision | None:
+    cleaned = strip_sql_comments_and_literals(sql)
+    if re.search(r"\bDROP\s+TABLE\b", cleaned, flags=re.IGNORECASE):
+        return BlockDecision("DROP TABLE", "DROP TABLE is blocked because it can destroy schema and data.")
+    if re.search(r"\bTRUNCATE(?:\s+TABLE)?\b", cleaned, flags=re.IGNORECASE):
+        return BlockDecision("TRUNCATE", "TRUNCATE is blocked because it can erase table contents.")
+    return None
+
+
+def has_delete_without_where(sql: str) -> bool:
+    cleaned = strip_sql_comments_and_literals(sql)
+    for statement in re.split(r";", cleaned):
+        match = re.search(r"\bDELETE\s+FROM\b(?P<body>.*)$", statement, flags=re.IGNORECASE | re.DOTALL)
+        if match and not re.search(r"\bWHERE\b", match.group("body"), flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def sql_decision(tokens: list[str]) -> BlockDecision | None:
+    for sql_text in extract_sql_texts(tokens):
+        decision = has_sql_drop_or_truncate(sql_text)
+        if decision is not None:
+            return decision
+        if has_delete_without_where(sql_text):
+            return BlockDecision(
+                "DELETE FROM without WHERE",
+                "DELETE FROM without a WHERE clause is blocked because it can delete every row.",
+            )
+    return None
+
+
+def nested_shell_commands(tokens: list[str]) -> list[str]:
+    commands: list[str] = []
+    for segment in command_segments(tokens):
+        if segment in (["|"], [";"], ["&&"], ["||"]):
+            continue
+        exec_index = executable_index(segment)
+        if exec_index is None or basename(segment[exec_index]) not in SHELLS:
+            continue
+        args = segment[exec_index + 1 :]
+        for index, arg in enumerate(args):
+            if arg == "-c" and index + 1 < len(args):
+                commands.append(args[index + 1])
+                break
+            if arg.startswith("-") and "c" in arg[1:] and index + 1 < len(args):
+                commands.append(args[index + 1])
+                break
+    return commands
+
+
+def evaluate(command: str) -> BlockDecision | None:
+    command_without_comments = strip_shell_comments(command)
+    tokens = shell_tokens(command_without_comments)
+    if has_destructive_rm(tokens):
+        return BlockDecision(
+            "rm -rf",
+            "Recursive forced deletion is blocked. Use a narrower remove command or ask for explicit approval.",
+        )
+    if has_forced_git_push(tokens):
+        return BlockDecision(
+            "git push --force",
+            "Forced git pushes are blocked because they can overwrite remote history.",
+        )
+    decision = sql_decision(tokens)
+    if decision is not None:
+        return decision
+    for nested_command in nested_shell_commands(tokens):
+        decision = evaluate(nested_command)
+        if decision is not None:
+            return decision
+    return None
+
+
+def log_block(payload: dict, command: str, decision: BlockDecision) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "attempted_command": command,
+        "project_path": payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or "unknown",
+        "pattern": decision.pattern,
+        "reason": decision.reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def deny(decision: BlockDecision) -> None:
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": f"{decision.pattern}: {decision.reason}",
+        }
+    }
+    print(json.dumps(output))
+
+
+def main() -> int:
+    payload = read_payload()
+    if payload.get("hook_event_name") not in {None, "PreToolUse"}:
+        return 0
+    if payload.get("tool_name") not in {None, "Bash"}:
+        return 0
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    command = tool_input.get("command") or payload.get("command") or ""
+    if not isinstance(command, str) or not command.strip():
+        return 0
+    decision = evaluate(command)
+    if decision is None:
+        return 0
+    try:
+        log_block(payload, command, decision)
+    except OSError:
+        pass
+    deny(decision)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/pre-tool-use/install.py
+++ b/hooks/pre-tool-use/install.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash guard for Claude Code."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import stat
+from pathlib import Path
+
+
+SOURCE_HOOK = Path(__file__).with_name("destructive-bash-guard.py")
+CLAUDE_DIR = Path.home() / ".claude"
+HOOKS_DIR = CLAUDE_DIR / "hooks"
+TARGET_HOOK = HOOKS_DIR / "destructive-bash-guard.py"
+SETTINGS_PATH = CLAUDE_DIR / "settings.json"
+
+
+def load_settings() -> dict:
+    if not SETTINGS_PATH.exists():
+        return {}
+    with SETTINGS_PATH.open(encoding="utf-8") as settings_file:
+        data = json.load(settings_file)
+    return data if isinstance(data, dict) else {}
+
+
+def write_settings(settings: dict) -> None:
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SETTINGS_PATH.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+
+def install_hook() -> None:
+    HOOKS_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE_HOOK, TARGET_HOOK)
+    TARGET_HOOK.chmod(TARGET_HOOK.stat().st_mode | stat.S_IXUSR)
+
+
+def merge_settings(settings: dict) -> dict:
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    command = shlex.quote(str(TARGET_HOOK))
+
+    for matcher in pre_tool_use:
+        if matcher.get("matcher") != "Bash":
+            continue
+        matcher_hooks = matcher.setdefault("hooks", [])
+        if not any(hook.get("type") == "command" and hook.get("command") == command for hook in matcher_hooks):
+            matcher_hooks.append({"type": "command", "command": command})
+        return settings
+
+    pre_tool_use.append(
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": command}],
+        }
+    )
+    return settings
+
+
+def main() -> int:
+    install_hook()
+    settings = merge_settings(load_settings())
+    write_settings(settings)
+    print(f"Installed {TARGET_HOOK}")
+    print(f"Updated {SETTINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/pre-tool-use/install.py
+++ b/hooks/pre-tool-use/install.py
@@ -39,15 +39,33 @@ def install_hook() -> None:
 
 
 def merge_settings(settings: dict) -> dict:
-    hooks = settings.setdefault("hooks", {})
-    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        hooks = {}
+        settings["hooks"] = hooks
+
+    pre_tool_use = hooks.get("PreToolUse")
+    if not isinstance(pre_tool_use, list):
+        pre_tool_use = []
+        hooks["PreToolUse"] = pre_tool_use
+
     command = shlex.quote(str(TARGET_HOOK))
 
     for matcher in pre_tool_use:
+        if not isinstance(matcher, dict):
+            continue
         if matcher.get("matcher") != "Bash":
             continue
-        matcher_hooks = matcher.setdefault("hooks", [])
-        if not any(hook.get("type") == "command" and hook.get("command") == command for hook in matcher_hooks):
+        matcher_hooks = matcher.get("hooks")
+        if not isinstance(matcher_hooks, list):
+            matcher_hooks = []
+            matcher["hooks"] = matcher_hooks
+        if not any(
+            isinstance(hook, dict)
+            and hook.get("type") == "command"
+            and hook.get("command") == command
+            for hook in matcher_hooks
+        ):
             matcher_hooks.append({"type": "command", "command": command})
         return settings
 

--- a/tests/test_destructive_bash_guard.py
+++ b/tests/test_destructive_bash_guard.py
@@ -102,6 +102,25 @@ class DestructiveBashGuardTest(unittest.TestCase):
     def test_does_not_block_text_that_mentions_rm_rf(self):
         self.assert_allowed("echo 'rm -rf build'")
 
+    def test_ignores_shell_comments_that_mention_rm_rf(self):
+        for command in [
+            "# rm -rf /",
+            "git status # rm -rf /",
+            "echo safe # rm -rf /",
+        ]:
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+    def test_preserves_quoted_hash_characters(self):
+        hook = load_hook_module()
+        for command in [
+            "echo '# rm -rf /'",
+            'printf "%s\\n" "# git push --force origin main"',
+        ]:
+            with self.subTest(command=command):
+                self.assertEqual(hook.strip_shell_comments(command), command)
+                self.assert_allowed(command)
+
     def test_blocks_forced_git_push_forms(self):
         for command in [
             "git push --force origin main",

--- a/tests/test_destructive_bash_guard.py
+++ b/tests/test_destructive_bash_guard.py
@@ -1,0 +1,224 @@
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "hooks" / "pre-tool-use" / "destructive-bash-guard.py"
+INSTALLER = REPO_ROOT / "hooks" / "pre-tool-use" / "install.py"
+
+
+def load_hook_module():
+    spec = importlib.util.spec_from_file_location("destructive_bash_guard", HOOK)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_hook(home: Path, command: str, tool_name: str = "Bash", hook_event_name: str = "PreToolUse"):
+    payload = {
+        "session_id": "test-session",
+        "transcript_path": str(home / "transcript.jsonl"),
+        "cwd": str(home / "project"),
+        "hook_event_name": hook_event_name,
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class DestructiveBashGuardTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.home = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def log_path(self) -> Path:
+        return self.home / ".claude" / "hooks" / "blocked.log"
+
+    def assert_allowed(self, command: str):
+        result = run_hook(self.home, command)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        self.assertFalse(self.log_path().exists())
+
+    def assert_denied(self, command: str, pattern: str):
+        result = run_hook(self.home, command)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+        output = json.loads(result.stdout)
+        hook_output = output["hookSpecificOutput"]
+        self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+        self.assertEqual(hook_output["permissionDecision"], "deny")
+        self.assertIn(pattern, hook_output["permissionDecisionReason"])
+
+        log_record = json.loads(self.log_path().read_text(encoding="utf-8").strip().splitlines()[-1])
+        self.assertEqual(log_record["attempted_command"], command)
+        self.assertEqual(log_record["project_path"], str(self.home / "project"))
+        self.assertEqual(log_record["pattern"], pattern)
+        self.assertIn("timestamp", log_record)
+
+    def test_allows_normal_bash_command(self):
+        self.assert_allowed("git status --short")
+
+    def test_blocks_recursive_forced_rm_forms(self):
+        for command in [
+            "rm -rf build",
+            "rm -fr build",
+            "sudo rm --recursive --force build",
+            "find build -type f -exec rm -rf {} ;",
+        ]:
+            with self.subTest(command=command):
+                self.assert_denied(command, "rm -rf")
+                self.log_path().unlink()
+
+    def test_blocks_nested_bash_login_command_rm_rf(self):
+        self.assert_denied("bash -lc 'rm -rf /tmp/project'", "rm -rf")
+
+    def test_blocks_xargs_rm_rf_with_xargs_option(self):
+        self.assert_denied("printf '%s\\0' target | xargs -0 rm -rf", "rm -rf")
+
+    def test_does_not_block_text_that_mentions_rm_rf(self):
+        self.assert_allowed("echo 'rm -rf build'")
+
+    def test_blocks_forced_git_push_forms(self):
+        for command in [
+            "git push --force origin main",
+            "git -C repo push -f origin main",
+            "sudo git push --force-with-lease origin main",
+        ]:
+            with self.subTest(command=command):
+                self.assert_denied(command, "git push --force")
+                self.log_path().unlink()
+
+    def test_blocks_plus_refspec_forced_git_push(self):
+        self.assert_denied("git push origin +main", "git push --force")
+
+    def test_does_not_block_text_that_mentions_force_push(self):
+        self.assert_allowed("printf '%s\\n' 'git push --force origin main'")
+
+    def test_blocks_dangerous_sql_through_sql_clients(self):
+        cases = [
+            ("psql -c 'DROP TABLE users'", "DROP TABLE"),
+            ("mysql -e 'TRUNCATE sessions'", "TRUNCATE"),
+            ("sqlite3 app.db 'DELETE FROM accounts'", "DELETE FROM without WHERE"),
+            ("echo 'DROP TABLE users' | psql", "DROP TABLE"),
+        ]
+        for command, pattern in cases:
+            with self.subTest(command=command):
+                self.assert_denied(command, pattern)
+                self.log_path().unlink()
+
+    def test_blocks_psql_compact_command_option_drop_table(self):
+        self.assert_denied("psql -XAtc 'DROP TABLE users'", "DROP TABLE")
+
+    def test_allows_sql_with_where_clause(self):
+        self.assert_allowed("psql -c 'DELETE FROM accounts WHERE id = 1'")
+
+    def test_sql_comments_do_not_hide_missing_where_clause(self):
+        self.assert_denied("psql -c 'DELETE FROM accounts -- WHERE id = 1'", "DELETE FROM without WHERE")
+
+    def test_does_not_block_plain_text_sql_examples(self):
+        self.assert_allowed("echo 'DROP TABLE users'")
+
+    def test_ignores_non_bash_tools(self):
+        result = run_hook(self.home, "rm -rf build", tool_name="Read")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertFalse(self.log_path().exists())
+
+    def test_ignores_other_hook_events(self):
+        result = run_hook(self.home, "rm -rf build", hook_event_name="PostToolUse")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertFalse(self.log_path().exists())
+
+    def test_installer_merges_bash_hook_without_overwriting_existing_settings(self):
+        settings_path = self.home / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "model": "sonnet",
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Read",
+                                "hooks": [{"type": "command", "command": "echo read"}],
+                            }
+                        ]
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["HOME"] = str(self.home)
+
+        result = subprocess.run(
+            [sys.executable, str(INSTALLER)],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        installed_hook = self.home / ".claude" / "hooks" / "destructive-bash-guard.py"
+        self.assertTrue(installed_hook.exists())
+        self.assertTrue(os.access(installed_hook, os.X_OK))
+
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertEqual(settings["model"], "sonnet")
+        matchers = settings["hooks"]["PreToolUse"]
+        self.assertTrue(any(matcher.get("matcher") == "Read" for matcher in matchers))
+        bash_matchers = [matcher for matcher in matchers if matcher.get("matcher") == "Bash"]
+        self.assertEqual(len(bash_matchers), 1)
+        self.assertIn(str(installed_hook), bash_matchers[0]["hooks"][0]["command"])
+
+    def test_logging_failure_does_not_prevent_denial(self):
+        hook = load_hook_module()
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf build"},
+            "cwd": str(self.home / "project"),
+        }
+
+        with (
+            mock.patch("sys.stdin", io.StringIO(json.dumps(payload))),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as stdout,
+            mock.patch.object(hook, "log_block", side_effect=OSError("disk full")),
+        ):
+            self.assertEqual(hook.main(), 0)
+
+        output = json.loads(stdout.getvalue())
+        hook_output = output["hookSpecificOutput"]
+        self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+        self.assertEqual(hook_output["permissionDecision"], "deny")
+        self.assertIn("rm -rf", hook_output["permissionDecisionReason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_destructive_bash_guard.py
+++ b/tests/test_destructive_bash_guard.py
@@ -45,6 +45,19 @@ def run_hook(home: Path, command: str, tool_name: str = "Bash", hook_event_name:
     )
 
 
+def run_hook_with_payload(home: Path, payload: dict):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
 class DestructiveBashGuardTest(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -95,6 +108,16 @@ class DestructiveBashGuardTest(unittest.TestCase):
 
     def test_blocks_nested_bash_login_command_rm_rf(self):
         self.assert_denied("bash -lc 'rm -rf /tmp/project'", "rm -rf")
+
+    def test_blocks_rm_rf_around_compact_and_separator(self):
+        for command in [
+            "echo ok&&rm -rf build",
+            "rm -rf build&&echo ok",
+            "echo ok&rm -rf build",
+        ]:
+            with self.subTest(command=command):
+                self.assert_denied(command, "rm -rf")
+                self.log_path().unlink()
 
     def test_blocks_xargs_rm_rf_with_xargs_option(self):
         self.assert_denied("printf '%s\\0' target | xargs -0 rm -rf", "rm -rf")
@@ -173,6 +196,25 @@ class DestructiveBashGuardTest(unittest.TestCase):
         self.assertEqual(result.stdout, "")
         self.assertFalse(self.log_path().exists())
 
+    def test_accepts_camel_case_payload_keys(self):
+        result = run_hook_with_payload(
+            self.home,
+            {
+                "session_id": "test-session",
+                "transcript_path": str(self.home / "transcript.jsonl"),
+                "cwd": str(self.home / "project"),
+                "hookEventName": "PreToolUse",
+                "toolName": "Bash",
+                "toolInput": {"command": "rm -rf build"},
+            },
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+        output = json.loads(result.stdout)
+        self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertTrue(self.log_path().exists())
+
     def test_installer_merges_bash_hook_without_overwriting_existing_settings(self):
         settings_path = self.home / ".claude" / "settings.json"
         settings_path.parent.mkdir(parents=True)
@@ -215,6 +257,41 @@ class DestructiveBashGuardTest(unittest.TestCase):
         bash_matchers = [matcher for matcher in matchers if matcher.get("matcher") == "Bash"]
         self.assertEqual(len(bash_matchers), 1)
         self.assertIn(str(installed_hook), bash_matchers[0]["hooks"][0]["command"])
+
+    def test_installer_normalizes_unexpected_hook_settings_types(self):
+        settings_path = self.home / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": {
+                            "matcher": "Bash",
+                            "hooks": {"type": "command", "command": "echo old"},
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["HOME"] = str(self.home)
+
+        result = subprocess.run(
+            [sys.executable, str(INSTALLER)],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        matchers = settings["hooks"]["PreToolUse"]
+        self.assertIsInstance(matchers, list)
+        bash_matchers = [matcher for matcher in matchers if matcher.get("matcher") == "Bash"]
+        self.assertEqual(len(bash_matchers), 1)
+        self.assertIn("destructive-bash-guard.py", bash_matchers[0]["hooks"][0]["command"])
 
     def test_logging_failure_does_not_prevent_denial(self):
         hook = load_hook_module()


### PR DESCRIPTION
Closes #3

/claim #3

## Summary
- Add a Python Claude Code PreToolUse hook for the Bash tool.
- Use shlex-aware command segmentation to block rm -rf, git force pushes, and destructive SQL through common clients.
- Add an installer that copies the hook into ~/.claude/hooks and merges a Bash matcher into ~/.claude/settings.json.
- Document the two-command installation flow and hook behavior.

## Safety coverage
- Handles wrappers, git global options, nested shell commands, xargs and find execution forms, forced refspecs, compact SQL command flags, and log write failures.
- Avoids blocking plain-text examples in normal echo or printf output.

## Tests
- python3 -m unittest discover -s tests -v
- python3 -m py_compile hooks/pre-tool-use/destructive-bash-guard.py hooks/pre-tool-use/install.py tests/test_destructive_bash_guard.py
- git diff --cached --check