### PR TITLE
Add generate-changelog skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+else
+  PYTHON_BIN="python"
+fi
+
+exec "$PYTHON_BIN" "$SCRIPT_DIR/skills/generate-changelog/generate_changelog.py" "$@"

--- a/samples/CHANGELOG.sample.md
+++ b/samples/CHANGELOG.sample.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Generated for `claude-builders-bounty` on 2026-05-20, using commits from full git history.
+
+## 2026-05-20
+
+### Added
+- feat: initial README with bounty board (`1aeae2a`)
+
+### Fixed
+- No entries.
+
+### Changed
+- Initial commit (`a80a580`)
+
+### Removed
+- No entries.

--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,25 @@
+# Generate Changelog Skill
+
+Generate a structured `CHANGELOG.md` from git history since the latest tag.
+
+## Setup and Usage
+
+1. Copy this repository's `changelog.sh` and `skills/generate-changelog/` directory into your project root.
+2. Run `bash changelog.sh` from the project root.
+3. Review the generated `CHANGELOG.md`, then commit it with your release changes.
+
+## Options
+
+```bash
+bash changelog.sh --repo /path/to/repo
+bash changelog.sh --since v1.2.3 --output RELEASE_NOTES.md
+```
+
+The generator uses the latest reachable git tag by default. If no tag exists, it includes the full history. Commit subjects are categorized as:
+
+- `Added`: feature and add-style commits
+- `Fixed`: bug fix commits
+- `Changed`: refactors, chores, docs, tests, builds, CI, and uncategorized work
+- `Removed`: remove, delete, drop, and deprecation commits
+
+See `samples/CHANGELOG.sample.md` for output captured from a real GitHub repository.

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when the user asks to create or refresh a `CHANGELOG.md` from a git repository.
+
+## Command
+
+Run this from the repository root:
+
+```bash
+bash changelog.sh
+```
+
+Optional flags:
+
+```bash
+bash changelog.sh --repo /path/to/repo --output CHANGELOG.md
+bash changelog.sh --since v1.2.3 --output RELEASE_NOTES.md
+```
+
+## Behavior
+
+- Reads commits after the latest reachable git tag.
+- If the repository has no tags, reads the full commit history.
+- Categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a complete Markdown changelog with the current date and source range.
+- Keeps commit subjects concise and links each entry to its short SHA.
+
+## Review Checklist
+
+1. Run the command from a real git repository.
+2. Inspect the generated categories for obvious misclassification.
+3. Commit the generated `CHANGELOG.md` only when it matches the release scope.

