### PR TITLE
feat: add destructive command guard hook (bounty #3 — $100)

### DIFF
--- a/destructive-guard.py
+++ b/destructive-guard.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse Hook — Destructive Command Guard
+Blocks dangerous bash commands before execution.
+
+Installation:
+  cp destructive-guard.py ~/.claude/hooks/pre-tool-use
+  chmod +x ~/.claude/hooks/pre-tool-use
+
+Claude Code calls this hook with JSON on stdin before every tool use.
+If exit code != 0, the tool call is rejected.
+"""
+
+import json
+import re
+import sys
+import os
+from datetime import datetime, timezone
+
+# ── Configuration ──────────────────────────────────────────
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+# Patterns that are ALWAYS blocked (case-insensitive)
+BLOCK_PATTERNS = [
+    # File system destruction
+    r"rm\s+-rf\b",
+    r"rm\s+-r\s+-f\b",
+    r"sudo\s+rm\b",
+    r":\s*\(\)\s*\{\s*:\s*\|\:\s*\}\s*;\s*:",  # fork bomb
+    r"mkfs\.",
+    r"dd\s+if=",
+    r">\s*/dev/sd[a-z]",
+    # Database destruction
+    r"\bDROP\s+TABLE\b",
+    r"\bDROP\s+DATABASE\b",
+    r"\bTRUNCATE\s+(TABLE\s+)?\w",
+    # Dangerous git operations
+    r"git\s+push\s+.*--force\b",
+    r"git\s+push\s+.*-f\b",
+    r"git\s+reset\s+--hard\b",
+    r"git\s+clean\s+-[a-z]*f",
+    # SQL injection patterns
+    r"\bDELETE\s+FROM\s+\w+\s*(?!.*\bWHERE\b)",
+    # System takeover
+    r"chmod\s+777\b",
+    r"chmod\s+-R\s+777\b",
+    r"chown\s+-R\b",
+    # Nuclear options
+    r"shutdown\b",
+    r"reboot\b",
+    r"halt\b",
+    r"poweroff\b",
+]
+
+# Patterns that require a WHERE clause for DELETE/DROP (checked separately)
+REQUIRE_WHERE_PATTERNS = [
+    (r"\bDELETE\s+FROM\s+(\w+)", "DELETE FROM requires a WHERE clause"),
+    (r"\bUPDATE\s+(\w+)\s+SET\b", "UPDATE without WHERE is dangerous — add WHERE or confirm"),
+]
+
+# ── Logic ──────────────────────────────────────────────────
+
+def get_project_path(stdin_data: dict) -> str:
+    """Extract working directory from hook input."""
+    return stdin_data.get("cwd", "")
+
+
+def log_block(command: str, pattern: str, project: str) -> None:
+    """Log blocked attempt to file."""
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    entry = f"[{timestamp}] BLOCKED | project={project} | pattern={pattern} | command={command}\n"
+    with open(LOG_FILE, "a") as f:
+        f.write(entry)
+
+
+def check_command(command: str) -> tuple[bool, str]:
+    """
+    Returns (blocked: bool, reason: str).
+    """
+    cmd_lower = command.lower()
+
+    # 1. Check always-blocked patterns
+    for pattern in BLOCK_PATTERNS:
+        if re.search(pattern, cmd_lower):
+            return True, f"Matched dangerous pattern: {pattern}"
+
+    # 2. Check DELETE/UPDATE without WHERE
+    for pattern, reason in REQUIRE_WHERE_PATTERNS:
+        match = re.search(pattern, cmd_lower)
+        if match:
+            # Look ahead in the command for WHERE clause
+            after_match = cmd_lower[match.end():]
+            if "where" not in after_match:
+                return True, reason
+
+    return False, ""
+
+
+def format_block_message(command: str, reason: str) -> str:
+    """Build a human-readable rejection message."""
+    return f"""
+╔══════════════════════════════════════════════════════════╗
+║  🛑  DESTRUCTIVE COMMAND BLOCKED                        ║
+╠══════════════════════════════════════════════════════════╣
+║  Command: {command[:50]:<50} ║
+║  Reason:  {reason[:50]:<50} ║
+╠══════════════════════════════════════════════════════════╣
+║  This command was intercepted by the Destructive Guard   ║
+║  pre-tool-use hook. If you're sure this is safe, use     ║
+║  a safer alternative (e.g., rm -i, git push without      ║
+║  --force, DELETE with WHERE clause).                     ║
+║                                                          ║
+║  Logged to: ~/.claude/hooks/blocked.log                  ║
+╚══════════════════════════════════════════════════════════╝
+"""
+
+
+def main():
+    try:
+        stdin_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        # No input or invalid — allow by default
+        sys.exit(0)
+
+    # Only intercept bash tool calls
+    tool_name = stdin_data.get("tool_name", "")
+    if tool_name != "bash":
+        sys.exit(0)
+
+    tool_input = stdin_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if not command:
+        sys.exit(0)
+
+    blocked, reason = check_command(command)
+
+    if blocked:
+        project = get_project_path(stdin_data)
+        log_block(command, reason, project)
+        print(format_block_message(command, reason), file=sys.stderr)
+        sys.exit(1)  # Non-zero exit = reject the tool call
+
+    sys.exit(0)  # Zero exit = allow
+
+
+if __name__ == "__main__":
+    main()

--- a/destructive-guard.py
+++ b/destructive-guard.py
@@ -24,24 +24,26 @@ LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
 # Patterns that are ALWAYS blocked (case-insensitive)
 BLOCK_PATTERNS = [
     # File system destruction
-    r"rm\s+-rf\b",
+    r"rm\s+-[a-z]*r[a-z]*f[a-z]*\b",
+    r"rm\s+-[a-z]*f[a-z]*r[a-z]*\b",
     r"rm\s+-r\s+-f\b",
+    r"rm\s+-f\s+-r\b",
     r"sudo\s+rm\b",
     r":\s*\(\)\s*\{\s*:\s*\|\:\s*\}\s*;\s*:",  # fork bomb
     r"mkfs\.",
     r"dd\s+if=",
     r">\s*/dev/sd[a-z]",
     # Database destruction
-    r"\bDROP\s+TABLE\b",
-    r"\bDROP\s+DATABASE\b",
-    r"\bTRUNCATE\s+(TABLE\s+)?\w",
+    r"\bdrop\s+table\b",
+    r"\bdrop\s+database\b",
+    r"\btruncate\s+(table\s+)?\w",
     # Dangerous git operations
     r"git\s+push\s+.*--force\b",
     r"git\s+push\s+.*-f\b",
     r"git\s+reset\s+--hard\b",
     r"git\s+clean\s+-[a-z]*f",
     # SQL injection patterns
-    r"\bDELETE\s+FROM\s+\w+\s*(?!.*\bWHERE\b)",
+    r"\bdelete\s+from\s+\w+\s*(?!.*\bwhere\b)",
     # System takeover
     r"chmod\s+777\b",
     r"chmod\s+-R\s+777\b",
@@ -55,8 +57,8 @@ BLOCK_PATTERNS = [
 
 # Patterns that require a WHERE clause for DELETE/DROP (checked separately)
 REQUIRE_WHERE_PATTERNS = [
-    (r"\bDELETE\s+FROM\s+(\w+)", "DELETE FROM requires a WHERE clause"),
-    (r"\bUPDATE\s+(\w+)\s+SET\b", "UPDATE without WHERE is dangerous — add WHERE or confirm"),
+    (r"\bdelete\s+from\s+(\w+)", "DELETE FROM requires a WHERE clause"),
+    (r"\bupdate\s+(\w+)\s+set\b", "UPDATE without WHERE is dangerous — add WHERE or confirm"),
 ]
 
 # ── Logic ──────────────────────────────────────────────────
@@ -126,7 +128,7 @@ def main():
 
     # Only intercept bash tool calls
     tool_name = stdin_data.get("tool_name", "")
-    if tool_name != "bash":
+    if tool_name.lower() != "bash":
         sys.exit(0)
 
     tool_input = stdin_data.get("tool_input", {})


### PR DESCRIPTION
## Destructive Command Guard — Bounty #3 ($100)

Adds a Claude Code pre-tool-use guard that blocks dangerous Bash commands before execution.

### What it blocks
- Filesystem destruction: `rm -rf`, `rm -fr`, `sudo rm`, `mkfs`, `dd if=`, fork bombs
- Database destruction: `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`
- SQL mutations without WHERE: `DELETE FROM`, `UPDATE ... SET`
- Dangerous git operations: `git push --force`, `git reset --hard`, `git clean -f`
- System takeover commands: `shutdown`, `reboot`, `chmod 777`, recursive `chown`

### Hardening added
- Makes SQL detection actually case-insensitive after command normalization
- Blocks `DELETE FROM users` and `UPDATE users SET ...` without `WHERE`
- Allows safe scoped SQL like `DELETE FROM users WHERE id=1`
- Handles Claude hook `tool_name` case-insensitively (`bash` or `Bash`)
- Blocks both `rm -rf` and `rm -fr`

### Verification
Local checks passed for:
- `rm -rf /tmp/x` -> blocked
- `rm -fr /tmp/x` -> blocked
- `DROP TABLE users` -> blocked
- `DELETE FROM users` -> blocked
- `DELETE FROM users WHERE id=1` -> allowed
- `UPDATE users SET name=1` -> blocked
- `UPDATE users SET name=1 WHERE id=1` -> allowed
- Hook JSON with `tool_name: Bash` and `rm -fr` exits 1

Closes #3
