### PR TITLE
Add changelog generation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Generate Changelog Bounty Submission
+
+## Setup
+1. Copy `changelog.sh` into any git repo.
+2. Run `bash changelog.sh` from the repo root.
+3. Commit the generated `CHANGELOG.md`.
+
+## Notes
+- Uses commits since the latest git tag; if no tag exists, uses all history.
+- Categorizes commits into Added, Fixed, Changed, Removed.
+- See `examples/sample-output.md` for sample output.
 # Claude Builders Bounty 🤖
 
 > A community bounty board for Claude Code builders.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out="${1:-CHANGELOG.md}"
+latest_tag=""
+range=""
+
+if latest_tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+  range="${latest_tag}..HEAD"
+else
+  latest_tag="initial history"
+  range="HEAD"
+fi
+
+commit_lines="$(git log --no-merges --pretty=format:'%s' "$range")"
+
+category_for() {
+  local subject="$1"
+  local lower
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    fix:*|fix\(*|fixed:*|bug:*|bugfix:*|hotfix:*|*fix*|*bug*) printf 'Fixed' ;;
+    add:*|added:*|feat:*|feature:*|new:*|*add*|*implement*) printf 'Added' ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|*remove*|*delete*) printf 'Removed' ;;
+    change:*|changed:*|chore:*|refactor:*|update:*|docs:*|style:*|perf:*|test:*|*change*|*update*|*refactor*) printf 'Changed' ;;
+    *) printf 'Changed' ;;
+  esac
+}
+
+section_file() {
+  printf '%s/%s' "$tmpdir" "$1"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+for section in Added Fixed Changed Removed; do : > "$(section_file "$section")"; done
+
+if [ -n "$commit_lines" ]; then
+  while IFS= read -r subject; do
+    [ -z "$subject" ] && continue
+    category="$(category_for "$subject")"
+    printf -- '- %s\n' "$subject" >> "$(section_file "$category")"
+  done <<EOF_COMMITS
+$commit_lines
+EOF_COMMITS
+fi
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated from commits since `%s`.\n\n' "$latest_tag"
+  printf '## Unreleased\n\n'
+  for section in Added Fixed Changed Removed; do
+    printf '### %s\n' "$section"
+    if [ -s "$(section_file "$section")" ]; then
+      cat "$(section_file "$section")"
+    else
+      printf -- '- No changes.\n'
+    fi
+    printf '\n'
+  done
+} > "$out"
+
+printf 'Wrote %s using commits since %s\n' "$out" "$latest_tag"

--- a/examples/sample-output.md
+++ b/examples/sample-output.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Generated from commits since `v1.0.0`.
+
+## Unreleased
+
+### Added
+- feat: add webhook delivery retries
+
+### Fixed
+- fix: handle missing config file
+
+### Changed
+- docs: update installation steps
+
+### Removed
+- remove deprecated legacy flag

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git commits since the latest tag.
+---
+
+# Generate Changelog
+
+Run this from a git repo root:
+
+```bash
+bash changelog.sh
+```
+
+The script finds the latest git tag, reads non-merge commit subjects since that tag, categorizes them into `Added`, `Fixed`, `Changed`, and `Removed`, then writes `CHANGELOG.md`.


### PR DESCRIPTION
Closes #1.\n\nAdds `changelog.sh` plus a Claude Code skill wrapper for generating a structured `CHANGELOG.md` from commits since the latest git tag.\n\nVerification:\n- `bash changelog.sh /tmp/generated-changelog.md`\n- `bash -n changelog.sh`\n- `git diff --check`\n\nSample output is included in `examples/sample-output.md`.