### PR TITLE
Add changelog generator skill

### DIFF
--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,44 @@
+# Generate Changelog
+
+Small dependency-free changelog generator for Claude Code projects and regular Git repositories.
+
+It reads the current repository history, finds commits since the latest Git tag, groups them into `Added`, `Fixed`, `Changed`, and `Removed`, then writes a formatted `CHANGELOG.md`.
+
+## Setup
+
+1. Copy the `generate-changelog` folder into your project.
+2. Run `bash generate-changelog/changelog.sh` from the project root.
+3. Review and commit the generated `CHANGELOG.md`.
+
+## Usage
+
+```bash
+bash generate-changelog/changelog.sh
+```
+
+Optional flags:
+
+```bash
+python generate-changelog/generate_changelog.py --output CHANGELOG.md
+python generate-changelog/generate_changelog.py --since v1.2.0 --version v1.3.0
+python generate-changelog/generate_changelog.py --dry-run
+```
+
+## Categorization Rules
+
+- `Added`: `feat`, `add`, `new`, `introduce`
+- `Fixed`: `fix`, `bug`, `patch`, `repair`, `resolve`
+- `Changed`: `change`, `refactor`, `docs`, `chore`, `perf`, `style`, `test`, `build`, `ci`
+- `Removed`: `remove`, `delete`, `drop`, `deprecate`
+
+The matcher prefers Conventional Commit prefixes, then falls back to practical keywords in the subject line.
+
+## Git Range
+
+- If the repository has tags, the script uses commits after the latest tag.
+- If no tag exists, it uses all commits in the repository.
+- Merge commits are skipped to keep the changelog focused on user-facing work.
+
+## Sample Output
+
+See [sample-output.md](sample-output.md) for a generated example.

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -42,3 +42,10 @@ The matcher prefers Conventional Commit prefixes, then falls back to practical k
 ## Sample Output
 
 See [sample-output.md](sample-output.md) for a generated example.
+
+## Testing
+
+```bash
+python -m unittest generate-changelog/test_generate_changelog.py
+python -m py_compile generate-changelog/generate_changelog.py
+```

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "Python 3 is required to generate the changelog." >&2
+  exit 1
+fi
+
+"$PYTHON_BIN" "$SCRIPT_DIR/generate_changelog.py" "$@"

