### PR TITLE
Generate changelog skill

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,9 @@
+Generate a structured `CHANGELOG.md` from this repository's git history.
+
+Run the checked-in changelog generator:
+
+```bash
+bash changelog.sh
+```
+
+Then summarize the generated sections and call out whether commits were collected since the latest git tag or from the full history.

--- a/.claude/skills/generate-changelog/SKILL.md
+++ b/.claude/skills/generate-changelog/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when a repository needs a structured changelog generated from Git commit history.
+
+## Steps
+
+1. Run the checked-in generator from the repository root:
+
+   ```bash
+   bash changelog.sh
+   ```
+
+2. Inspect `CHANGELOG.md` and confirm it includes these sections:
+
+   - `Added`
+   - `Fixed`
+   - `Changed`
+   - `Removed`
+
+3. If you need a different output path, pass it as the first argument:
+
+   ```bash
+   bash changelog.sh docs/CHANGELOG.md
+   ```
+
+## Validation
+
+For a deterministic smoke test, run:
+
+```bash
+bash generate-changelog/test-changelog.sh ./changelog.sh
+```
+
+The smoke test creates a temporary tagged repository and verifies that only commits since the latest tag are included.

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,0 +1,20 @@
+name: Generate Changelog
+
+on:
+  pull_request:
+  push:
+    branches:
+      - generate-changelog-skill
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell syntax
+        run: bash -n changelog.sh
+
+      - name: Run changelog smoke test
+        run: bash generate-changelog/test-changelog.sh ./changelog.sh

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh must be run inside a git repository." >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  range_label="since ${latest_tag}"
+else
+  range="HEAD"
+  range_label="from all commits"
+fi
+
+added=""
+fixed=""
+changed=""
+removed=""
+
+clean_subject() {
+  local subject="$1"
+  subject="${subject#*: }"
+  subject="${subject#*): }"
+  printf '%s' "$subject"
+}
+
+add_commit() {
+  local subject="$1"
+  local normalized
+  local cleaned
+  normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  cleaned="$(clean_subject "$subject")"
+
+  case "$normalized" in
+    feat:*|feat\(*|add:*|added:*|new:*|implement:*|create:*)
+      added="${added}- ${cleaned}"$'\n'
+      ;;
+    fix:*|fix\(*|bug:*|bugfix:*|hotfix:*|repair:*)
+      fixed="${fixed}- ${cleaned}"$'\n'
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*)
+      removed="${removed}- ${cleaned}"$'\n'
+      ;;
+    chore:*|refactor:*|perf:*|style:*|test:*|docs:*|ci:*|build:*|change:*|changed:*|update:*|updated:*)
+      changed="${changed}- ${cleaned}"$'\n'
+      ;;
+    *)
+      changed="${changed}- ${subject}"$'\n'
+      ;;
+  esac
+}
+
+write_section() {
+  local title="$1"
+  local items="$2"
+
+  printf '### %s\n\n' "$title"
+  if [[ -z "$items" ]]; then
+    printf -- '- None\n\n'
+    return
+  fi
+
+  printf '%s\n' "$items"
+}
+
+while IFS= read -r commit; do
+  [[ -n "$commit" ]] || continue
+  add_commit "$commit"
+done < <(git log --no-merges --reverse --format='%s' "$range")
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated %s for commits %s.\n\n' "$(date -u +%Y-%m-%d)" "$range_label"
+  write_section "Added" "$added"
+  write_section "Fixed" "$fixed"
+  write_section "Changed" "$changed"
+  write_section "Removed" "$removed"
+} > "$output_file"
+
+echo "Wrote ${output_file}"

--- a/generate-changelog/ACCEPTANCE.md
+++ b/generate-changelog/ACCEPTANCE.md
@@ -1,0 +1,26 @@
+# Acceptance Checklist
+
+This checklist maps the bounty requirements to the files and commands in this PR.
+
+- Works via `/generate-changelog` command or `bash changelog.sh`
+  - `/generate-changelog`: `.claude/commands/generate-changelog.md`
+  - Claude Code skill: `.claude/skills/generate-changelog/SKILL.md`
+  - Bash command: `bash changelog.sh`
+
+- Fetches commits since the last git tag
+  - Implemented in `changelog.sh` with `git describe --tags --abbrev=0` and the `${latest_tag}..HEAD` range.
+  - Covered by `bash generate-changelog/test-changelog.sh ./changelog.sh`, which creates a temporary `v1.0.0` tag and verifies pre-tag commits are excluded.
+
+- Auto-categorizes into `Added`, `Fixed`, `Changed`, and `Removed`
+  - Implemented in `changelog.sh` with conventional-commit-style prefixes and keyword fallbacks.
+  - Covered by the smoke test using `feat:`, `fix:`, `docs:`, and `remove:` commits.
+
+- Outputs a properly formatted `CHANGELOG.md`
+  - `changelog.sh` writes a Markdown document with a `# Changelog` heading and all four sections.
+
+- Tested on a real GitHub repo with sample output
+  - Sample output is included in `generate-changelog/SAMPLE_OUTPUT.md`.
+  - The same output is shown in `generate-changelog/README.md`.
+
+- README with setup instructions in 3 steps or fewer
+  - `generate-changelog/README.md` has a three-step setup section.

--- a/generate-changelog/ACCEPTANCE.md
+++ b/generate-changelog/ACCEPTANCE.md
@@ -24,3 +24,12 @@ This checklist maps the bounty requirements to the files and commands in this PR
 
 - README with setup instructions in 3 steps or fewer
   - `generate-changelog/README.md` has a three-step setup section.
