### PR TITLE
Add destructive Bash command blocker hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,42 @@
+# Destructive Bash Command Blocker
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## What It Blocks
+
+- `rm -rf` and `rm -fr`
+- `git push --force`, `git push --force-with-lease`, and `git push -f`
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` statements that do not include a `WHERE` clause
+
+Blocked attempts are appended to `~/.claude/hooks/blocked.log` as JSON lines with:
+
+- timestamp
+- attempted command
+- project path
+- block reason
+
+## Install
+
+Run from this repository:
+
+```bash
+python3 hooks/install_block_destructive_bash.py
+```
+
+Then run `/hooks` in Claude Code and confirm a `PreToolUse` hook is registered for `Bash`.
+
+## Manual Configuration
+
+If you prefer manual setup, copy `hooks/block_destructive_bash.py` into `~/.claude/hooks/` and add the contents of `hooks/settings.example.json` to `~/.claude/settings.json`.
+
+## Behavior
+
+Safe Bash commands pass silently and do not write to the log. Blocked commands return a Claude Code `PreToolUse` denial with a clear reason so Claude can choose a safer, reversible command or ask the user for confirmation.
+
+## Test
+
+```bash
+python3 -m unittest tests/test_block_destructive_bash.py
+```

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BLOCK_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"(?is)\brm\s+(?:(?:-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*)|(?:-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*))\b"),
+        "recursive force removal with rm -rf/rm -fr",
+    ),
+    (
+        re.compile(r"(?is)\brm\s+(?:-[A-Za-z]*r[A-Za-z]*\s+-[A-Za-z]*f[A-Za-z]*|-[A-Za-z]*f[A-Za-z]*\s+-[A-Za-z]*r[A-Za-z]*)\b"),
+        "recursive force removal with rm -r -f/rm -f -r",
+    ),
+    (
+        re.compile(r"(?is)\bgit\s+push\b[^\n;|&]*?(?:--force(?:-with-lease)?\b|-f\b)"),
+        "force-pushing with git push --force/-f",
+    ),
+    (
+        re.compile(r"(?is)\bDROP\s+TABLE\b"),
+        "DROP TABLE statement",
+    ),
+    (
+        re.compile(r"(?is)\bTRUNCATE(?:\s+TABLE)?\b"),
+        "TRUNCATE statement",
+    ),
+)
+
+DELETE_FROM_PATTERN = re.compile(r"(?is)\bDELETE\s+FROM\b")
+WHERE_PATTERN = re.compile(r"(?is)\bWHERE\b")
+
+
+def _hook_log_path() -> Path:
+    override = os.environ.get("CLAUDE_HOOKS_LOG")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def _normalize_command(input_data: dict[str, Any]) -> str:
+    tool_input = input_data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return ""
+    command = tool_input.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def _statements(command: str) -> list[str]:
+    return [part.strip() for part in re.split(r";|\n", command) if part.strip()]
+
+
+def find_block_reason(command: str) -> str | None:
+    for pattern, reason in BLOCK_PATTERNS:
+        if pattern.search(command):
+            return reason
+
+    for statement in _statements(command):
+        if DELETE_FROM_PATTERN.search(statement) and not WHERE_PATTERN.search(statement):
+            return "DELETE FROM statement without a WHERE clause"
+
+    return None
+
+
+def log_blocked(command: str, project_path: str, reason: str) -> None:
+    log_path = _hook_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    entry = {
+        "timestamp": timestamp,
+        "project_path": project_path,
+        "reason": reason,
+        "command": command,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def deny(reason: str) -> None:
+    message = (
+        "Blocked destructive Bash command: "
+        f"{reason}. Choose a safer, reversible command or ask the user for explicit confirmation."
+    )
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": message,
+        }
+    }
+    print(json.dumps(output))
+
+
+def main() -> int:
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if input_data.get("hook_event_name") != "PreToolUse" or input_data.get("tool_name") != "Bash":
+        return 0
+
+    command = _normalize_command(input_data)
+    if not command:
+        return 0
+
+    reason = find_block_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = str(input_data.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    log_blocked(command, project_path, reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/install_block_destructive_bash.py
+++ b/hooks/install_block_destructive_bash.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash command blocker into ~/.claude/hooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+from pathlib import Path
+
+
+HOOK_NAME = "block_destructive_bash.py"
+
+
+def main() -> int:
+    source = Path(__file__).resolve().with_name(HOOK_NAME)
+    claude_dir = Path.home() / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    settings_path = claude_dir / "settings.json"
+    target = hooks_dir / HOOK_NAME
+
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    try:
+        target.chmod(target.stat().st_mode | 0o111)
+    except OSError:
+        pass
+
+    settings: dict[str, object]
+    if settings_path.exists():
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        if not isinstance(settings, dict):
+            raise ValueError(f"{settings_path} must contain a JSON object")
+    else:
+        settings = {}
+
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise ValueError("settings.hooks must be a JSON object")
+
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    if not isinstance(pre_tool_use, list):
+        raise ValueError("settings.hooks.PreToolUse must be a JSON array")
+
+    command = f"python3 {shlex.quote(str(target))}"
+    matcher = {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": command,
+            }
+        ],
+    }
+
+    has_command = any(
+        isinstance(item, dict)
+        and any(
+            isinstance(hook, dict) and hook.get("command") == command
+            for hook in item.get("hooks", [])
+        )
+        for item in pre_tool_use
+    )
+    if not has_command:
+        pre_tool_use.append(matcher)
+
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"Installed {target}")
+    print(f"Updated {settings_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/settings.example.json
+++ b/hooks/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,92 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block_destructive_bash.py"
+
+
+def run_hook(command, log_path):
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": "/tmp/project",
+        "tool_input": {"command": command},
+    }
+    env = os.environ.copy()
+    env["CLAUDE_HOOKS_LOG"] = str(log_path)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class DestructiveBashHookTests(unittest.TestCase):
+    def test_allows_normal_command_without_logging(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "blocked.log"
+            result = run_hook("git status --short", log_path)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse(log_path.exists())
+
+    def test_blocks_rm_rf_and_logs_attempt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "blocked.log"
+            result = run_hook("rm -r -f dist", log_path)
+
+            self.assertEqual(result.returncode, 0)
+            output = json.loads(result.stdout)
+            reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+            self.assertIn("rm -r -f", reason)
+
+            entries = log_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(entries), 1)
+            entry = json.loads(entries[0])
+            self.assertEqual(entry["command"], "rm -r -f dist")
+            self.assertEqual(entry["project_path"], "/tmp/project")
+
+    def test_blocks_force_push(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hook("git push origin main --force-with-lease", Path(tmp) / "blocked.log")
+
+            output = json.loads(result.stdout)
+            self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+            self.assertIn("force-pushing", output["hookSpecificOutput"]["permissionDecisionReason"])
+
+    def test_allows_delete_from_with_where(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hook("psql -c \"DELETE FROM users WHERE id = 1\"", Path(tmp) / "blocked.log")
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_blocks_delete_from_without_where(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hook("psql -c \"DELETE FROM users\"", Path(tmp) / "blocked.log")
+
+            output = json.loads(result.stdout)
+            self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+            self.assertIn("without a WHERE clause", output["hookSpecificOutput"]["permissionDecisionReason"])
+
+    def test_blocks_drop_table_and_truncate(self):
+        for command in ("psql -c 'DROP TABLE users'", "psql -c 'TRUNCATE TABLE users'"):
+            with self.subTest(command=command), tempfile.TemporaryDirectory() as tmp:
+                result = run_hook(command, Path(tmp) / "blocked.log")
+
+                output = json.loads(result.stdout)
+                self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a Claude Code `PreToolUse` hook that denies destructive Bash commands before execution.
- Blocks `rm -rf`/`rm -fr`, split `rm -r -f` variants, force pushes, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` without `WHERE`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, project path, and reason.
- Includes a one-command installer, example settings, README, and standard-library tests.

## Verification
- `python -m unittest tests/test_block_destructive_bash.py`

/claim #3