--- a/generate-changelog/generate_changelog.py
+++ b/generate-changelog/generate_changelog.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+
+KEYWORDS = {
+    "Added": ("feat", "add", "new", "introduce"),
+    "Fixed": ("fix", "bug", "patch", "repair", "resolve"),
+    "Changed": ("change", "refactor", "docs", "chore", "perf", "style", "test", "build", "ci"),
+    "Removed": ("remove", "delete", "drop", "deprecate"),
+}
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    body: str
+
+    @property
+    def short_sha(self) -> str:
+        return self.sha[:7]
+
+
+def run_git(repo: Path, *args: str, allow_failure: bool = False) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        if allow_failure:
+            return ""
+        message = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"git {' '.join(args)} failed: {message}")
+    return result.stdout.strip()
+
+
+def find_latest_tag(repo: Path) -> str | None:
+    tag = run_git(repo, "describe", "--tags", "--abbrev=0", allow_failure=True)
+    return tag or None
+
+
+def build_range(repo: Path, since: str | None) -> tuple[str, str]:
+    if since:
+        return f"{since}..HEAD", since
+
+    latest_tag = find_latest_tag(repo)
+    if latest_tag:
+        return f"{latest_tag}..HEAD", latest_tag
+
+    return "HEAD", "repository start"
+
+
+def get_commits(repo: Path, revision_range: str) -> list[Commit]:
+    raw = run_git(
+        repo,
+        "log",
+        "--no-merges",
+        "--format=%H%x1f%s%x1f%b%x1e",
+        revision_range,
+    )
+    commits: list[Commit] = []
+    for record in raw.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x1f")
+        if len(parts) < 2:
+            continue
+        sha = parts[0].strip()
+        subject = parts[1].strip()
+        body = parts[2].strip() if len(parts) > 2 else ""
+        if sha and subject:
+            commits.append(Commit(sha=sha, subject=subject, body=body))
+    return commits
+
+
+def clean_subject(subject: str) -> str:
+    subject = re.sub(r"^[a-zA-Z]+(?:\([^)]+\))?!?:\s*", "", subject).strip()
+    return subject[:1].upper() + subject[1:] if subject else subject
+
+
+def categorize(subject: str) -> str:
+    normalized = subject.lower().strip()
+    conventional_type = normalized.split(":", 1)[0]
+    conventional_type = conventional_type.split("(", 1)[0].rstrip("!")
+
+    for category, words in KEYWORDS.items():
+        if conventional_type in words:
+            return category
+
+    for category, words in KEYWORDS.items():
+        if any(re.search(rf"\b{re.escape(word)}\b", normalized) for word in words):
+            return category
+
+    return "Changed"
+
+
+def remote_compare_url(repo: Path, base_ref: str, head_ref: str = "HEAD") -> str | None:
+    remote = run_git(repo, "config", "--get", "remote.origin.url", allow_failure=True)
+    if not remote:
+        return None
+
+    match = re.match(r"(?:git@github\.com:|https://github\.com/)([^/]+/[^/.]+)(?:\.git)?", remote)
+    if not match:
+        return None
+
+    slug = match.group(1)
+    if base_ref == "repository start":
+        return f"https://github.com/{slug}/commits/{head_ref}"
+    return f"https://github.com/{slug}/compare/{base_ref}...{head_ref}"
+
+
+def render_changelog(repo: Path, commits: list[Commit], since_ref: str, version: str) -> str:
+    today = dt.date.today().isoformat()
+    grouped: dict[str, list[Commit]] = {category: [] for category in CATEGORIES}
+    for commit in commits:
+        grouped[categorize(commit.subject)].append(commit)
+
+    lines = [
+        "# Changelog",
+        "",
+        f"## {version} - {today}",
+        "",
+        f"_Generated from commits since {since_ref}._",
+    ]
+
+    compare_url = remote_compare_url(repo, since_ref)
+    if compare_url:
+        lines.extend(["", f"[Compare changes]({compare_url})"])
+
+    for category in CATEGORIES:
+        lines.extend(["", f"### {category}", ""])
+        if grouped[category]:
+            for commit in grouped[category]:
+                lines.append(f"- {clean_subject(commit.subject)} ({commit.short_sha})")
+        else:
+            lines.append("- No changes.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git history.")
+    parser.add_argument("--repo", default=".", help="Repository path. Defaults to current directory.")
+    parser.add_argument("--output", default="CHANGELOG.md", help="Output file path.")
+    parser.add_argument("--since", help="Git tag or ref to use as the changelog base.")
+    parser.add_argument("--version", default="Unreleased", help="Version heading for the generated section.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the changelog instead of writing it.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = Path(args.repo).resolve()
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = repo / output
+
+    try:
+        run_git(repo, "rev-parse", "--is-inside-work-tree")
+        revision_range, since_ref = build_range(repo, args.since)
+        commits = get_commits(repo, revision_range)
+        changelog = render_changelog(repo, commits, since_ref, args.version)
+    except RuntimeError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print(changelog)
+        return 0
+
+    output.write_text(changelog, encoding="utf-8")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/generate-changelog/sample-output.md
+++ b/generate-changelog/sample-output.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Unreleased - 2026-05-20
+
+_Generated from commits since v1.2.0._
+
+[Compare changes](https://github.com/example/app/compare/v1.2.0...HEAD)
+
+### Added
+
+- Add usage analytics export (a1b2c3d)
+
+### Fixed
+
+- Handle empty project names in settings form (b2c3d4e)
+
+### Changed
+
+- Refactor database seed command (c3d4e5f)
+- Document local development setup (d4e5f6a)
+
+### Removed
+
+- Remove deprecated billing flag (e5f6a7b)

--- a/generate-changelog/test_generate_changelog.py
+++ b/generate-changelog/test_generate_changelog.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Focused tests for the changelog generator."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("generate_changelog.py")
+SPEC = importlib.util.spec_from_file_location("generate_changelog", MODULE_PATH)
+assert SPEC and SPEC.loader
+generate_changelog = importlib.util.module_from_spec(SPEC)
+sys.modules["generate_changelog"] = generate_changelog
+SPEC.loader.exec_module(generate_changelog)
+
+
+class GenerateChangelogTests(unittest.TestCase):
+    def test_categorizes_conventional_commits(self) -> None:
+        cases = {
+            "feat(parser): support scopes": "Added",
+            "fix: handle empty git log": "Fixed",
+            "docs: update setup guide": "Changed",
+            "remove deprecated option": "Removed",
+        }
+
+        for subject, expected in cases.items():
+            with self.subTest(subject=subject):
+                self.assertEqual(generate_changelog.categorize(subject), expected)
+
+    def test_clean_subject_removes_conventional_prefix(self) -> None:
+        self.assertEqual(
+            generate_changelog.clean_subject("feat(cli): add dry run mode"),
+            "Add dry run mode",
+        )
+
+    def test_render_includes_sections_and_commit_entries(self) -> None:
+        commits = [
+            generate_changelog.Commit("abc123456789", "feat: add parser", ""),
+            generate_changelog.Commit("def987654321", "fix: handle empty logs", ""),
+            generate_changelog.Commit("987654321abc", "remove legacy flag", ""),
+        ]
+
+        output = generate_changelog.render_changelog(
+            repo=Path(__file__).resolve().parent,
+            commits=commits,
+            since_ref="v1.0.0",
+            version="v1.1.0",
+        )
+
+        self.assertIn(f"## v1.1.0 - {dt.date.today().isoformat()}", output)
+        self.assertIn("### Added", output)
+        self.assertIn("- Add parser (abc1234)", output)
+        self.assertIn("### Fixed", output)
+        self.assertIn("- Handle empty logs (def9876)", output)
+        self.assertIn("### Removed", output)
+        self.assertIn("- Remove legacy flag (9876543)", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a dependency-free changelog generator for bounty #1. The solution includes a Bash entrypoint, a Python implementation, setup docs, and sample output.

## Changes
- Added `generate-changelog/changelog.sh` as the requested Bash command entrypoint.
- Added `generate-changelog/generate_changelog.py` to collect commits since the latest tag and group them into Added, Fixed, Changed, and Removed.
- Added concise setup instructions and sample generated changelog output.

## Testing
- `python generate-changelog\generate_changelog.py --dry-run`
- `python generate-changelog\generate_changelog.py --output generate-changelog\CHANGELOG.test.md --version TestRun`
- `git diff --cached --check`
- `python -B -m py_compile generate-changelog\generate_changelog.py`
- `bash generate-changelog/changelog.sh --dry-run` could not run locally because Bash is not installed in this Windows environment; the Bash wrapper is POSIX-compatible and delegates to Python.

## Notes
Kept the change minimal and focused on the reported issue.

## Bounty
/opire try

