### PR TITLE
Add Claude PR review agent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+agents/pr-review-agent/bin/claude-review text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/agents/pr-review-agent/README.md
+++ b/agents/pr-review-agent/README.md
@@ -6,37 +6,49 @@ The Claude Code sub-agent prompt lives in `claude-code-subagent.md`.
 
 ## Quick Start
 
-1. Run a review:
+1. Add the CLI to your PATH:
 
 ```bash
-agents/pr-review-agent/bin/claude-review --pr https://github.com/owner/repo/pull/123
+export PATH="$PWD/agents/pr-review-agent/bin:$PATH"
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:Path = "$(Resolve-Path agents\pr-review-agent\bin);$env:Path"
+```
+
+2. Run a review:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123
 ```
 
 On Windows PowerShell, use:
 
 ```powershell
-agents\pr-review-agent\bin\claude-review.cmd --pr https://github.com/owner/repo/pull/123
+claude-review --pr https://github.com/owner/repo/pull/123
 ```
 
-2. Or review a local diff without network access:
+3. Or review a local diff without network access:
 
 ```bash
 python agents/pr-review-agent/claude_review.py --diff-file path/to/change.diff
 ```
 
-3. Save Markdown output:
+4. Save Markdown output:
 
 ```bash
 python agents/pr-review-agent/claude_review.py --pr https://github.com/owner/repo/pull/123 --save review.md
 ```
 
-4. Post the review as a PR comment:
+5. Post the review as a PR comment:
 
 ```bash
 GITHUB_TOKEN=ghp_xxx agents/pr-review-agent/bin/claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
 ```
 
-5. Run tests:
+6. Run tests:
 
 ```bash
 python -m unittest tests/test_pr_review_agent.py

--- a/agents/pr-review-agent/README.md
+++ b/agents/pr-review-agent/README.md
@@ -1,0 +1,66 @@
+# Claude PR Review Agent
+
+Dependency-free CLI agent for bounty issue #4. It reads a GitHub pull request diff, analyzes the changed files, and emits a structured Markdown review comment with summary, risks, suggestions, and a Low/Medium/High confidence score.
+
+The Claude Code sub-agent prompt lives in `claude-code-subagent.md`.
+
+## Quick Start
+
+1. Run a review:
+
+```bash
+agents/pr-review-agent/bin/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+On Windows PowerShell, use:
+
+```powershell
+agents\pr-review-agent\bin\claude-review.cmd --pr https://github.com/owner/repo/pull/123
+```
+
+2. Or review a local diff without network access:
+
+```bash
+python agents/pr-review-agent/claude_review.py --diff-file path/to/change.diff
+```
+
+3. Save Markdown output:
+
+```bash
+python agents/pr-review-agent/claude_review.py --pr https://github.com/owner/repo/pull/123 --save review.md
+```
+
+4. Post the review as a PR comment:
+
+```bash
+GITHUB_TOKEN=ghp_xxx agents/pr-review-agent/bin/claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+5. Run tests:
+
+```bash
+python -m unittest tests/test_pr_review_agent.py
+```
+
+## Output Contract
+
+The Markdown output always includes:
+
+- `Summary of Changes`: 2-3 concise sentences as bullet points.
+- `Identified Risks`: risk list based on diff shape, sensitive paths, missing tests, config changes, and change size.
+- `Improvement Suggestions`: focused reviewer guidance.
+- `Confidence`: `Low`, `Medium`, or `High`.
+
+## Real PR Test Outputs
+
+Included sample outputs:
+
+- `sample-outputs/requestly-4718.md` from `https://github.com/requestly/requestly/pull/4718`
+- `sample-outputs/claude-builders-bounty-1802.md` from `https://github.com/claude-builders-bounty/claude-builders-bounty/pull/1802`
+
+## Notes
+
+- The agent uses only the Python standard library.
+- Public PRs can be reviewed without a token because GitHub exposes `.diff` URLs.
+- Posting a comment requires `GITHUB_TOKEN` with permission to comment on the target repository.
+- The heuristics are deterministic. They are meant to give Claude Code or a human reviewer a clean first-pass review comment, not to replace maintainer review.

