### PR TITLE
Add Claude PR review agent

### DIFF
--- a/README_REVIEW_AGENT.md
+++ b/README_REVIEW_AGENT.md
@@ -1,0 +1,78 @@
+# Claude Review Agent (Issue #4)
+
+This bounty implementation adds a small Python CLI that reviews a public GitHub PR and emits structured Markdown.
+
+## Files
+
+- `scripts/claude_review.py`: core logic (URL parsing, fetch, heuristics, markdown generation, optional post-comment)
+- `./claude-review`: executable wrapper
+- `tests/test_claude_review.py`: offline unit tests
+- `samples/*.md`: generated sample outputs from real public PR URLs
+
+## Requirements
+
+- Python 3.9+
+- Optional `GITHUB_TOKEN` env var for higher rate limits and for `--post-comment`
+
+No third-party Python dependencies are required.
+
+## Usage
+
+Run review and print Markdown to stdout:
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Use a token (optional for public PR fetches, recommended for rate limits):
+
+```bash
+export GITHUB_TOKEN=ghp_xxx
+./claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Post comment back to GitHub (explicit opt-in only):
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+`--post-comment` is gated by both the flag and `GITHUB_TOKEN`.
+
+## Heuristics
+
+The reviewer uses lightweight heuristics from metadata + diff:
+
+- PR size (files, additions, deletions)
+- Tests present/absent
+- Security/auth-related keywords
+- CI/workflow file changes
+- Dependency and lockfile changes
+- Migration file changes
+- File deletions
+
+It outputs:
+
+- Summary of changes (3 concise sentences)
+- Identified risks (bullet list)
+- Improvement suggestions (bullet list)
+- Confidence score (`Low`, `Medium`, `High`)
+
+## Tests
+
+Run:
+
+```bash
+python3 -m unittest -v tests/test_claude_review.py
+```
+
+Tests are fully offline and cover:
+
+- URL parsing validation
+- Diff/risk heuristics
+- Markdown section structure
+
+## Notes
+
+- Public PR fetches work without a token via GitHub public endpoints.
+- Do not run `--post-comment` in local verification unless you intentionally want to publish a comment.

--- a/claude-review
+++ b/claude-review
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from scripts.claude_review import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/pallets-flask-6028.md
+++ b/samples/pallets-flask-6028.md
@@ -1,0 +1,13 @@
+# Claude Review for pallets/flask#6028
+
+## Summary of changes
+This PR, "Fix FLASK_DEBUG env var ignored with click 8.4.0", proposes merging `fix/flask-debug-env-click-840` into `main`. It spans 2 files with 25 additions and 1 deletions across 1 commits. Primary touched paths include src/flask/cli.py, tests/test_cli.py, and the diff includes test file changes.
+
+## Identified risks
+- No major red flags from heuristic scan; residual risk remains for runtime behavior and edge cases.
+
+## Improvement suggestions
+- Run full CI and smoke tests before merge to validate runtime behavior.
+
+## Confidence score
+High

--- a/samples/psf-requests-7464.md
+++ b/samples/psf-requests-7464.md
@@ -1,0 +1,13 @@
+# Claude Review for psf/requests#7464
+
+## Summary of changes
+This PR, "fix(sessions): session.verify=False not overridden by REQUESTS_CA_BUNDLE env var", proposes merging `fix/session-verify-false-overridden-by-env` into `main`. It spans 1 files with 4 additions and 1 deletions across 1 commits. Primary touched paths include src/requests/sessions.py, and the diff does not include obvious test file changes.
+
+## Identified risks
+- No major red flags from heuristic scan; residual risk remains for runtime behavior and edge cases.
+
+## Improvement suggestions
+- Add or update automated tests that cover the main changed paths and one failure case.
+
+## Confidence score
+High

--- a/scripts/claude_review.py
+++ b/scripts/claude_review.py
@@ -14,15 +14,18 @@ from urllib.error import HTTPError, URLError
 
 USER_AGENT = "claude-review-agent/0.1"
 SECURITY_KEYWORDS = (
-    "auth",
-    "token",
-    "password",
-    "secret",
-    "permission",
-    "oauth",
-    "jwt",
-    "crypto",
-    "encrypt",
+    r"auth(?:enticat\w*|oriz\w*)?",
+    r"token\w*",
+    r"password\w*",
+    r"secret\w*",
+    r"permission\w*",
+    r"oauth\w*",
+    r"jwt",
+    r"crypto\w*",
+    r"encrypt\w*",
+)
+SECURITY_KEYWORD_PATTERN = re.compile(
+    r"(?<![a-z0-9])(?:" + "|".join(SECURITY_KEYWORDS) + r")(?![a-z0-9])"
 )
 DEPENDENCY_FILES = {
     "requirements.txt",
@@ -35,16 +38,24 @@ DEPENDENCY_FILES = {
     "yarn.lock",
     "go.mod",
     "go.sum",
-    "Cargo.toml",
-    "Cargo.lock",
-    "Gemfile",
-    "Gemfile.lock",
+    "cargo.toml",
+    "cargo.lock",
+    "gemfile",
+    "gemfile.lock",
     "composer.json",
     "composer.lock",
 }
 LOCKFILE_SUFFIXES = (".lock",)
 MIGRATION_TOKENS = ("migrations", "alembic", "db/migrate")
 CI_TOKENS = (".github/workflows", "circleci", ".gitlab-ci")
+LARGE_FILE_COUNT = 25
+MEDIUM_FILE_COUNT = 15
+LARGE_LINE_COUNT = 1200
+SUBSTANTIAL_LINE_COUNT = 400
+MISSING_TEST_LINE_COUNT = 80
+MEDIUM_LINE_COUNT = 500
+VERY_LARGE_LINE_COUNT = 2500
+LOW_CONFIDENCE_SIGNAL_COUNT = 3
 
 
 @dataclass(frozen=True)
@@ -141,6 +152,15 @@ def _has_test_files(files: List[str]) -> bool:
     return False
 
 
+def _security_touched(diff_text: str) -> bool:
+    return SECURITY_KEYWORD_PATTERN.search(diff_text.lower()) is not None
+
+
+def _count_text(count: int, singular: str, plural: str | None = None) -> str:
+    label = singular if count == 1 else plural or f"{singular}s"
+    return f"{count} {label}"
+
+
 def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
     files = extract_changed_files(diff_text)
     additions, deletions = diff_line_stats(diff_text)
@@ -149,11 +169,10 @@ def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
     deletions = int(metadata.get("deletions") or deletions)
     commits = int(metadata.get("commits") or 0)
 
-    lower_diff = diff_text.lower()
     lower_files = [f.lower() for f in files]
 
     tests_present = _has_test_files(files)
-    security_touched = any(keyword in lower_diff for keyword in SECURITY_KEYWORDS)
+    security_touched = _security_touched(diff_text)
     ci_touched = any(any(token in path for token in CI_TOKENS) for path in lower_files)
     dependency_touched = any(os.path.basename(path) in DEPENDENCY_FILES for path in lower_files)
     migration_touched = any(any(token in path for token in MIGRATION_TOKENS) for path in lower_files)
@@ -163,9 +182,9 @@ def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
     total_changed_lines = additions + deletions
 
     risks: List[str] = []
-    if changed_files >= 25 or total_changed_lines >= 1200:
+    if changed_files >= LARGE_FILE_COUNT or total_changed_lines >= LARGE_LINE_COUNT:
         risks.append("Large PR footprint increases regression risk and reviewer blind spots.")
-    if total_changed_lines >= 400:
+    if total_changed_lines >= SUBSTANTIAL_LINE_COUNT:
         risks.append("Substantial code churn may hide edge-case failures.")
     if security_touched:
         risks.append("Security/auth-related code appears in the diff and needs focused review.")
@@ -177,7 +196,7 @@ def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
         risks.append("CI/workflow definitions changed; verify pipeline behavior and permissions.")
     if deleted_file_count > 0:
         risks.append("File deletions detected; ensure removed logic has no runtime references.")
-    if not tests_present and total_changed_lines >= 80:
+    if not tests_present and total_changed_lines >= MISSING_TEST_LINE_COUNT:
         risks.append("No test files detected despite non-trivial changes.")
     if lockfile_count > 0 and lockfile_count == len(lower_files):
         risks.append("PR appears lockfile-only; verify this was intentionally generated from clean dependency updates.")
@@ -196,25 +215,25 @@ def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
         suggestions.append("Pin and scan updated dependencies, and include rationale for major version bumps.")
     if ci_touched:
         suggestions.append("Run CI with least-privilege checks for updated workflow files before merge.")
-    if changed_files >= 25 or total_changed_lines >= 1200:
+    if changed_files >= LARGE_FILE_COUNT or total_changed_lines >= LARGE_LINE_COUNT:
         suggestions.append("Consider splitting this PR into smaller, reviewable units.")
     if not suggestions:
         suggestions.append("Run full CI and smoke tests before merge to validate runtime behavior.")
 
     strong_risk_signals = sum(
         [
-            changed_files >= 25,
-            total_changed_lines >= 1200,
+            changed_files >= LARGE_FILE_COUNT,
+            total_changed_lines >= LARGE_LINE_COUNT,
             security_touched,
             migration_touched,
             ci_touched,
             dependency_touched,
-            (not tests_present and total_changed_lines >= 80),
+            (not tests_present and total_changed_lines >= MISSING_TEST_LINE_COUNT),
         ]
     )
-    if strong_risk_signals >= 3 or total_changed_lines >= 2500:
+    if strong_risk_signals >= LOW_CONFIDENCE_SIGNAL_COUNT or total_changed_lines >= VERY_LARGE_LINE_COUNT:
         confidence = "Low"
-    elif strong_risk_signals >= 1 or total_changed_lines >= 500 or changed_files >= 15:
+    elif strong_risk_signals >= 1 or total_changed_lines >= MEDIUM_LINE_COUNT or changed_files >= MEDIUM_FILE_COUNT:
         confidence = "Medium"
     else:
         confidence = "High"
@@ -230,6 +249,14 @@ def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
         "suggestions": suggestions,
         "confidence": confidence,
         "total_changed_lines": total_changed_lines,
+        "signals": {
+            "security_touched": security_touched,
+            "ci_touched": ci_touched,
+            "dependency_touched": dependency_touched,
+            "migration_touched": migration_touched,
+            "deleted_file_count": deleted_file_count,
+            "lockfile_count": lockfile_count,
+        },
     }
 
 
@@ -242,8 +269,10 @@ def build_summary(metadata: Dict[str, Any], analysis: Dict[str, Any]) -> str:
 
     sentence1 = f"This PR, \"{title}\", proposes merging `{head_ref}` into `{base_ref}`."
     sentence2 = (
-        f"It spans {analysis['changed_files']} files with {analysis['additions']} additions and "
-        f"{analysis['deletions']} deletions across {analysis['commits']} commits."
+        f"It spans {_count_text(analysis['changed_files'], 'file')} with "
+        f"{_count_text(analysis['additions'], 'addition')} and "
+        f"{_count_text(analysis['deletions'], 'deletion')} across "
+        f"{_count_text(analysis['commits'], 'commit')}."
     )
     sentence3 = f"Primary touched paths include {touched_preview}, and the diff {tests_text}."
     return " ".join([sentence1, sentence2, sentence3])

--- a/scripts/claude_review.py
+++ b/scripts/claude_review.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+from urllib import parse, request
+from urllib.error import HTTPError, URLError
+
+
+USER_AGENT = "claude-review-agent/0.1"
+SECURITY_KEYWORDS = (
+    "auth",
+    "token",
+    "password",
+    "secret",
+    "permission",
+    "oauth",
+    "jwt",
+    "crypto",
+    "encrypt",
+)
+DEPENDENCY_FILES = {
+    "requirements.txt",
+    "pyproject.toml",
+    "poetry.lock",
+    "pdm.lock",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "go.mod",
+    "go.sum",
+    "Cargo.toml",
+    "Cargo.lock",
+    "Gemfile",
+    "Gemfile.lock",
+    "composer.json",
+    "composer.lock",
+}
+LOCKFILE_SUFFIXES = (".lock",)
+MIGRATION_TOKENS = ("migrations", "alembic", "db/migrate")
+CI_TOKENS = (".github/workflows", "circleci", ".gitlab-ci")
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+
+
+def parse_pr_url(url: str) -> PullRequestRef:
+    parsed = parse.urlparse(url)
+    host = (parsed.netloc or "").lower()
+    if parsed.scheme not in {"http", "https"} or host not in {"github.com", "www.github.com"}:
+        raise ValueError("URL must be a github.com pull request URL")
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 4 or parts[2] != "pull":
+        raise ValueError("URL must match /owner/repo/pull/<number>")
+    if not parts[3].isdigit():
+        raise ValueError("Pull request number must be numeric")
+
+    return PullRequestRef(owner=parts[0], repo=parts[1], number=int(parts[3]))
+
+
+def _make_headers(token: str | None = None, accept: str = "application/vnd.github+json") -> Dict[str, str]:
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": accept,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _http_request(url: str, headers: Dict[str, str], method: str = "GET", body: bytes | None = None) -> str:
+    req = request.Request(url, headers=headers, method=method, data=body)
+    try:
+        with request.urlopen(req, timeout=25) as resp:
+            encoding = resp.headers.get_content_charset() or "utf-8"
+            return resp.read().decode(encoding, errors="replace")
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"HTTP {exc.code} from {url}: {detail}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Network error reaching {url}: {exc}") from exc
+
+
+def fetch_pr_metadata(pr: PullRequestRef, token: str | None = None) -> Dict[str, Any]:
+    url = f"https://api.github.com/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}"
+    payload = _http_request(url, _make_headers(token))
+    return json.loads(payload)
+
+
+def fetch_pr_diff(pr: PullRequestRef, token: str | None = None) -> str:
+    url = f"https://github.com/{pr.owner}/{pr.repo}/pull/{pr.number}.diff"
+    return _http_request(url, _make_headers(token, accept="text/x-diff"))
+
+
+def extract_changed_files(diff_text: str) -> List[str]:
+    files: List[str] = []
+    seen = set()
+    for line in diff_text.splitlines():
+        if not line.startswith("diff --git "):
+            continue
+        match = re.match(r"^diff --git a/(.+?) b/(.+)$", line)
+        if not match:
+            continue
+        left, right = match.groups()
+        path = right if right != "/dev/null" else left
+        if path not in seen:
+            seen.add(path)
+            files.append(path)
+    return files
+
+
+def diff_line_stats(diff_text: str) -> Tuple[int, int]:
+    additions = 0
+    deletions = 0
+    for line in diff_text.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            additions += 1
+        elif line.startswith("-"):
+            deletions += 1
+    return additions, deletions
+
+
+def _has_test_files(files: List[str]) -> bool:
+    for path in files:
+        lower = path.lower()
+        if re.search(r"(^|/)(test|tests)(/|_|\.|$)", lower) or lower.endswith("_test.py") or lower.endswith(".spec.js"):
+            return True
+    return False
+
+
+def analyze_pr(metadata: Dict[str, Any], diff_text: str) -> Dict[str, Any]:
+    files = extract_changed_files(diff_text)
+    additions, deletions = diff_line_stats(diff_text)
+    changed_files = int(metadata.get("changed_files") or len(files))
+    additions = int(metadata.get("additions") or additions)
+    deletions = int(metadata.get("deletions") or deletions)
+    commits = int(metadata.get("commits") or 0)
+
+    lower_diff = diff_text.lower()
+    lower_files = [f.lower() for f in files]
+
+    tests_present = _has_test_files(files)
+    security_touched = any(keyword in lower_diff for keyword in SECURITY_KEYWORDS)
+    ci_touched = any(any(token in path for token in CI_TOKENS) for path in lower_files)
+    dependency_touched = any(os.path.basename(path) in DEPENDENCY_FILES for path in lower_files)
+    migration_touched = any(any(token in path for token in MIGRATION_TOKENS) for path in lower_files)
+    deleted_file_count = diff_text.count("deleted file mode")
+    lockfile_count = sum(1 for path in lower_files if path.endswith(LOCKFILE_SUFFIXES) or os.path.basename(path) in {"package-lock.json", "pnpm-lock.yaml", "yarn.lock", "poetry.lock", "cargo.lock"})
+
+    total_changed_lines = additions + deletions
+
+    risks: List[str] = []
+    if changed_files >= 25 or total_changed_lines >= 1200:
+        risks.append("Large PR footprint increases regression risk and reviewer blind spots.")
+    if total_changed_lines >= 400:
+        risks.append("Substantial code churn may hide edge-case failures.")
+    if security_touched:
+        risks.append("Security/auth-related code appears in the diff and needs focused review.")
+    if migration_touched:
+        risks.append("Database migration files changed; rollback and data-compatibility risk should be checked.")
+    if dependency_touched:
+        risks.append("Dependency manifest or lockfile changes may introduce supply-chain or compatibility risk.")
+    if ci_touched:
+        risks.append("CI/workflow definitions changed; verify pipeline behavior and permissions.")
+    if deleted_file_count > 0:
+        risks.append("File deletions detected; ensure removed logic has no runtime references.")
+    if not tests_present and total_changed_lines >= 80:
+        risks.append("No test files detected despite non-trivial changes.")
+    if lockfile_count > 0 and lockfile_count == len(lower_files):
+        risks.append("PR appears lockfile-only; verify this was intentionally generated from clean dependency updates.")
+
+    if not risks:
+        risks.append("No major red flags from heuristic scan; residual risk remains for runtime behavior and edge cases.")
+
+    suggestions: List[str] = []
+    if not tests_present:
+        suggestions.append("Add or update automated tests that cover the main changed paths and one failure case.")
+    if security_touched:
+        suggestions.append("Request a focused security review for auth/secret/permission handling changes.")
+    if migration_touched:
+        suggestions.append("Document migration rollout and rollback steps, plus compatibility expectations.")
+    if dependency_touched:
+        suggestions.append("Pin and scan updated dependencies, and include rationale for major version bumps.")
+    if ci_touched:
+        suggestions.append("Run CI with least-privilege checks for updated workflow files before merge.")
+    if changed_files >= 25 or total_changed_lines >= 1200:
+        suggestions.append("Consider splitting this PR into smaller, reviewable units.")
+    if not suggestions:
+        suggestions.append("Run full CI and smoke tests before merge to validate runtime behavior.")
+
+    strong_risk_signals = sum(
+        [
+            changed_files >= 25,
+            total_changed_lines >= 1200,
+            security_touched,
+            migration_touched,
+            ci_touched,
+            dependency_touched,
+            (not tests_present and total_changed_lines >= 80),
+        ]
+    )
+    if strong_risk_signals >= 3 or total_changed_lines >= 2500:
+        confidence = "Low"
+    elif strong_risk_signals >= 1 or total_changed_lines >= 500 or changed_files >= 15:
+        confidence = "Medium"
+    else:
+        confidence = "High"
+
+    return {
+        "files": files,
+        "changed_files": changed_files,
+        "additions": additions,
+        "deletions": deletions,
+        "commits": commits,
+        "tests_present": tests_present,
+        "risks": risks,
+        "suggestions": suggestions,
+        "confidence": confidence,
+        "total_changed_lines": total_changed_lines,
+    }
+
+
+def build_summary(metadata: Dict[str, Any], analysis: Dict[str, Any]) -> str:
+    title = (metadata.get("title") or "Untitled pull request").strip()
+    base_ref = (metadata.get("base") or {}).get("ref") or "base"
+    head_ref = (metadata.get("head") or {}).get("ref") or "head"
+    touched_preview = ", ".join(analysis["files"][:3]) if analysis["files"] else "no parsed file names"
+    tests_text = "includes test file changes" if analysis["tests_present"] else "does not include obvious test file changes"
+
+    sentence1 = f"This PR, \"{title}\", proposes merging `{head_ref}` into `{base_ref}`."
+    sentence2 = (
+        f"It spans {analysis['changed_files']} files with {analysis['additions']} additions and "
+        f"{analysis['deletions']} deletions across {analysis['commits']} commits."
+    )
+    sentence3 = f"Primary touched paths include {touched_preview}, and the diff {tests_text}."
+    return " ".join([sentence1, sentence2, sentence3])
+
+
+def render_markdown(pr: PullRequestRef, metadata: Dict[str, Any], analysis: Dict[str, Any]) -> str:
+    summary = build_summary(metadata, analysis)
+
+    risk_lines = "\n".join(f"- {item}" for item in analysis["risks"])
+    suggestion_lines = "\n".join(f"- {item}" for item in analysis["suggestions"])
+
+    return "\n".join(
+        [
+            f"# Claude Review for {pr.owner}/{pr.repo}#{pr.number}",
+            "",
+            "## Summary of changes",
+            summary,
+            "",
+            "## Identified risks",
+            risk_lines,
+            "",
+            "## Improvement suggestions",
+            suggestion_lines,
+            "",
+            "## Confidence score",
+            analysis["confidence"],
+        ]
+    ) + "\n"
+
+
+def post_comment(pr: PullRequestRef, token: str, markdown: str) -> Dict[str, Any]:
+    if not token:
+        raise ValueError("GITHUB_TOKEN is required to post a comment")
+    url = f"https://api.github.com/repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments"
+    payload = json.dumps({"body": markdown}).encode("utf-8")
+    headers = _make_headers(token)
+    headers["Content-Type"] = "application/json"
+    response = _http_request(url, headers=headers, method="POST", body=payload)
+    return json.loads(response)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Review a GitHub pull request and emit structured markdown.")
+    parser.add_argument("--pr", required=True, help="GitHub pull request URL, e.g. https://github.com/owner/repo/pull/123")
+    parser.add_argument(
+        "--post-comment",
+        action="store_true",
+        help="Post the generated markdown as a PR comment (requires GITHUB_TOKEN).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    try:
+        pr = parse_pr_url(args.pr)
+    except ValueError as exc:
+        print(f"Invalid --pr value: {exc}", file=sys.stderr)
+        return 2
+
+    token = os.getenv("GITHUB_TOKEN")
+
+    try:
+        metadata = fetch_pr_metadata(pr, token=token)
+        diff_text = fetch_pr_diff(pr, token=token)
+        analysis = analyze_pr(metadata, diff_text)
+        markdown = render_markdown(pr, metadata, analysis)
+    except Exception as exc:
+        print(f"Failed to review PR: {exc}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(markdown)
+
+    if args.post_comment:
+        if not token:
+            print("--post-comment requires GITHUB_TOKEN", file=sys.stderr)
+            return 2
+        try:
+            response = post_comment(pr, token=token, markdown=markdown)
+        except Exception as exc:
+            print(f"Failed to post PR comment: {exc}", file=sys.stderr)
+            return 1
+        comment_url = response.get("html_url") or response.get("url") or "(unknown URL)"
+        print(f"Posted comment: {comment_url}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package marker for unittest module-path execution.

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,0 +1,101 @@
+import unittest
+
+from scripts.claude_review import analyze_pr, parse_pr_url, render_markdown
+
+
+class ParsePrUrlTests(unittest.TestCase):
+    def test_valid_pr_url(self):
+        ref = parse_pr_url("https://github.com/owner/repo/pull/123")
+        self.assertEqual(ref.owner, "owner")
+        self.assertEqual(ref.repo, "repo")
+        self.assertEqual(ref.number, 123)
+
+    def test_valid_pr_url_with_trailing_segments(self):
+        ref = parse_pr_url("https://github.com/owner/repo/pull/42/files#diff-abc")
+        self.assertEqual(ref.owner, "owner")
+        self.assertEqual(ref.repo, "repo")
+        self.assertEqual(ref.number, 42)
+
+    def test_invalid_pr_urls(self):
+        invalid_urls = [
+            "https://gitlab.com/owner/repo/pull/1",
+            "https://github.com/owner/repo/issues/1",
+            "https://github.com/owner/repo/pull/not-a-number",
+            "https://github.com/owner/repo",
+        ]
+        for url in invalid_urls:
+            with self.assertRaises(ValueError):
+                parse_pr_url(url)
+
+
+class HeuristicTests(unittest.TestCase):
+    def test_risk_heuristics_flag_security_and_missing_tests(self):
+        metadata = {
+            "title": "Harden auth middleware",
+            "changed_files": 4,
+            "additions": 180,
+            "deletions": 40,
+            "commits": 2,
+            "base": {"ref": "main"},
+            "head": {"ref": "feature/auth-hardening"},
+        }
+        diff_text = "\n".join(
+            [
+                "diff --git a/src/auth.py b/src/auth.py",
+                "--- a/src/auth.py",
+                "+++ b/src/auth.py",
+                "+token = request.headers.get('Authorization')",
+                "+if not token:",
+                "+    raise ValueError('missing token')",
+                "-legacy_auth = True",
+                "diff --git a/src/permissions.py b/src/permissions.py",
+                "--- a/src/permissions.py",
+                "+++ b/src/permissions.py",
+                "+SECRET_NAME = 'API_SECRET'",
+                "+def check_permission(user):",
+                "+    return user.is_admin",
+            ]
+        )
+
+        analysis = analyze_pr(metadata, diff_text)
+        risks_joined = " ".join(analysis["risks"])
+        self.assertIn("Security/auth-related code", risks_joined)
+        self.assertIn("No test files detected", risks_joined)
+        self.assertIn(analysis["confidence"], {"Low", "Medium", "High"})
+
+
+class MarkdownStructureTests(unittest.TestCase):
+    def test_markdown_contains_required_sections(self):
+        from scripts.claude_review import PullRequestRef
+
+        pr = PullRequestRef(owner="owner", repo="repo", number=123)
+        metadata = {
+            "title": "Add feature",
+            "changed_files": 2,
+            "additions": 10,
+            "deletions": 3,
+            "commits": 1,
+            "base": {"ref": "main"},
+            "head": {"ref": "feature"},
+        }
+        diff_text = "\n".join(
+            [
+                "diff --git a/tests/test_feature.py b/tests/test_feature.py",
+                "--- a/tests/test_feature.py",
+                "+++ b/tests/test_feature.py",
+                "+def test_feature():",
+                "+    assert True",
+            ]
+        )
+        analysis = analyze_pr(metadata, diff_text)
+        markdown = render_markdown(pr, metadata, analysis)
+
+        self.assertIn("## Summary of changes", markdown)
+        self.assertIn("## Identified risks", markdown)
+        self.assertIn("## Improvement suggestions", markdown)
+        self.assertIn("## Confidence score", markdown)
+        self.assertRegex(markdown, r"\n(Low|Medium|High)\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,6 +1,6 @@
 import unittest
 
-from scripts.claude_review import analyze_pr, parse_pr_url, render_markdown
+from scripts.claude_review import analyze_pr, build_summary, parse_pr_url, render_markdown
 
 
 class ParsePrUrlTests(unittest.TestCase):
@@ -62,6 +62,118 @@ class HeuristicTests(unittest.TestCase):
         self.assertIn("Security/auth-related code", risks_joined)
         self.assertIn("No test files detected", risks_joined)
         self.assertIn(analysis["confidence"], {"Low", "Medium", "High"})
+
+    def test_heuristics_flag_dependencies_ci_migrations_locks_and_deletions(self):
+        metadata = {
+            "title": "Update platform dependencies",
+            "commits": 1,
+            "base": {"ref": "main"},
+            "head": {"ref": "deps"},
+        }
+        diff_text = "\n".join(
+            [
+                "diff --git a/Cargo.toml b/Cargo.toml",
+                "--- a/Cargo.toml",
+                "+++ b/Cargo.toml",
+                "+serde = \"1\"",
+                "diff --git a/Cargo.lock b/Cargo.lock",
+                "--- a/Cargo.lock",
+                "+++ b/Cargo.lock",
+                "+[[package]]",
+                "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml",
+                "--- a/.github/workflows/ci.yml",
+                "+++ b/.github/workflows/ci.yml",
+                "+permissions: read-all",
+                "diff --git a/db/migrate/001_create_widgets.rb b/db/migrate/001_create_widgets.rb",
+                "--- a/db/migrate/001_create_widgets.rb",
+                "+++ b/db/migrate/001_create_widgets.rb",
+                "+create_table :widgets",
+                "diff --git a/src/old.py b/src/old.py",
+                "deleted file mode 100644",
+                "--- a/src/old.py",
+                "+++ /dev/null",
+                "-print('old')",
+            ]
+        )
+
+        analysis = analyze_pr(metadata, diff_text)
+
+        self.assertTrue(analysis["signals"]["dependency_touched"])
+        self.assertTrue(analysis["signals"]["ci_touched"])
+        self.assertTrue(analysis["signals"]["migration_touched"])
+        self.assertEqual(analysis["signals"]["lockfile_count"], 1)
+        self.assertEqual(analysis["signals"]["deleted_file_count"], 1)
+
+    def test_security_keyword_matching_avoids_author_false_positive(self):
+        metadata = {"title": "Docs", "commits": 1}
+        author_diff = "\n".join(
+            [
+                "diff --git a/src/docs.py b/src/docs.py",
+                "--- a/src/docs.py",
+                "+++ b/src/docs.py",
+                "+author = user.name",
+            ]
+        )
+        auth_diff = "\n".join(
+            [
+                "diff --git a/src/auth.py b/src/auth.py",
+                "--- a/src/auth.py",
+                "+++ b/src/auth.py",
+                "+authorization = request.headers.get('Authorization')",
+            ]
+        )
+
+        self.assertFalse(analyze_pr(metadata, author_diff)["signals"]["security_touched"])
+        self.assertTrue(analyze_pr(metadata, auth_diff)["signals"]["security_touched"])
+
+    def test_summary_pluralizes_singular_counts(self):
+        metadata = {
+            "title": "One file",
+            "changed_files": 1,
+            "additions": 1,
+            "deletions": 1,
+            "commits": 1,
+            "base": {"ref": "main"},
+            "head": {"ref": "feature"},
+        }
+        diff_text = "\n".join(
+            [
+                "diff --git a/src/one.py b/src/one.py",
+                "--- a/src/one.py",
+                "+++ b/src/one.py",
+                "+print('new')",
+                "-print('old')",
+            ]
+        )
+
+        summary = build_summary(metadata, analyze_pr(metadata, diff_text))
+
+        self.assertIn("It spans 1 file with 1 addition and 1 deletion across 1 commit.", summary)
+
+    def test_confidence_can_drop_to_low_for_many_risk_signals(self):
+        metadata = {
+            "title": "Large auth migration",
+            "changed_files": 30,
+            "additions": 1400,
+            "deletions": 1200,
+            "commits": 5,
+        }
+        diff_text = "\n".join(
+            [
+                "diff --git a/db/migrate/001_auth.rb b/db/migrate/001_auth.rb",
+                "--- a/db/migrate/001_auth.rb",
+                "+++ b/db/migrate/001_auth.rb",
+                "+authorization = token",
+                "diff --git a/package.json b/package.json",
+                "--- a/package.json",
+                "+++ b/package.json",
+                "+{\"dependencies\": {\"auth-lib\": \"1.0.0\"}}",
+            ]
+        )
+
+        analysis = analyze_pr(metadata, diff_text)
+
+        self.assertEqual(analysis["confidence"], "Low")
 
 
 class MarkdownStructureTests(unittest.TestCase):


### PR DESCRIPTION
Closes #4

/claim #4

## Summary
- Add a dependency-free Python CLI for `./claude-review --pr <github-pr-url>`.
- Fetch public GitHub PR metadata and diffs, then emit structured Markdown review output.
- Support optional token-authenticated GitHub comment posting behind explicit `--post-comment`.
- Include offline unit tests and two generated sample reviews from real public PRs.

## Acceptance criteria
- CLI works as `claude-review --pr https://github.com/owner/repo/pull/123`.
- Output includes Summary of changes, Identified risks, Improvement suggestions, and Confidence score.
- Sample outputs included for `psf/requests#7464` and `pallets/flask#6028`.
- README includes setup and usage instructions.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v tests/test_claude_review.py`
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile scripts/claude_review.py tests/test_claude_review.py`
- `./claude-review --help`
- `./claude-review --pr https://github.com/pallets/flask/pull/6028`
- `git diff --check HEAD~1..HEAD`