--- a/skills/generate-changelog/generate_changelog.py
+++ b/skills/generate-changelog/generate_changelog.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    body: str
+
+
+def run_git(repo: Path, *args: str, allow_failure: bool = False) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        if allow_failure:
+            return ""
+        raise SystemExit(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.rstrip("\r\n")
+
+
+def latest_tag(repo: Path) -> str | None:
+    tag = run_git(repo, "describe", "--tags", "--abbrev=0", allow_failure=True).strip()
+    return tag or None
+
+
+def read_commits(repo: Path, since: str | None) -> list[Commit]:
+    revision_range = f"{since}..HEAD" if since else "HEAD"
+    output = run_git(repo, "log", revision_range, "--pretty=format:%H%x1f%s%x1f%b%x1e", allow_failure=True)
+    commits: list[Commit] = []
+
+    for record in output.split("\x1e"):
+        record = record.strip("\r\n")
+        if not record:
+            continue
+        parts = record.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        commits.append(Commit(sha=parts[0], subject=parts[1].strip(), body=parts[2].strip()))
+
+    return commits
+
+
+def categorize(subject: str) -> str:
+    normalized = subject.strip().lower()
+    prefix = normalized.split(":", 1)[0].split("(", 1)[0]
+
+    if prefix in {"feat", "feature"} or normalized.startswith(("add ", "adds ", "added ")):
+        return "Added"
+    if prefix in {"fix", "bugfix", "hotfix"} or "fix" in normalized or "bug" in normalized:
+        return "Fixed"
+    if prefix in {"remove", "removed"} or normalized.startswith(("remove ", "delete ", "drop ", "deprecate ")):
+        return "Removed"
+    return "Changed"
+
+
+def render_changelog(repo: Path, commits: list[Commit], since: str | None) -> str:
+    today = dt.date.today().isoformat()
+    repo_name = repo.resolve().name
+    range_label = f"since `{since}`" if since else "from full git history"
+    grouped = {category: [] for category in CATEGORIES}
+
+    for commit in commits:
+        grouped[categorize(commit.subject)].append(commit)
+
+    lines = [
+        "# Changelog",
+        "",
+        f"Generated for `{repo_name}` on {today}, using commits {range_label}.",
+        "",
+        f"## {today}",
+        "",
+    ]
+
+    if not commits:
+        lines.extend(["No commits found for this range.", ""])
+        return "\n".join(lines)
+
+    for category in CATEGORIES:
+        lines.append(f"### {category}")
+        if grouped[category]:
+            for commit in grouped[category]:
+                lines.append(f"- {commit.subject} (`{commit.sha[:7]}`)")
+        else:
+            lines.append("- No entries.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git history.")
+    parser.add_argument("--repo", default=".", help="Path to the git repository. Defaults to current directory.")
+    parser.add_argument("--output", default="CHANGELOG.md", help="Output Markdown path. Defaults to CHANGELOG.md.")
+    parser.add_argument("--since", default=None, help="Git tag or revision to use instead of the latest tag.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    repo = Path(args.repo).resolve()
+
+    if not (repo / ".git").exists():
+        raise SystemExit(f"{repo} is not a git repository")
+
+    since = args.since or latest_tag(repo)
+    commits = read_commits(repo, since)
+    changelog = render_changelog(repo, commits, since)
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = repo / output_path
+    output_path.write_text(changelog, encoding="utf-8")
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -1,0 +1,55 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = ROOT / "skills" / "generate-changelog" / "generate_changelog.py"
+
+
+class GenerateChangelogTest(unittest.TestCase):
+    def run_git(self, repo, *args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+    def commit_file(self, repo, name, content, message):
+        path = repo / name
+        path.write_text(content, encoding="utf-8")
+        self.run_git(repo, "add", name)
+        self.run_git(repo, "commit", "-m", message)
+
+    def test_generates_changelog_since_latest_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self.run_git(repo, "init")
+            self.run_git(repo, "config", "user.name", "Test User")
+            self.run_git(repo, "config", "user.email", "test@example.com")
+
+            self.commit_file(repo, "README.md", "initial\n", "chore: initial commit")
+            self.run_git(repo, "tag", "v1.0.0")
+            self.commit_file(repo, "feature.txt", "feature\n", "feat: add dashboard")
+            self.commit_file(repo, "bug.txt", "bug\n", "fix: repair login redirect")
+            self.commit_file(repo, "old.txt", "removed\n", "remove deprecated route")
+
+            output = repo / "CHANGELOG.md"
+            subprocess.run(
+                [sys.executable, str(GENERATOR), "--repo", str(repo), "--output", str(output)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            changelog = output.read_text(encoding="utf-8")
+            self.assertIn("using commits since `v1.0.0`", changelog)
+            self.assertIn("### Added", changelog)
+            self.assertIn("feat: add dashboard", changelog)
+            self.assertIn("### Fixed", changelog)
+            self.assertIn("fix: repair login redirect", changelog)
+            self.assertIn("### Removed", changelog)
+            self.assertIn("remove deprecated route", changelog)
+            self.assertNotIn("chore: initial commit", changelog)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Claude Code generate-changelog skill and root `changelog.sh` entrypoint
- generate `CHANGELOG.md` from commits since the latest git tag, grouped into Added / Fixed / Changed / Removed
- include a 3-step README, real-repo sample output, and regression test coverage

Closes #1.
/claim #1

## Verification
- python -m unittest tests/test_generate_changelog.py
- bash changelog.sh --output samples/CHANGELOG.sample.md
- bash changelog.sh --output CHANGELOG.generated.md