### PR TITLE
feat: add destructive command guard hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,29 @@
+# Destructive Command Guard
+
+Claude Code `pre-tool-use` hook that blocks dangerous bash commands before they run.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/destructive-command-guard.py ~/.claude/hooks/destructive-command-guard.py
+chmod +x ~/.claude/hooks/destructive-command-guard.py
+```
+
+Then register `~/.claude/hooks/destructive-command-guard.py` as a `pre-tool-use` hook in your Claude Code hook settings.
+
+## What it blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM ...` without a `WHERE` clause
+
+Each blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSONL with:
+
+- timestamp
+- attempted command
+- project path
+- reason
+
+Normal bash commands exit successfully and are not logged.

--- a/hooks/destructive-command-guard.py
+++ b/hooks/destructive-command-guard.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Claude Code pre-tool-use hook that blocks destructive bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+BLOCK_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "recursive force delete",
+        re.compile(r"(^|[;&|`$()\n])\s*rm\s+[^\n;&|]*-[^\n;&|]*r[^\n;&|]*f|(^|[;&|`$()\n])\s*rm\s+[^\n;&|]*-[^\n;&|]*f[^\n;&|]*r", re.IGNORECASE),
+        "rm -rf can irreversibly delete files. Ask the user before running destructive deletes.",
+    ),
+    (
+        "drop table",
+        re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE),
+        "DROP TABLE can destroy database schema/data. Require explicit human approval.",
+    ),
+    (
+        "force push",
+        re.compile(r"\bgit\s+push\b[^\n;&|]*(--force|-f|--force-with-lease)\b", re.IGNORECASE),
+        "Force-pushing can rewrite shared history. Require explicit human approval.",
+    ),
+    (
+        "truncate",
+        re.compile(r"\bTRUNCATE\b", re.IGNORECASE),
+        "TRUNCATE can delete all rows from a table. Require explicit human approval.",
+    ),
+    (
+        "delete without where",
+        re.compile(r"\bDELETE\s+FROM\s+[\w.\"`]+(?![^;\n]*\bWHERE\b)", re.IGNORECASE),
+        "DELETE FROM without a WHERE clause can remove every row. Add a WHERE clause or ask the user.",
+    ),
+]
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+        return payload if isinstance(payload, dict) else {}
+    except json.JSONDecodeError:
+        return {"raw_input": raw}
+
+
+def find_command(value: Any) -> str:
+    """Find the bash command across common Claude Code hook payload shapes."""
+    if isinstance(value, dict):
+        for key in ("command", "cmd", "bash_command", "input"):
+            item = value.get(key)
+            if isinstance(item, str) and item.strip():
+                return item
+        for key in ("tool_input", "toolUse", "tool_use", "parameters", "args"):
+            command = find_command(value.get(key))
+            if command:
+                return command
+        for item in value.values():
+            command = find_command(item)
+            if command:
+                return command
+    elif isinstance(value, list):
+        for item in value:
+            command = find_command(item)
+            if command:
+                return command
+    elif isinstance(value, str):
+        return value
+    return ""
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "workspace", "root", "repo_path"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return os.getcwd()
+
+
+def blocked_reason(command: str) -> str | None:
+    for _name, pattern, message in BLOCK_RULES:
+        if pattern.search(command):
+            return message
+    return None
+
+
+def log_block(command: str, path: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_path": path,
+        "attempted_command": command,
+        "reason": reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    payload = load_payload()
+    command = find_command(payload)
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    path = project_path(payload)
+    log_block(command, path, reason)
+    print(
+        "Blocked by destructive-command-guard: "
+        f"{reason}\nCommand: {command}\nProject: {path}",
+        file=sys.stderr,
+    )
+    # Claude Code treats a non-zero pre-tool-use hook as a blocked tool call.
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-guard.py
+++ b/hooks/destructive-command-guard.py
@@ -26,7 +26,10 @@ BLOCK_RULES: list[tuple[str, re.Pattern[str], str]] = [
     ),
     (
         "force push",
-        re.compile(r"\bgit\s+push\b[^\n;&|]*(--force|-f|--force-with-lease)\b", re.IGNORECASE),
+        re.compile(
+            r"\bgit\s+push\b(?=[^\n;&|]*\s(?:--force|-f|--force-with-lease)(?:\s|$))",
+            re.IGNORECASE,
+        ),
         "Force-pushing can rewrite shared history. Require explicit human approval.",
     ),
     (

--- a/hooks/test_destructive_command_guard.py
+++ b/hooks/test_destructive_command_guard.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+SCRIPT = Path(__file__).with_name("destructive-command-guard.py")
+spec = importlib.util.spec_from_file_location("guard", SCRIPT)
+assert spec is not None
+assert spec.loader is not None
+guard = cast(Any, importlib.util.module_from_spec(spec))
+spec.loader.exec_module(guard)
+
+
+class DestructiveCommandGuardTest(unittest.TestCase):
+    def test_blocks_required_patterns(self):
+        commands = [
+            "rm -rf build",
+            "psql -c 'DROP TABLE users'",
+            "git push --force origin main",
+            "git push -f origin main",
+            "git push --force-with-lease origin main",
+            "TRUNCATE audit_log",
+            "DELETE FROM users",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIsNotNone(guard.blocked_reason(command))
+
+    def test_allows_normal_commands_and_safe_delete(self):
+        commands = [
+            "git status",
+            "rm -r build",
+            "git push origin main",
+            "SELECT * FROM users",
+            "DELETE FROM users WHERE id = 1",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIsNone(guard.blocked_reason(command))
+
+    def test_extracts_command_from_common_hook_payloads(self):
+        payloads = [
+            {"tool_input": {"command": "git status"}},
+            {"toolUse": {"input": {"command": "rm -rf /tmp/x"}}},
+            {"parameters": {"cmd": "TRUNCATE logs"}},
+        ]
+        self.assertEqual(
+            [guard.find_command(payload) for payload in payloads],
+            ["git status", "rm -rf /tmp/x", "TRUNCATE logs"],
+        )
+
+    def test_log_block_writes_jsonl(self):
+        with tempfile.TemporaryDirectory() as directory:
+            old_log_path = guard.LOG_PATH
+            guard.LOG_PATH = Path(directory) / "blocked.log"
+            try:
+                guard.log_block("rm -rf build", "/repo", "danger")
+                entry = json.loads(guard.LOG_PATH.read_text().strip())
+            finally:
+                guard.LOG_PATH = old_log_path
+        self.assertEqual(entry["attempted_command"], "rm -rf build")
+        self.assertEqual(entry["project_path"], "/repo")
+        self.assertEqual(entry["reason"], "danger")
+        self.assertIn("timestamp", entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/test_destructive_command_guard.py
+++ b/hooks/test_destructive_command_guard.py
@@ -33,6 +33,7 @@ class DestructiveCommandGuardTest(unittest.TestCase):
             "git status",
             "rm -r build",
             "git push origin main",
+            "git push origin feature/fix-login",
             "SELECT * FROM users",
             "DELETE FROM users WHERE id = 1",
         ]


### PR DESCRIPTION
## What changed
- Added a Claude Code pre-tool-use hook that blocks destructive bash commands before execution.
- Blocks the required patterns: `rm -rf`, `DROP TABLE`, `git push --force` / `-f` / `--force-with-lease`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause.
- Logs blocked attempts as JSONL to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
- Added a short README with a two-command install flow.
- Added local unit tests for block/allow behavior, command extraction, and log writing.

## Validation
- `python3 -m unittest hooks/test_destructive_command_guard.py -v`
- Manual blocked-command check: `rm -rf build` exits with code `2` and prints a clear block reason.
- Manual normal-command check: `git status` exits successfully.
- `git diff --cached --check`

Closes #3