+
+## Verification Commands
+
+```bash
+bash -n changelog.sh
+bash generate-changelog/test-changelog.sh ./changelog.sh
+```
+
+The branch also includes `.github/workflows/generate-changelog.yml`, which runs the same syntax and smoke-test checks on push and pull request events.

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -8,6 +8,13 @@ Generate a structured `CHANGELOG.md` from the current repository's git history.
 2. Run `bash changelog.sh` to generate `CHANGELOG.md`.
 3. Optionally pass a custom output path: `bash changelog.sh docs/CHANGELOG.md`.
 
+## Claude Code Entrypoints
+
+This PR includes both Claude Code invocation styles:
+
+- `.claude/commands/generate-changelog.md` exposes `/generate-changelog` as a project slash command.
+- `.claude/skills/generate-changelog/SKILL.md` exposes the same workflow as a project skill.
+
 ## What It Does
 
 - Reads commits since the most recent git tag, or all commits when no tag exists.

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,41 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from the current repository's git history.
+
+## Setup
+
+1. Copy `changelog.sh` into the root of a git repository.
+2. Run `bash changelog.sh` to generate `CHANGELOG.md`.
+3. Optionally pass a custom output path: `bash changelog.sh docs/CHANGELOG.md`.
+
+## What It Does
+
+- Reads commits since the most recent git tag, or all commits when no tag exists.
+- Skips merge commits.
+- Categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+
+## Sample Output
+
+Tested against this repository on `main`, which has no git tags:
+
+```md
+# Changelog
+
+Generated 2026-05-20 for commits from all commits.
+
+### Added
+
+- initial README with bounty board
+
+### Fixed
+
+- None
+
+### Changed
+
+- None
+
+### Removed
+
+- None
+```

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -14,6 +14,16 @@ Generate a structured `CHANGELOG.md` from the current repository's git history.
 - Skips merge commits.
 - Categorizes commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
 
+## Validation
+
+Run the included smoke test from this repository root:
+
+```bash
+bash generate-changelog/test-changelog.sh ./changelog.sh
+```
+
+The test creates a temporary git repository with a tag, generates a changelog from post-tag commits, and verifies all four output categories.
+
 ## Sample Output
 
 Tested against this repository on `main`, which has no git tags:

--- a/generate-changelog/SAMPLE_OUTPUT.md
+++ b/generate-changelog/SAMPLE_OUTPUT.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Generated 2026-05-20 for commits from all commits.
+
+### Added
+
+- initial README with bounty board
+
+### Fixed
+
+- None
+
+### Changed
+
+- None
+
+### Removed
+
+- None

--- a/generate-changelog/SKILL.md
+++ b/generate-changelog/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when a project needs a structured `CHANGELOG.md` generated from its Git history.
+
+## Command
+
+Run the repository script from the project root:
+
+```bash
+bash changelog.sh
+```
+
+To write to another path, pass the output file as the first argument:
+
+```bash
+bash changelog.sh /tmp/CHANGELOG.md
+```
+
+## What It Does
+
+The script finds commits since the latest Git tag. If the repository has no tags, it uses the full history.
+
+It ignores merge commits, categorizes commit subjects into these sections, and writes a Markdown changelog:
+
+- `Added`
+- `Fixed`
+- `Changed`
+- `Removed`
+
+## Review Checklist
+
+After running the command, verify that:
+
+- `CHANGELOG.md` exists at the expected path
+- commits are grouped under the four supported headings
+- the generated range matches the latest tag or the full history when no tag exists

--- a/generate-changelog/test-changelog.sh
+++ b/generate-changelog/test-changelog.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_path="${1:-./changelog.sh}"
+script_path="$(cd "$(dirname "$script_path")" && pwd)/$(basename "$script_path")"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cd "$tmpdir"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Changelog Test"
+
+printf 'initial\n' > file.txt
+git add file.txt
+git commit -q -m "feat: initial release"
+git tag v1.0.0
+
+printf 'feature\n' >> file.txt
+git add file.txt
+git commit -q -m "feat: add dashboard"
+
+printf 'fix\n' >> file.txt
+git add file.txt
+git commit -q -m "fix: repair login"
+
+printf 'docs\n' >> file.txt
+git add file.txt
+git commit -q -m "docs: update usage guide"
+
+printf 'remove\n' >> file.txt
+git add file.txt
+git commit -q -m "remove: drop legacy config"
+
+bash "$script_path" CHANGELOG.md >/dev/null
+
+assert_contains() {
+  local expected="$1"
+  if ! grep -Fq -- "$expected" CHANGELOG.md; then
+    echo "Expected generated changelog to contain: $expected" >&2
+    echo "--- CHANGELOG.md ---" >&2
+    cat CHANGELOG.md >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local unexpected="$1"
+  if grep -Fq -- "$unexpected" CHANGELOG.md; then
+    echo "Generated changelog unexpectedly contained: $unexpected" >&2
+    echo "--- CHANGELOG.md ---" >&2
+    cat CHANGELOG.md >&2
+    exit 1
+  fi
+}
+
+assert_contains "Generated"
+assert_contains "since v1.0.0"
+assert_contains "### Added"
+assert_contains "- add dashboard"
+assert_contains "### Fixed"
+assert_contains "- repair login"
+assert_contains "### Changed"
+assert_contains "- update usage guide"
+assert_contains "### Removed"
+assert_contains "- drop legacy config"
+assert_not_contains "initial release"
+
+echo "changelog smoke test passed"


### PR DESCRIPTION
## Summary
- Adds `changelog.sh` to generate a structured `CHANGELOG.md` from git history.
- - Categorizes non-merge commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
- - Includes a 3-step setup README plus sample output generated from this repository.
## Verification
- `bash -n changelog.sh`
- - `bash changelog.sh /tmp/sample-changelog.md`
Closes #1 