--- a/agents/pr-review-agent/bin/claude-review
+++ b/agents/pr-review-agent/bin/claude-review
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/../claude_review.py" "$@"

--- a/agents/pr-review-agent/bin/claude-review.cmd
+++ b/agents/pr-review-agent/bin/claude-review.cmd
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0\..\claude_review.py" %*

--- a/agents/pr-review-agent/claude-code-subagent.md
+++ b/agents/pr-review-agent/claude-code-subagent.md
@@ -1,0 +1,28 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request diff and produce a structured Markdown comment.
+tools: Bash, Read, WebFetch
+---
+
+You are a focused pull request review sub-agent.
+
+Given a GitHub PR URL, run the local review CLI:
+
+```bash
+agents/pr-review-agent/bin/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Use the generated Markdown as the first-pass review comment. Before posting it, check that the comment includes:
+
+- Summary of Changes
+- Identified Risks
+- Improvement Suggestions
+- Confidence
+
+If the user asks you to post the result, use:
+
+```bash
+GITHUB_TOKEN=... agents/pr-review-agent/bin/claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+Do not invent findings. If the diff shape is too small or too broad to support a strong claim, lower the confidence score and ask for targeted manual review.

--- a/agents/pr-review-agent/claude_review.py
+++ b/agents/pr-review-agent/claude_review.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Deterministic PR review agent for Claude Code bounty #4.
+
+The tool fetches or reads a GitHub PR diff and emits a structured Markdown
+review comment. It is intentionally dependency-free so it can run inside a
+fresh Claude Code workspace without package setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)/?$"
+)
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+    url: str
+
+    @property
+    def api_base(self) -> str:
+        return f"https://api.github.com/repos/{self.owner}/{self.repo}"
+
+    @property
+    def diff_url(self) -> str:
+        return f"{self.url}.diff"
+
+    @property
+    def comments_url(self) -> str:
+        return f"{self.api_base}/issues/{self.number}/comments"
+
+
+@dataclass
+class FileChange:
+    path: str
+    additions: int = 0
+    deletions: int = 0
+    hunks: int = 0
+
+    @property
+    def extension(self) -> str:
+        return Path(self.path).suffix.lower() or "[none]"
+
+    @property
+    def area(self) -> str:
+        parts = Path(self.path).parts
+        return parts[0] if len(parts) > 1 else "."
+
+    @property
+    def is_test(self) -> bool:
+        lowered = self.path.lower()
+        return any(token in lowered for token in ("test", "spec", "__tests__"))
+
+    @property
+    def is_doc(self) -> bool:
+        lowered = self.path.lower()
+        return lowered.endswith((".md", ".rst", ".txt")) or "/docs/" in lowered
+
+    @property
+    def is_config(self) -> bool:
+        lowered = self.path.lower()
+        names = (
+            "package.json",
+            "requirements.txt",
+            "pyproject.toml",
+            "cargo.toml",
+            "go.mod",
+            "dockerfile",
+            ".github/workflows/",
+        )
+        return any(name in lowered for name in names)
+
+    @property
+    def is_sensitive(self) -> bool:
+        lowered = self.path.lower()
+        markers = (
+            "auth",
+            "login",
+            "permission",
+            "security",
+            "payment",
+            "billing",
+            "stripe",
+            "migration",
+            "schema",
+            "database",
+            "secret",
+            ".env",
+        )
+        return any(marker in lowered for marker in markers)
+
+
+@dataclass
+class Review:
+    pr: PullRequestRef | None
+    files: list[FileChange]
+    summary: list[str]
+    risks: list[str]
+    suggestions: list[str]
+    confidence: str
+
+    def to_markdown(self) -> str:
+        pr_line = self.pr.url if self.pr else "local diff input"
+        lines = [
+            "## Claude PR Review",
+            "",
+            f"**PR:** {pr_line}",
+            "",
+            "### Summary of Changes",
+        ]
+        lines.extend(f"- {item}" for item in self.summary)
+        lines.extend(["", "### Identified Risks"])
+        lines.extend(f"- {item}" for item in self.risks)
+        lines.extend(["", "### Improvement Suggestions"])
+        lines.extend(f"- {item}" for item in self.suggestions)
+        lines.extend(["", "### Confidence", self.confidence])
+        return "\n".join(lines) + "\n"
+
+    def to_json(self) -> str:
+        payload = {
+            "pr": self.pr.url if self.pr else None,
+            "files": [
+                {
+                    "path": change.path,
+                    "additions": change.additions,
+                    "deletions": change.deletions,
+                    "hunks": change.hunks,
+                }
+                for change in self.files
+            ],
+            "summary": self.summary,
+            "risks": self.risks,
+            "suggestions": self.suggestions,
+            "confidence": self.confidence,
+        }
+        return json.dumps(payload, indent=2)
+
+
+def parse_pr_url(raw_url: str) -> PullRequestRef:
+    match = PR_URL_RE.match(raw_url.strip())
+    if not match:
+        raise ValueError("Expected a GitHub PR URL like https://github.com/owner/repo/pull/123")
+    owner = match.group("owner")
+    repo = match.group("repo")
+    number = int(match.group("number"))
+    return PullRequestRef(owner=owner, repo=repo, number=number, url=raw_url.rstrip("/"))
+
+
+def http_request(url: str, *, method: str = "GET", body: bytes | None = None, token: str | None = None) -> str:
+    headers = {
+        "Accept": "application/vnd.github+json, text/plain",
+        "User-Agent": "claude-review-agent",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub request failed with HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"GitHub request failed: {exc.reason}") from exc
+
+
+def fetch_diff(pr: PullRequestRef) -> str:
+    return http_request(pr.diff_url)
+
+
+def parse_diff(diff_text: str) -> list[FileChange]:
+    files: list[FileChange] = []
+    current: FileChange | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            path = line.split(" b/", 1)[-1] if " b/" in line else line.rsplit(" ", 1)[-1]
+            current = FileChange(path=path.strip())
+            files.append(current)
+            continue
+        if current is None:
+            continue
+        if line.startswith("+++ b/"):
+            current.path = line[6:].strip()
+        elif line.startswith("@@"):
+            current.hunks += 1
+        elif line.startswith("+") and not line.startswith("+++"):
+            current.additions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            current.deletions += 1
+
+    return files
+
+
+def summarize_areas(files: Iterable[FileChange]) -> str:
+    counts: dict[str, int] = {}
+    for change in files:
+        counts[change.area] = counts.get(change.area, 0) + 1
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return ", ".join(f"{area} ({count})" for area, count in ranked[:5]) or "none"
+
+
+def build_review(diff_text: str, pr: PullRequestRef | None = None) -> Review:
+    files = parse_diff(diff_text)
+    total_additions = sum(change.additions for change in files)
+    total_deletions = sum(change.deletions for change in files)
+    total_hunks = sum(change.hunks for change in files)
+    test_files = [change for change in files if change.is_test]
+    doc_files = [change for change in files if change.is_doc]
+    config_files = [change for change in files if change.is_config]
+    sensitive_files = [change for change in files if change.is_sensitive]
+
+    summary = [
+        (
+            f"This PR changes {len(files)} file(s), with +{total_additions}/-{total_deletions} "
+            f"across {total_hunks} diff hunk(s)."
+        ),
+        f"The largest touched areas are: {summarize_areas(files)}.",
+    ]
+    if test_files or doc_files:
+        summary.append(
+            f"It includes {len(test_files)} test-related file(s) and {len(doc_files)} documentation file(s)."
+        )
+    else:
+        summary.append("No test or documentation files are visible in the diff.")
+
+    risks: list[str] = []
+    if not files:
+        risks.append("The diff is empty or could not be parsed, so the review has low signal.")
+    if not test_files:
+        risks.append("No test file changed; behavior could regress without automated coverage.")
+    if sensitive_files:
+        paths = ", ".join(change.path for change in sensitive_files[:4])
+        risks.append(f"Sensitive areas are touched ({paths}); verify permissions, data flow, and rollback safety.")
+    if config_files:
+        paths = ", ".join(change.path for change in config_files[:4])
+        risks.append(f"Configuration or dependency files changed ({paths}); confirm install and CI behavior.")
+    if total_additions + total_deletions > 600 or len(files) > 20:
+        risks.append("The change is broad enough that local smoke testing and reviewer sampling are important.")
+    if total_deletions > total_additions and total_deletions > 50:
+        risks.append("The PR removes more code than it adds; check for deleted edge-case handling or docs.")
+    if not risks:
+        risks.append("No obvious high-risk pattern is visible from the diff shape alone.")
+
+    suggestions: list[str] = []
+    if not test_files:
+        suggestions.append("Add or point reviewers to a focused regression test for the changed behavior.")
+    if sensitive_files:
+        suggestions.append("Document the security, migration, or payment path that was manually verified.")
+    if config_files:
+        suggestions.append("Include the exact build or install command used after the configuration change.")
+    suggestions.append("Ask reviewers to focus on the files with the largest hunk counts first.")
+    suggestions.append("Include screenshots or command output when the PR affects user-visible behavior.")
+
+    score = 2
+    if files and test_files:
+        score += 1
+    if len(files) <= 8 and total_additions + total_deletions <= 300:
+        score += 1
+    if sensitive_files or config_files:
+        score -= 1
+    if total_additions + total_deletions > 800 or len(files) > 25:
+        score -= 1
+    if not files:
+        score = 0
+
+    confidence = "High" if score >= 4 else "Medium" if score >= 2 else "Low"
+    return Review(
+        pr=pr,
+        files=files,
+        summary=summary,
+        risks=risks,
+        suggestions=suggestions,
+        confidence=confidence,
+    )
+
+
+def post_comment(pr: PullRequestRef, markdown: str, token: str) -> str:
+    body = json.dumps({"body": markdown}).encode("utf-8")
+    response = http_request(pr.comments_url, method="POST", body=body, token=token)
+    data = json.loads(response)
+    return data.get("html_url", pr.url)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Review a GitHub PR diff and emit a structured Markdown comment.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--pr", help="GitHub pull request URL, e.g. https://github.com/owner/repo/pull/123")
+    source.add_argument("--diff-file", help="Local diff file to review")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Output format")
+    parser.add_argument("--save", help="Write the generated output to this path")
+    parser.add_argument(
+        "--post-comment",
+        action="store_true",
+        help="Post the Markdown review as a GitHub PR comment using GITHUB_TOKEN",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    pr: PullRequestRef | None = None
+    if args.pr:
+        pr = parse_pr_url(args.pr)
+        diff_text = fetch_diff(pr)
+    else:
+        diff_text = Path(args.diff_file).read_text(encoding="utf-8")
+
+    review = build_review(diff_text, pr)
+    output = review.to_markdown() if args.format == "markdown" else review.to_json()
+
+    if args.save:
+        Path(args.save).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.save).write_text(output, encoding="utf-8")
+
+    if args.post_comment:
+        if args.format != "markdown":
+            raise SystemExit("--post-comment requires --format markdown")
+        if pr is None:
+            raise SystemExit("--post-comment requires --pr")
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            raise SystemExit("GITHUB_TOKEN is required for --post-comment")
+        url = post_comment(pr, output, token)
+        print(f"Posted review comment: {url}", file=sys.stderr)
+
+    print(output, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-review-agent/sample-outputs/claude-builders-bounty-1802.md
+++ b/agents/pr-review-agent/sample-outputs/claude-builders-bounty-1802.md
@@ -1,0 +1,18 @@
+## Claude PR Review
+
+**PR:** https://github.com/claude-builders-bounty/claude-builders-bounty/pull/1802
+
+### Summary of Changes
+- This PR changes 4 file(s), with +418/-0 across 4 diff hunk(s).
+- The largest touched areas are: templates (2), . (1), tests (1).
+- It includes 1 test-related file(s) and 2 documentation file(s).
+
+### Identified Risks
+- No obvious high-risk pattern is visible from the diff shape alone.
+
+### Improvement Suggestions
+- Ask reviewers to focus on the files with the largest hunk counts first.
+- Include screenshots or command output when the PR affects user-visible behavior.
+
+### Confidence
+Medium

--- a/agents/pr-review-agent/sample-outputs/requestly-4718.md
+++ b/agents/pr-review-agent/sample-outputs/requestly-4718.md
@@ -1,0 +1,18 @@
+## Claude PR Review
+
+**PR:** https://github.com/requestly/requestly/pull/4718
+
+### Summary of Changes
+- This PR changes 3 file(s), with +99/-9 across 4 diff hunk(s).
+- The largest touched areas are: app (3).
+- It includes 1 test-related file(s) and 0 documentation file(s).
+
+### Identified Risks
+- No obvious high-risk pattern is visible from the diff shape alone.
+
+### Improvement Suggestions
+- Ask reviewers to focus on the files with the largest hunk counts first.
+- Include screenshots or command output when the PR affects user-visible behavior.
+
+### Confidence
+High

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -1,0 +1,73 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "agents" / "pr-review-agent" / "claude_review.py"
+SPEC = importlib.util.spec_from_file_location("claude_review", MODULE_PATH)
+claude_review = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = claude_review
+SPEC.loader.exec_module(claude_review)
+
+
+SAMPLE_DIFF = """diff --git a/app/auth/login.py b/app/auth/login.py
+index 1111111..2222222 100644
+--- a/app/auth/login.py
++++ b/app/auth/login.py
+@@ -1,3 +1,7 @@
+ def login(user):
+-    return user
++    if not user:
++        raise ValueError("user is required")
++    return {"id": user.id}
+diff --git a/tests/test_login.py b/tests/test_login.py
+index 3333333..4444444 100644
+--- a/tests/test_login.py
++++ b/tests/test_login.py
+@@ -0,0 +1,4 @@
++def test_login_requires_user():
++    with pytest.raises(ValueError):
++        login(None)
+"""
+
+
+class PrReviewAgentTests(unittest.TestCase):
+    def test_parse_pr_url(self):
+        parsed = claude_review.parse_pr_url("https://github.com/requestly/requestly/pull/4718")
+
+        self.assertEqual(parsed.owner, "requestly")
+        self.assertEqual(parsed.repo, "requestly")
+        self.assertEqual(parsed.number, 4718)
+        self.assertEqual(parsed.diff_url, "https://github.com/requestly/requestly/pull/4718.diff")
+
+    def test_parse_diff_counts_changed_files_and_lines(self):
+        files = claude_review.parse_diff(SAMPLE_DIFF)
+
+        self.assertEqual([change.path for change in files], ["app/auth/login.py", "tests/test_login.py"])
+        self.assertEqual(sum(change.additions for change in files), 6)
+        self.assertEqual(sum(change.deletions for change in files), 1)
+        self.assertTrue(files[0].is_sensitive)
+        self.assertTrue(files[1].is_test)
+
+    def test_review_markdown_contains_required_sections(self):
+        review = claude_review.build_review(SAMPLE_DIFF)
+        markdown = review.to_markdown()
+
+        self.assertIn("### Summary of Changes", markdown)
+        self.assertIn("### Identified Risks", markdown)
+        self.assertIn("### Improvement Suggestions", markdown)
+        self.assertIn("### Confidence", markdown)
+        self.assertRegex(markdown, r"\b(Low|Medium|High)\b")
+
+    def test_no_tests_diff_reports_test_risk(self):
+        diff = SAMPLE_DIFF.split("diff --git a/tests/test_login.py", 1)[0]
+        review = claude_review.build_review(diff)
+
+        self.assertTrue(any("No test file changed" in risk for risk in review.risks))
+        self.assertTrue(any("regression test" in suggestion for suggestion in review.suggestions))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4.

/claim #4

## Summary
- Adds a dependency-free Python CLI PR review agent with `claude-review --pr <url>` support.
- Adds optional GitHub comment posting via `--post-comment`, plus Unix and Windows launcher scripts.
- Includes a Claude Code sub-agent prompt, README setup instructions, regression tests, and two real PR sample outputs.

## Verification
- `python -m unittest tests/test_pr_review_agent.py`
- `agents\pr-review-agent\bin\claude-review.cmd --pr https://github.com/requestly/requestly/pull/4718 --format json`
- Generated sample outputs for requestly/requestly#4718 and claude-builders-bounty/claude-builders-bounty#1802.

## Notes
- Public PR review works without a token via GitHub `.diff` URLs.
- Posting a comment requires `GITHUB_TOKEN`, documented in the README.