### PR TITLE
HOOK: Block destructive Bash commands in Claude Code

### DIFF
--- a/.github/workflows/test-pre-tool-use-block-destructive.yml
+++ b/.github/workflows/test-pre-tool-use-block-destructive.yml
@@ -1,0 +1,25 @@
+name: Test destructive Bash hook
+
+on:
+  pull_request:
+    paths:
+      - "hooks/pre-tool-use-block-destructive/**"
+      - ".github/workflows/test-pre-tool-use-block-destructive.yml"
+  push:
+    paths:
+      - "hooks/pre-tool-use-block-destructive/**"
+      - ".github/workflows/test-pre-tool-use-block-destructive.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Run hook tests
+        run: |
+          PYTHONDONTWRITEBYTECODE=1 python -m unittest discover \
+            -s hooks/pre-tool-use-block-destructive \
+            -p 'test_*.py'

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -1,0 +1,30 @@
+# Block Destructive Bash Commands
+
+Claude Code `PreToolUse` hook that denies dangerous Bash commands before they run.
+
+## Installation
+
+```bash
+python3 install.py
+```
+
+The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bash `PreToolUse` hook to `~/.claude/settings.json`.
+
+## What It Blocks
+
+- `rm -rf` and `rm -fr`
+- `DROP TABLE`
+- `git push --force` and `git push -f`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with:
+
+- timestamp
+- attempted command
+- project path
+- block reason
+
+## Hook Behavior
+
+The hook reads Claude Code hook JSON from stdin. Non-Bash tool calls are allowed. Safe Bash commands return `continue: true`. Blocked commands return a `PreToolUse` `permissionDecision` of `deny` with a reason Claude can use to choose a safer command.

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -16,12 +16,15 @@ The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bas
 - `rm -Rf`, `rm -fR`, and `rm --recursive --force`
 - `DROP TABLE`, `DROP DATABASE`, `DROP SCHEMA`, `DROP INDEX`, `DROP VIEW`, `DROP FUNCTION`, and `DROP PROCEDURE`
 - `git push --force`, `git push -f`, and `git push --force-with-lease`
+- force-push bypasses such as `git push +main:main` and `git -c push.force=true push`
 - `git reset --hard` and destructive `git clean` variants such as `git clean -fdx`
 - `TRUNCATE`
 - `DELETE FROM` statements without a `WHERE` clause
 - `UPDATE ... SET` statements without a `WHERE` clause
 - `ALTER TABLE ... DROP`
-- direct block-device writes such as `mkfs`, `mkswap`, `dd ... of=/dev/sd*`, and redirects to `/dev/sd*`
+- direct block-device writes/wipes such as `mkfs`, `mkswap`, `wipefs`, `dd ... of=/dev/sd*`, and redirects to `/dev/sd*`
+- remote script execution through `curl|bash` or `wget|sh`
+- shell fork bombs
 - recursive permissive root-path permission changes such as `chmod -R 777 /...`
 
 Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with:

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -14,11 +14,14 @@ The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bas
 
 - `rm -rf` and `rm -fr`
 - `rm -Rf`, `rm -fR`, and `rm --recursive --force`
-- `DROP TABLE`, `DROP DATABASE`, and `DROP SCHEMA`
+- `DROP TABLE`, `DROP DATABASE`, `DROP SCHEMA`, `DROP INDEX`, `DROP VIEW`, `DROP FUNCTION`, and `DROP PROCEDURE`
 - `git push --force`, `git push -f`, and `git push --force-with-lease`
+- `git reset --hard` and destructive `git clean` variants such as `git clean -fdx`
 - `TRUNCATE`
 - `DELETE FROM` statements without a `WHERE` clause
-- direct block-device writes such as `mkfs`, `dd ... of=/dev/sd*`, and redirects to `/dev/sd*`
+- `UPDATE ... SET` statements without a `WHERE` clause
+- `ALTER TABLE ... DROP`
+- direct block-device writes such as `mkfs`, `mkswap`, `dd ... of=/dev/sd*`, and redirects to `/dev/sd*`
 - recursive permissive root-path permission changes such as `chmod -R 777 /...`
 
 Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with:

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -27,6 +27,8 @@ The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bas
 - shell fork bombs
 - recursive permissive root-path permission changes such as `chmod -R 777 /...`
 
+Read-only text inspection commands such as `grep`, `rg`, `cat`, `echo`, and `printf` are allowed to contain SQL-looking text unless the same command segment invokes a SQL client such as `psql`, `mysql`, or `sqlite3`.
+
 Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with:
 
 - timestamp

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -13,8 +13,9 @@ The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bas
 ## What It Blocks
 
 - `rm -rf` and `rm -fr`
-- `DROP TABLE`
-- `git push --force` and `git push -f`
+- `rm -Rf`, `rm -fR`, and `rm --recursive --force`
+- `DROP TABLE`, `DROP DATABASE`, and `DROP SCHEMA`
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
 - `TRUNCATE`
 - `DELETE FROM` statements without a `WHERE` clause
 

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -18,6 +18,8 @@ The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bas
 - `git push --force`, `git push -f`, and `git push --force-with-lease`
 - `TRUNCATE`
 - `DELETE FROM` statements without a `WHERE` clause
+- direct block-device writes such as `mkfs`, `dd ... of=/dev/sd*`, and redirects to `/dev/sd*`
+- recursive permissive root-path permission changes such as `chmod -R 777 /...`
 
 Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with:
 

--- a/hooks/pre-tool-use-block-destructive/README.md
+++ b/hooks/pre-tool-use-block-destructive/README.md
@@ -18,6 +18,8 @@ The installer copies `block_destructive.py` to `~/.claude/hooks/` and adds a Bas
 - `git push --force`, `git push -f`, and `git push --force-with-lease`
 - force-push bypasses such as `git push +main:main` and `git -c push.force=true push`
 - `git reset --hard` and destructive `git clean` variants such as `git clean -fdx`
+- destructive commands hidden behind shell wrappers such as `bash -c 'rm -rf build'`
+- broad `find` deletes such as `find / -delete` or `find $HOME -delete`
 - `TRUNCATE`
 - `DELETE FROM` statements without a `WHERE` clause
 - `UPDATE ... SET` statements without a `WHERE` clause

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -12,11 +12,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
-DROP_DDL = re.compile(r"(?is)\bdrop\s+(table|database|schema)\b")
+DROP_DDL = re.compile(r"(?is)\bdrop\s+(table|database|schema|index|view|function|procedure)\b")
 DELETE_FROM = re.compile(r"(?is)\bdelete\s+from\b")
+UPDATE_SET = re.compile(r"(?is)\bupdate\s+[\w.]+\s+set\b")
+ALTER_TABLE_DROP = re.compile(r"(?is)\balter\s+table\b.*\bdrop\b")
 TRUNCATE = re.compile(r"(?is)\btruncate(?:\s+table)?\s+[a-z_][\w.]*")
 WHERE = re.compile(r"(?is)\bwhere\b")
-MKFS = re.compile(r"(?is)(?:^|[\s;&|])mkfs(?:\.\w+)?(?:\s|$)")
+MKFS = re.compile(r"(?is)(?:^|[\s;&|])(?:mkfs(?:\.\w+)?|mkswap)(?:\s|$)")
 DD_TO_BLOCK_DEVICE = re.compile(
     r"(?is)(?:^|[\s;&|])dd\s+[^\n;&|]*\bof=/dev/(sd|hd|vd|xvd|nvme|disk)"
 )
@@ -35,8 +37,11 @@ def find_block_reason(command: str) -> str | None:
     if has_forced_git_push(command):
         return "Force-pushing is blocked. Matched pattern: git push --force."
 
+    if has_destructive_git_history_command(command):
+        return "Destructive Git history cleanup is blocked. Matched pattern: git reset --hard/git clean -fd."
+
     if DROP_DDL.search(command):
-        return "Destructive DROP statement is blocked. Matched pattern: DROP TABLE/DATABASE/SCHEMA."
+        return "Destructive DROP statement is blocked. Matched pattern: DROP TABLE/DATABASE/SCHEMA/INDEX/VIEW."
 
     if has_sql_truncate(command):
         return "TRUNCATE statements are blocked. Matched pattern: TRUNCATE."
@@ -48,8 +53,13 @@ def find_block_reason(command: str) -> str | None:
         return "Recursive permissive chmod on root paths is blocked. Matched pattern: chmod 777 /."
 
     for statement in split_sql_statements(command):
+        statement = strip_sql_comments(statement)
         if DELETE_FROM.search(statement) and not WHERE.search(statement):
             return "DELETE FROM without a WHERE clause is blocked. Matched pattern: DELETE FROM."
+        if UPDATE_SET.search(statement) and not WHERE.search(statement):
+            return "UPDATE without a WHERE clause is blocked. Matched pattern: UPDATE SET."
+        if ALTER_TABLE_DROP.search(statement):
+            return "ALTER TABLE DROP statements are blocked. Matched pattern: ALTER TABLE DROP."
 
     return None
 
@@ -103,6 +113,53 @@ def has_forced_git_push(command: str) -> bool:
 
             push_args = [arg.lower() for arg in git_args[push_index + 1 :]]
             if any(arg in {"--force", "--force-with-lease", "-f"} for arg in push_args):
+                return True
+
+    return False
+
+
+def has_destructive_git_history_command(command: str) -> bool:
+    for words in shell_commands(command):
+        words = strip_command_wrappers(words)
+        for index, word in enumerate(words):
+            if command_name(word) != "git":
+                continue
+
+            git_args = [arg.lower() for arg in words[index + 1 :]]
+            reset_index = next(
+                (i for i, arg in enumerate(git_args) if arg == "reset"),
+                None,
+            )
+            if reset_index is not None and "--hard" in git_args[reset_index + 1 :]:
+                return True
+
+            clean_index = next(
+                (i for i, arg in enumerate(git_args) if arg == "clean"),
+                None,
+            )
+            if clean_index is None:
+                continue
+
+            clean_args = git_args[clean_index + 1 :]
+            has_force = False
+            has_directory_or_ignored = False
+            is_dry_run = False
+            for arg in clean_args:
+                if arg in {"--force", "-f"}:
+                    has_force = True
+                elif arg in {"-d", "--directories", "-x", "-X"}:
+                    has_directory_or_ignored = True
+                elif arg in {"-n", "--dry-run"}:
+                    is_dry_run = True
+                elif arg.startswith("-") and not arg.startswith("--"):
+                    flags = arg.lstrip("-")
+                    has_force = has_force or "f" in flags
+                    has_directory_or_ignored = has_directory_or_ignored or any(
+                        flag in flags for flag in ("d", "x", "X")
+                    )
+                    is_dry_run = is_dry_run or "n" in flags
+
+            if has_force and has_directory_or_ignored and not is_dry_run:
                 return True
 
     return False
@@ -177,6 +234,13 @@ def command_name(word: str) -> str:
 
 def split_sql_statements(command: str) -> list[str]:
     return [part.strip() for part in re.split(r"[;\n]", command) if part.strip()]
+
+
+def strip_sql_comments(statement: str) -> str:
+    without_block_comments = re.sub(r"(?is)/\*.*?\*/", " ", statement)
+    return "\n".join(
+        re.sub(r"--.*$", "", line) for line in without_block_comments.splitlines()
+    )
 
 
 def hook_output(decision: str | None = None, reason: str | None = None) -> dict:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -50,6 +50,18 @@ GIT_FORCE_CONFIG_FALSE_VALUES = {"false", "0", "no", "off", "n"}
 REMOTE_SHELLS = {"bash", "sh"}
 REMOTE_DOWNLOADERS = {"curl", "wget"}
 SHELL_C_COMMANDS = {"bash", "dash", "fish", "ksh", "sh", "zsh"}
+CONTAINER_EXEC_COMMANDS = {"docker", "kubectl", "nerdctl", "podman"}
+CONTAINER_EXEC_OPTIONS_WITH_VALUES = {
+    "-c",
+    "-n",
+    "-u",
+    "-w",
+    "--container",
+    "--context",
+    "--namespace",
+    "--user",
+    "--workdir",
+}
 DANGEROUS_FIND_DELETE_ROOTS = {"/", "~", "$HOME", "${HOME}"}
 
 
@@ -265,6 +277,10 @@ def strip_command_wrappers(words: list[str]) -> list[str]:
         if head == "env":
             result = strip_env_prefix(result[1:])
             continue
+        container_inner = container_exec_inner_command(result)
+        if container_inner is not None:
+            result = container_inner
+            continue
         break
     return result
 
@@ -282,6 +298,44 @@ def strip_env_prefix(words: list[str]) -> list[str]:
             result = result[1:]
             continue
         return result
+    return result
+
+
+def container_exec_inner_command(words: list[str]) -> list[str] | None:
+    if not words or command_name(words[0]) not in CONTAINER_EXEC_COMMANDS:
+        return None
+
+    if command_name(words[0]) == "docker" and len(words) > 2 and words[1] == "compose":
+        if words[2] != "exec":
+            return None
+        tail = words[3:]
+    elif len(words) > 1 and words[1] == "exec":
+        tail = words[2:]
+    else:
+        return None
+
+    tail = strip_container_exec_options(tail)
+    if not tail:
+        return None
+
+    inner = tail[1:]
+    if inner and inner[0] == "--":
+        inner = inner[1:]
+    return inner or None
+
+
+def strip_container_exec_options(words: list[str]) -> list[str]:
+    result = list(words)
+    while result:
+        option = result[0]
+        if option == "--":
+            return result[1:]
+        if not option.startswith("-") or option == "-":
+            return result
+        if option.split("=", 1)[0] in CONTAINER_EXEC_OPTIONS_WITH_VALUES:
+            result = result[2:] if "=" not in option and len(result) > 1 else result[1:]
+            continue
+        result = result[1:]
     return result
 
 

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -124,7 +124,7 @@ def hook_output(decision: str | None = None, reason: str | None = None) -> dict:
 
 
 def log_blocked_attempt(command: str, cwd: str, reason: str) -> None:
-    log_dir = Path.home() / ".claude" / "hooks"
+    log_dir = hooks_dir()
     log_dir.mkdir(parents=True, exist_ok=True)
     entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -134,6 +134,18 @@ def log_blocked_attempt(command: str, cwd: str, reason: str) -> None:
     }
     with (log_dir / "blocked.log").open("a", encoding="utf-8") as log_file:
         log_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def hooks_dir() -> Path:
+    override = os.environ.get("CLAUDE_HOOKS_DIR")
+    if override:
+        return Path(override)
+
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if config_dir:
+        return Path(config_dir) / "hooks"
+
+    return Path.home() / ".claude" / "hooks"
 
 
 def main() -> int:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -50,6 +50,7 @@ GIT_FORCE_CONFIG_FALSE_VALUES = {"false", "0", "no", "off", "n"}
 REMOTE_SHELLS = {"bash", "sh"}
 REMOTE_DOWNLOADERS = {"curl", "wget"}
 SHELL_C_COMMANDS = {"bash", "dash", "fish", "ksh", "sh", "zsh"}
+EVASION_SEPARATORS = "\x00\u115f\u1160\u2800\u3164\uffa0"
 CONTAINER_EXEC_COMMANDS = {"docker", "kubectl", "nerdctl", "podman"}
 CONTAINER_EXEC_OPTIONS_WITH_VALUES = {
     "-c",
@@ -109,30 +110,31 @@ def find_block_reason(command: str) -> str | None:
 
 
 def normalize_command(command: str) -> str:
-    if "\x00" not in command:
+    if not any(char in command for char in EVASION_SEPARATORS):
         return command
 
-    return command.replace("\x00", " ") + "\n" + command.replace("\x00", "")
+    space_translation = str.maketrans({char: " " for char in EVASION_SEPARATORS})
+    remove_translation = str.maketrans("", "", EVASION_SEPARATORS)
+    return command.translate(space_translation) + "\n" + command.translate(remove_translation)
 
 
 def has_rm_recursive_force(command: str) -> bool:
     for words in shell_commands(command):
-        words = strip_command_wrappers(words)
-        for index, word in enumerate(words):
-            if command_name(word) != "rm":
+        for words in executable_command_positions(words):
+            if not words or command_name(words[0]) != "rm":
                 continue
 
             has_recursive = False
             has_force = False
-            for option in words[index + 1 :]:
+            for option in words[1:]:
                 if option == "--":
                     continue
                 if not option.startswith("-") or option == "-":
                     break
 
-                if option == "--recursive":
+                if option == "--recursive" or option.startswith("--recursive="):
                     has_recursive = True
-                elif option == "--force":
+                elif option == "--force" or option.startswith("--force="):
                     has_force = True
                 elif option.startswith("--"):
                     continue
@@ -145,6 +147,19 @@ def has_rm_recursive_force(command: str) -> bool:
                     return True
 
     return False
+
+
+def executable_command_positions(words: list[str]) -> list[list[str]]:
+    commands = []
+    segment = []
+    for word in words:
+        if word == "|":
+            commands.append(strip_command_wrappers(segment))
+            segment = []
+            continue
+        segment.append(word)
+    commands.append(strip_command_wrappers(segment))
+    return [command for command in commands if command]
 
 
 def has_forced_git_push(command: str) -> bool:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -28,7 +28,12 @@ REDIRECT_TO_BLOCK_DEVICE = re.compile(
 CHMOD_777_ROOT = re.compile(
     r"(?is)(?:^|[\s;&|])chmod\s+(?:-[\w]*R[\w]*\s+|--recursive\s+)?(?:777|666)\s+/"
 )
+WIPEFS = re.compile(r"(?is)(?:^|[\s;&|])wipefs(?:\s|$)")
+FORK_BOMB = re.compile(r"(?is):\s*\(\s*\)\s*\{.*:\s*\|.*:.*&.*\}")
 READ_ONLY_SEARCH_COMMANDS = {"ag", "grep", "rg"}
+GIT_FORCE_CONFIG_FALSE_VALUES = {"false", "0", "no", "off", "n"}
+REMOTE_SHELLS = {"bash", "sh"}
+REMOTE_DOWNLOADERS = {"curl", "wget"}
 
 
 def find_block_reason(command: str) -> str | None:
@@ -41,6 +46,9 @@ def find_block_reason(command: str) -> str | None:
     if has_destructive_git_history_command(command):
         return "Destructive Git history cleanup is blocked. Matched pattern: git reset --hard/git clean -fd."
 
+    if has_remote_shell_pipe(command):
+        return "Remote script execution is blocked. Matched pattern: curl|bash or wget|sh."
+
     if has_destructive_drop(command):
         return "Destructive DROP statement is blocked. Matched pattern: DROP TABLE/DATABASE/SCHEMA/INDEX/VIEW."
 
@@ -49,6 +57,12 @@ def find_block_reason(command: str) -> str | None:
 
     if has_block_device_write(command):
         return "Direct writes to block devices are blocked. Matched pattern: mkfs/dd/> /dev."
+
+    if WIPEFS.search(command):
+        return "Disk signature wiping is blocked. Matched pattern: wipefs."
+
+    if FORK_BOMB.search(command):
+        return "Shell fork bombs are blocked. Matched pattern: :(){ :|:& };:."
 
     if CHMOD_777_ROOT.search(command):
         return "Recursive permissive chmod on root paths is blocked. Matched pattern: chmod 777 /."
@@ -108,8 +122,38 @@ def has_forced_git_push(command: str) -> bool:
                 continue
 
             push_args = [arg.lower() for arg in git_args[push_index + 1 :]]
-            if any(arg in {"--force", "--force-with-lease", "-f"} for arg in push_args):
+            if git_force_config_enabled(git_args[:push_index]):
                 return True
+            if any(
+                arg in {"--force", "--force-with-lease", "-f"}
+                or arg.startswith("--force-with-lease=")
+                or arg.startswith("--force=")
+                or arg.startswith("+")
+                for arg in push_args
+            ):
+                return True
+
+    return False
+
+
+def git_force_config_enabled(args: list[str]) -> bool:
+    for index, arg in enumerate(args):
+        config = None
+        if arg == "-c" and index + 1 < len(args):
+            config = args[index + 1]
+        elif arg.startswith("-c") and len(arg) > 2:
+            config = arg[2:].lstrip()
+
+        if not config:
+            continue
+
+        key, has_value, value = config.partition("=")
+        if key.lower() != "push.force":
+            continue
+
+        normalized_value = value.strip().strip("'\"").lower()
+        if not has_value or normalized_value not in GIT_FORCE_CONFIG_FALSE_VALUES:
+            return True
 
     return False
 
@@ -200,6 +244,21 @@ def has_block_device_write(command: str) -> bool:
         or DD_TO_BLOCK_DEVICE.search(command)
         or REDIRECT_TO_BLOCK_DEVICE.search(command)
     )
+
+
+def has_remote_shell_pipe(command: str) -> bool:
+    for words in shell_commands(command):
+        for index, word in enumerate(words):
+            if command_name(word) not in REMOTE_DOWNLOADERS:
+                continue
+            try:
+                pipe_index = words.index("|", index + 1)
+            except ValueError:
+                continue
+            shell_words_after_pipe = strip_command_wrappers(words[pipe_index + 1 :])
+            if shell_words_after_pipe and command_name(shell_words_after_pipe[0]) in REMOTE_SHELLS:
+                return True
+    return False
 
 
 def has_destructive_drop(command: str) -> bool:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -30,7 +30,22 @@ CHMOD_777_ROOT = re.compile(
 )
 WIPEFS = re.compile(r"(?is)(?:^|[\s;&|])wipefs(?:\s|$)")
 FORK_BOMB = re.compile(r"(?is):\s*\(\s*\)\s*\{.*:\s*\|.*:.*&.*\}")
-READ_ONLY_SEARCH_COMMANDS = {"ag", "grep", "rg"}
+READ_ONLY_TEXT_COMMANDS = {
+    "ag",
+    "awk",
+    "cat",
+    "echo",
+    "grep",
+    "head",
+    "less",
+    "more",
+    "printf",
+    "rg",
+    "sed",
+    "tail",
+    "tee",
+}
+SQL_CLIENT_COMMANDS = {"mariadb", "mysql", "mysqladmin", "psql", "sqlite3", "sqlcmd"}
 GIT_FORCE_CONFIG_FALSE_VALUES = {"false", "0", "no", "off", "n"}
 REMOTE_SHELLS = {"bash", "sh"}
 REMOTE_DOWNLOADERS = {"curl", "wget"}
@@ -299,7 +314,15 @@ def destructive_sql_statement_reason(command: str) -> str | None:
 
 def is_read_only_search_command(words: list[str]) -> bool:
     words = strip_command_wrappers(words)
-    return bool(words and command_name(words[0]) in READ_ONLY_SEARCH_COMMANDS)
+    return bool(
+        words
+        and command_name(words[0]) in READ_ONLY_TEXT_COMMANDS
+        and not has_sql_client_command(words)
+    )
+
+
+def has_sql_client_command(words: list[str]) -> bool:
+    return any(command_name(word) in SQL_CLIENT_COMMANDS for word in words)
 
 
 def shell_commands(command: str) -> list[list[str]]:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -49,6 +49,8 @@ SQL_CLIENT_COMMANDS = {"mariadb", "mysql", "mysqladmin", "psql", "sqlite3", "sql
 GIT_FORCE_CONFIG_FALSE_VALUES = {"false", "0", "no", "off", "n"}
 REMOTE_SHELLS = {"bash", "sh"}
 REMOTE_DOWNLOADERS = {"curl", "wget"}
+SHELL_C_COMMANDS = {"bash", "dash", "fish", "ksh", "sh", "zsh"}
+DANGEROUS_FIND_DELETE_ROOTS = {"/", "~", "$HOME", "${HOME}"}
 
 
 def find_block_reason(command: str) -> str | None:
@@ -60,6 +62,9 @@ def find_block_reason(command: str) -> str | None:
 
     if has_destructive_git_history_command(command):
         return "Destructive Git history cleanup is blocked. Matched pattern: git reset --hard/git clean -fd."
+
+    if has_destructive_find_delete(command):
+        return "Broad find deletion is blocked. Matched pattern: find / -delete or find $HOME -delete."
 
     if has_remote_shell_pipe(command):
         return "Remote script execution is blocked. Matched pattern: curl|bash or wget|sh."
@@ -220,6 +225,24 @@ def has_destructive_git_history_command(command: str) -> bool:
     return False
 
 
+def has_destructive_find_delete(command: str) -> bool:
+    for words in shell_commands(command):
+        words = strip_command_wrappers(words)
+        if not words or command_name(words[0]) != "find" or "-delete" not in words:
+            continue
+
+        roots = []
+        for word in words[1:]:
+            if word.startswith("-"):
+                break
+            roots.append(word)
+
+        if any(root in DANGEROUS_FIND_DELETE_ROOTS for root in roots):
+            return True
+
+    return False
+
+
 def strip_command_wrappers(words: list[str]) -> list[str]:
     result = list(words)
     while result:
@@ -327,7 +350,31 @@ def has_sql_client_command(words: list[str]) -> bool:
 
 def shell_commands(command: str) -> list[list[str]]:
     segments = re.split(r"(?:&&|\|\||;|\n)", command)
-    return [shell_words(segment) for segment in segments if segment.strip()]
+    commands = []
+    for segment in segments:
+        if not segment.strip():
+            continue
+
+        words = shell_words(segment)
+        commands.append(words)
+
+        inner = shell_c_command(words)
+        if inner:
+            commands.extend(shell_commands(inner))
+
+    return commands
+
+
+def shell_c_command(words: list[str]) -> str | None:
+    words = strip_command_wrappers(words)
+    if not words or command_name(words[0]) not in SHELL_C_COMMANDS:
+        return None
+
+    for index, word in enumerate(words[1:-1], start=1):
+        if word == "-c" or (word.startswith("-") and "c" in word[1:]):
+            return words[index + 1]
+
+    return None
 
 
 def shell_words(command: str) -> list[str]:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -14,8 +14,18 @@ from pathlib import Path
 
 DROP_DDL = re.compile(r"(?is)\bdrop\s+(table|database|schema)\b")
 DELETE_FROM = re.compile(r"(?is)\bdelete\s+from\b")
-TRUNCATE = re.compile(r"(?is)\btruncate\b")
+TRUNCATE = re.compile(r"(?is)\btruncate(?:\s+table)?\s+[a-z_][\w.]*")
 WHERE = re.compile(r"(?is)\bwhere\b")
+MKFS = re.compile(r"(?is)(?:^|[\s;&|])mkfs(?:\.\w+)?(?:\s|$)")
+DD_TO_BLOCK_DEVICE = re.compile(
+    r"(?is)(?:^|[\s;&|])dd\s+[^\n;&|]*\bof=/dev/(sd|hd|vd|xvd|nvme|disk)"
+)
+REDIRECT_TO_BLOCK_DEVICE = re.compile(
+    r"(?is)(?:^|[\s;&|])(?:>|1>|2>)\s*/dev/(sd|hd|vd|xvd|nvme|disk)"
+)
+CHMOD_777_ROOT = re.compile(
+    r"(?is)(?:^|[\s;&|])chmod\s+(?:-[\w]*R[\w]*\s+|--recursive\s+)?(?:777|666)\s+/"
+)
 
 
 def find_block_reason(command: str) -> str | None:
@@ -28,8 +38,14 @@ def find_block_reason(command: str) -> str | None:
     if DROP_DDL.search(command):
         return "Destructive DROP statement is blocked. Matched pattern: DROP TABLE/DATABASE/SCHEMA."
 
-    if TRUNCATE.search(command):
+    if has_sql_truncate(command):
         return "TRUNCATE statements are blocked. Matched pattern: TRUNCATE."
+
+    if has_block_device_write(command):
+        return "Direct writes to block devices are blocked. Matched pattern: mkfs/dd/> /dev."
+
+    if CHMOD_777_ROOT.search(command):
+        return "Recursive permissive chmod on root paths is blocked. Matched pattern: chmod 777 /."
 
     for statement in split_sql_statements(command):
         if DELETE_FROM.search(statement) and not WHERE.search(statement):
@@ -87,6 +103,24 @@ def has_forced_git_push(command: str) -> bool:
             if any(arg in {"--force", "--force-with-lease", "-f"} for arg in push_args):
                 return True
 
+    return False
+
+
+def has_block_device_write(command: str) -> bool:
+    return bool(
+        MKFS.search(command)
+        or DD_TO_BLOCK_DEVICE.search(command)
+        or REDIRECT_TO_BLOCK_DEVICE.search(command)
+    )
+
+
+def has_sql_truncate(command: str) -> bool:
+    for words in shell_commands(command):
+        if words and command_name(words[0]) == "truncate" and len(words) > 1:
+            if words[1].startswith("-"):
+                continue
+        if TRUNCATE.search(" ".join(words)):
+            return True
     return False
 
 

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -56,6 +56,7 @@ def find_block_reason(command: str) -> str | None:
 
 def has_rm_recursive_force(command: str) -> bool:
     for words in shell_commands(command):
+        words = strip_command_wrappers(words)
         for index, word in enumerate(words):
             if command_name(word) != "rm":
                 continue
@@ -87,6 +88,7 @@ def has_rm_recursive_force(command: str) -> bool:
 
 def has_forced_git_push(command: str) -> bool:
     for words in shell_commands(command):
+        words = strip_command_wrappers(words)
         for index, word in enumerate(words):
             if command_name(word) != "git":
                 continue
@@ -104,6 +106,39 @@ def has_forced_git_push(command: str) -> bool:
                 return True
 
     return False
+
+
+def strip_command_wrappers(words: list[str]) -> list[str]:
+    result = list(words)
+    while result:
+        head = command_name(result[0])
+        if head == "sudo":
+            result = result[1:]
+            continue
+        if head == "command":
+            result = result[1:]
+            continue
+        if head == "env":
+            result = strip_env_prefix(result[1:])
+            continue
+        break
+    return result
+
+
+def strip_env_prefix(words: list[str]) -> list[str]:
+    result = list(words)
+    while result:
+        token = result[0]
+        if token == "--":
+            return result[1:]
+        if token.startswith("-"):
+            result = result[1:]
+            continue
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token):
+            result = result[1:]
+            continue
+        return result
+    return result
 
 
 def has_block_device_write(command: str) -> bool:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -28,6 +28,7 @@ REDIRECT_TO_BLOCK_DEVICE = re.compile(
 CHMOD_777_ROOT = re.compile(
     r"(?is)(?:^|[\s;&|])chmod\s+(?:-[\w]*R[\w]*\s+|--recursive\s+)?(?:777|666)\s+/"
 )
+READ_ONLY_SEARCH_COMMANDS = {"ag", "grep", "rg"}
 
 
 def find_block_reason(command: str) -> str | None:
@@ -40,7 +41,7 @@ def find_block_reason(command: str) -> str | None:
     if has_destructive_git_history_command(command):
         return "Destructive Git history cleanup is blocked. Matched pattern: git reset --hard/git clean -fd."
 
-    if DROP_DDL.search(command):
+    if has_destructive_drop(command):
         return "Destructive DROP statement is blocked. Matched pattern: DROP TABLE/DATABASE/SCHEMA/INDEX/VIEW."
 
     if has_sql_truncate(command):
@@ -52,14 +53,9 @@ def find_block_reason(command: str) -> str | None:
     if CHMOD_777_ROOT.search(command):
         return "Recursive permissive chmod on root paths is blocked. Matched pattern: chmod 777 /."
 
-    for statement in split_sql_statements(command):
-        statement = strip_sql_comments(statement)
-        if DELETE_FROM.search(statement) and not WHERE.search(statement):
-            return "DELETE FROM without a WHERE clause is blocked. Matched pattern: DELETE FROM."
-        if UPDATE_SET.search(statement) and not WHERE.search(statement):
-            return "UPDATE without a WHERE clause is blocked. Matched pattern: UPDATE SET."
-        if ALTER_TABLE_DROP.search(statement):
-            return "ALTER TABLE DROP statements are blocked. Matched pattern: ALTER TABLE DROP."
+    sql_reason = destructive_sql_statement_reason(command)
+    if sql_reason:
+        return sql_reason
 
     return None
 
@@ -206,14 +202,45 @@ def has_block_device_write(command: str) -> bool:
     )
 
 
+def has_destructive_drop(command: str) -> bool:
+    for words in shell_commands(command):
+        if is_read_only_search_command(words):
+            continue
+        if DROP_DDL.search(" ".join(words)):
+            return True
+    return False
+
+
 def has_sql_truncate(command: str) -> bool:
     for words in shell_commands(command):
+        if is_read_only_search_command(words):
+            continue
         if words and command_name(words[0]) == "truncate" and len(words) > 1:
             if words[1].startswith("-"):
                 continue
         if TRUNCATE.search(" ".join(words)):
             return True
     return False
+
+
+def destructive_sql_statement_reason(command: str) -> str | None:
+    for words in shell_commands(command):
+        if is_read_only_search_command(words):
+            continue
+        segment = strip_sql_comments(" ".join(words))
+        for statement in split_sql_statements(segment):
+            if DELETE_FROM.search(statement) and not WHERE.search(statement):
+                return "DELETE FROM without a WHERE clause is blocked. Matched pattern: DELETE FROM."
+            if UPDATE_SET.search(statement) and not WHERE.search(statement):
+                return "UPDATE without a WHERE clause is blocked. Matched pattern: UPDATE SET."
+            if ALTER_TABLE_DROP.search(statement):
+                return "ALTER TABLE DROP statements are blocked. Matched pattern: ALTER TABLE DROP."
+    return None
+
+
+def is_read_only_search_command(words: list[str]) -> bool:
+    words = strip_command_wrappers(words)
+    return bool(words and command_name(words[0]) in READ_ONLY_SEARCH_COMMANDS)
 
 
 def shell_commands(command: str) -> list[list[str]]:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -6,51 +6,104 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 
-BLOCK_RULES = (
-    (
-        "rm -rf",
-        re.compile(
-            r"(?is)(?:^|[\s;&|()])rm\s+"
-            r"(?:-[^\s;|&]*r[^\s;|&]*f[^\s;|&]*|-[^\s;|&]*f[^\s;|&]*r[^\s;|&]*)\b"
-        ),
-        "Recursive forced deletion is blocked.",
-    ),
-    (
-        "DROP TABLE",
-        re.compile(r"(?is)\bdrop\s+table\b"),
-        "DROP TABLE statements are blocked.",
-    ),
-    (
-        "git push --force",
-        re.compile(r"(?is)(?:^|[\s;&|()])git\s+push\b[^\n;&|]*\s(?:--force|-f)\b"),
-        "Force-pushing is blocked.",
-    ),
-    (
-        "TRUNCATE",
-        re.compile(r"(?is)\btruncate\b"),
-        "TRUNCATE statements are blocked.",
-    ),
-)
-
+DROP_DDL = re.compile(r"(?is)\bdrop\s+(table|database|schema)\b")
 DELETE_FROM = re.compile(r"(?is)\bdelete\s+from\b")
+TRUNCATE = re.compile(r"(?is)\btruncate\b")
 WHERE = re.compile(r"(?is)\bwhere\b")
 
 
 def find_block_reason(command: str) -> str | None:
-    for name, pattern, reason in BLOCK_RULES:
-        if pattern.search(command):
-            return f"{reason} Matched pattern: {name}."
+    if has_rm_recursive_force(command):
+        return "Recursive forced deletion is blocked. Matched pattern: rm -rf."
+
+    if has_forced_git_push(command):
+        return "Force-pushing is blocked. Matched pattern: git push --force."
+
+    if DROP_DDL.search(command):
+        return "Destructive DROP statement is blocked. Matched pattern: DROP TABLE/DATABASE/SCHEMA."
+
+    if TRUNCATE.search(command):
+        return "TRUNCATE statements are blocked. Matched pattern: TRUNCATE."
 
     for statement in split_sql_statements(command):
         if DELETE_FROM.search(statement) and not WHERE.search(statement):
             return "DELETE FROM without a WHERE clause is blocked. Matched pattern: DELETE FROM."
 
     return None
+
+
+def has_rm_recursive_force(command: str) -> bool:
+    for words in shell_commands(command):
+        for index, word in enumerate(words):
+            if command_name(word) != "rm":
+                continue
+
+            has_recursive = False
+            has_force = False
+            for option in words[index + 1 :]:
+                if option == "--":
+                    continue
+                if not option.startswith("-") or option == "-":
+                    break
+
+                if option == "--recursive":
+                    has_recursive = True
+                elif option == "--force":
+                    has_force = True
+                elif option.startswith("--"):
+                    continue
+                else:
+                    flags = option.lstrip("-")
+                    has_recursive = has_recursive or "r" in flags.lower()
+                    has_force = has_force or "f" in flags
+
+                if has_recursive and has_force:
+                    return True
+
+    return False
+
+
+def has_forced_git_push(command: str) -> bool:
+    for words in shell_commands(command):
+        for index, word in enumerate(words):
+            if command_name(word) != "git":
+                continue
+
+            git_args = words[index + 1 :]
+            push_index = next(
+                (i for i, arg in enumerate(git_args) if arg.lower() == "push"),
+                None,
+            )
+            if push_index is None:
+                continue
+
+            push_args = [arg.lower() for arg in git_args[push_index + 1 :]]
+            if any(arg in {"--force", "--force-with-lease", "-f"} for arg in push_args):
+                return True
+
+    return False
+
+
+def shell_commands(command: str) -> list[list[str]]:
+    segments = re.split(r"(?:&&|\|\||;|\n)", command)
+    return [shell_words(segment) for segment in segments if segment.strip()]
+
+
+def shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def command_name(word: str) -> str:
+    return Path(word).name.lower()
 
 
 def split_sql_statements(command: str) -> list[str]:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -54,6 +54,8 @@ DANGEROUS_FIND_DELETE_ROOTS = {"/", "~", "$HOME", "${HOME}"}
 
 
 def find_block_reason(command: str) -> str | None:
+    command = normalize_command(command)
+
     if has_rm_recursive_force(command):
         return "Recursive forced deletion is blocked. Matched pattern: rm -rf."
 
@@ -92,6 +94,13 @@ def find_block_reason(command: str) -> str | None:
         return sql_reason
 
     return None
+
+
+def normalize_command(command: str) -> str:
+    if "\x00" not in command:
+        return command
+
+    return command.replace("\x00", " ") + "\n" + command.replace("\x00", "")
 
 
 def has_rm_recursive_force(command: str) -> bool:

--- a/hooks/pre-tool-use-block-destructive/block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/block_destructive.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+BLOCK_RULES = (
+    (
+        "rm -rf",
+        re.compile(
+            r"(?is)(?:^|[\s;&|()])rm\s+"
+            r"(?:-[^\s;|&]*r[^\s;|&]*f[^\s;|&]*|-[^\s;|&]*f[^\s;|&]*r[^\s;|&]*)\b"
+        ),
+        "Recursive forced deletion is blocked.",
+    ),
+    (
+        "DROP TABLE",
+        re.compile(r"(?is)\bdrop\s+table\b"),
+        "DROP TABLE statements are blocked.",
+    ),
+    (
+        "git push --force",
+        re.compile(r"(?is)(?:^|[\s;&|()])git\s+push\b[^\n;&|]*\s(?:--force|-f)\b"),
+        "Force-pushing is blocked.",
+    ),
+    (
+        "TRUNCATE",
+        re.compile(r"(?is)\btruncate\b"),
+        "TRUNCATE statements are blocked.",
+    ),
+)
+
+DELETE_FROM = re.compile(r"(?is)\bdelete\s+from\b")
+WHERE = re.compile(r"(?is)\bwhere\b")
+
+
+def find_block_reason(command: str) -> str | None:
+    for name, pattern, reason in BLOCK_RULES:
+        if pattern.search(command):
+            return f"{reason} Matched pattern: {name}."
+
+    for statement in split_sql_statements(command):
+        if DELETE_FROM.search(statement) and not WHERE.search(statement):
+            return "DELETE FROM without a WHERE clause is blocked. Matched pattern: DELETE FROM."
+
+    return None
+
+
+def split_sql_statements(command: str) -> list[str]:
+    return [part.strip() for part in re.split(r"[;\n]", command) if part.strip()]
+
+
+def hook_output(decision: str | None = None, reason: str | None = None) -> dict:
+    if decision is None:
+        return {"continue": True, "suppressOutput": True}
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def log_blocked_attempt(command: str, cwd: str, reason: str) -> None:
+    log_dir = Path.home() / ".claude" / "hooks"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "command": command,
+        "project_path": cwd,
+        "reason": reason,
+    }
+    with (log_dir / "blocked.log").open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(
+            json.dumps(
+                hook_output(
+                    "deny",
+                    f"Could not parse PreToolUse hook input as JSON: {exc}",
+                )
+            )
+        )
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        print(json.dumps(hook_output()))
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    cwd = payload.get("cwd") or os.getcwd()
+    reason = find_block_reason(command)
+
+    if reason is None:
+        print(json.dumps(hook_output()))
+        return 0
+
+    log_blocked_attempt(command, cwd, reason)
+    print(json.dumps(hook_output("deny", reason)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/pre-tool-use-block-destructive/install.py
+++ b/hooks/pre-tool-use-block-destructive/install.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -23,15 +24,23 @@ def load_settings(settings_path: Path) -> dict:
     return json.loads(settings_path.read_text(encoding="utf-8"))
 
 
+def claude_config_dir() -> Path:
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude"
+
+
 def install() -> None:
     source = Path(__file__).with_name("block_destructive.py")
-    hooks_dir = Path.home() / ".claude" / "hooks"
+    config_dir = claude_config_dir()
+    hooks_dir = config_dir / "hooks"
     hooks_dir.mkdir(parents=True, exist_ok=True)
 
     target = hooks_dir / "block_destructive.py"
     shutil.copy2(source, target)
 
-    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path = config_dir / "settings.json"
     settings = load_settings(settings_path)
     hooks = settings.setdefault("hooks", {})
     pre_tool_use = hooks.setdefault(HOOK_EVENT, [])

--- a/hooks/pre-tool-use-block-destructive/install.py
+++ b/hooks/pre-tool-use-block-destructive/install.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Install the destructive-command hook into ~/.claude."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+HOOK_EVENT = "PreToolUse"
+HOOK_MATCHER = "Bash"
+
+
+def command_for(script_path: Path) -> str:
+    return f'"{sys.executable}" "{script_path}"'
+
+
+def load_settings(settings_path: Path) -> dict:
+    if not settings_path.exists():
+        return {}
+    return json.loads(settings_path.read_text(encoding="utf-8"))
+
+
+def install() -> None:
+    source = Path(__file__).with_name("block_destructive.py")
+    hooks_dir = Path.home() / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    target = hooks_dir / "block_destructive.py"
+    shutil.copy2(source, target)
+
+    settings_path = Path.home() / ".claude" / "settings.json"
+    settings = load_settings(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault(HOOK_EVENT, [])
+    hook_entry = {
+        "matcher": HOOK_MATCHER,
+        "hooks": [{"type": "command", "command": command_for(target)}],
+    }
+
+    if hook_entry not in pre_tool_use:
+        pre_tool_use.append(hook_entry)
+
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"Installed hook at {target}")
+    print(f"Updated settings at {settings_path}")
+
+
+if __name__ == "__main__":
+    install()

--- a/hooks/pre-tool-use-block-destructive/settings.example.json
+++ b/hooks/pre-tool-use-block-destructive/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/block_destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -119,6 +119,12 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("git push --force", find_block_reason("git push origin main --\x00force"))
         self.assertIn("DROP TABLE", find_block_reason("DROP\x00TABLE users"))
 
+    def test_blocks_container_exec_inner_commands(self):
+        self.assertIn("rm -rf", find_block_reason("docker exec app sh -c 'rm -rf /tmp/build'"))
+        self.assertIn("git push --force", find_block_reason("kubectl exec pod -- sh -c 'git push --force origin main'"))
+        self.assertIn("DROP TABLE", find_block_reason("docker compose exec app psql -c 'DROP TABLE users'"))
+        self.assertIsNone(find_block_reason("echo \"docker exec app sh -c 'rm -rf /tmp/build'\""))
+
 
 class HookIntegrationTests(unittest.TestCase):
     def run_hook(self, payload, home):

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -36,6 +36,8 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("rm -rf", find_block_reason("rm -Rf dist"))
         self.assertIn("rm -rf", find_block_reason("rm --recursive --force dist"))
         self.assertIn("rm -rf", find_block_reason("cd app && rm -rf .next"))
+        self.assertIn("rm -rf", find_block_reason("bash -c 'rm -rf build'"))
+        self.assertIn("rm -rf", find_block_reason("sudo sh -lc 'rm -rf build'"))
 
     def test_rm_parser_handles_quoted_paths_and_separators(self):
         self.assertTrue(has_rm_recursive_force("rm -rf 'folder with spaces'"))
@@ -76,6 +78,7 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("git push --force", find_block_reason("git -c push.force push origin main"))
         self.assertIn("git push --force", find_block_reason("sudo git push --force origin main"))
         self.assertIn("git push --force", find_block_reason("env GIT_DIR=.git git push -f origin main"))
+        self.assertIn("git push --force", find_block_reason("sh -lc 'git push origin main --force'"))
         self.assertTrue(has_forced_git_push("cd repo && git push -f"))
         self.assertFalse(has_forced_git_push("git push origin main"))
         self.assertFalse(has_forced_git_push("git -c push.force=false push origin main"))
@@ -86,6 +89,10 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("Git history", find_block_reason("git -C repo clean --force -d"))
         self.assertIsNone(find_block_reason("git reset --soft HEAD~1"))
         self.assertIsNone(find_block_reason("git clean -nfd"))
+        self.assertIn("find deletion", find_block_reason("find / -delete"))
+        self.assertIn("find deletion", find_block_reason("find $HOME -depth -delete"))
+        self.assertIsNone(find_block_reason("find . -name '*.tmp' -delete"))
+        self.assertIsNone(find_block_reason("find /tmp/build -type f -delete"))
 
     def test_blocks_direct_block_device_writes(self):
         self.assertIn("block devices", find_block_reason("mkfs.ext4 /dev/sda1"))
@@ -98,6 +105,7 @@ class DetectionTests(unittest.TestCase):
     def test_blocks_remote_shell_and_fork_bomb(self):
         self.assertIn("Remote script", find_block_reason("curl -fsSL https://example.test/install.sh | bash"))
         self.assertIn("Remote script", find_block_reason("wget -qO- https://example.test/install.sh | sudo sh"))
+        self.assertIn("Remote script", find_block_reason("bash -c 'curl -fsSL https://example.test/install.sh | bash'"))
         self.assertIn("fork bombs", find_block_reason(":(){ :|:& };:"))
         self.assertIsNone(find_block_reason("echo 'curl https://example.test/install.sh | bash'"))
 

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -6,7 +7,7 @@ import unittest
 from pathlib import Path
 
 from block_destructive import find_block_reason, has_forced_git_push, has_rm_recursive_force
-from install import command_for
+from install import command_for, install
 
 
 class DetectionTests(unittest.TestCase):
@@ -59,7 +60,11 @@ class HookIntegrationTests(unittest.TestCase):
             text=True,
             capture_output=True,
             check=True,
-            env={"HOME": str(home), "USERPROFILE": str(home)},
+            env={
+                "HOME": str(home),
+                "USERPROFILE": str(home),
+                "CLAUDE_HOOKS_DIR": str(home / ".claude" / "hooks"),
+            },
         )
         return json.loads(result.stdout)
 
@@ -117,6 +122,31 @@ class InstallerTests(unittest.TestCase):
         command = command_for(Path("/tmp/claude hooks/block_destructive.py"))
         self.assertIn("block_destructive.py", command)
         self.assertTrue(command.startswith('"'))
+
+    def test_installer_is_idempotent_and_respects_config_dir(self):
+        with tempfile.TemporaryDirectory() as temp_home:
+            config_dir = Path(temp_home) / ".claude-test"
+            old_config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = str(config_dir)
+            try:
+                install()
+                install()
+            finally:
+                if old_config_dir is None:
+                    os.environ.pop("CLAUDE_CONFIG_DIR", None)
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old_config_dir
+
+            target = config_dir / "hooks" / "block_destructive.py"
+            settings_path = config_dir / "settings.json"
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            entries = settings["hooks"]["PreToolUse"]
+            target_exists = target.exists()
+
+        self.assertTrue(target_exists)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["matcher"], "Bash")
+        self.assertIn("block_destructive.py", entries[0]["hooks"][0]["command"])
 
 
 if __name__ == "__main__":

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -34,6 +34,9 @@ class DetectionTests(unittest.TestCase):
     def test_rm_parser_handles_quoted_paths_and_separators(self):
         self.assertTrue(has_rm_recursive_force("rm -rf 'folder with spaces'"))
         self.assertTrue(has_rm_recursive_force("echo ok; rm -fR build"))
+        self.assertTrue(has_rm_recursive_force("sudo rm -rf build"))
+        self.assertTrue(has_rm_recursive_force("command rm -rf build"))
+        self.assertTrue(has_rm_recursive_force("env PATH=/usr/bin rm -rf build"))
         self.assertFalse(has_rm_recursive_force("echo 'rm -rf docs'"))
 
     def test_blocks_sql_destructive_patterns(self):
@@ -54,6 +57,8 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("git push --force", find_block_reason("git push -f origin main"))
         self.assertIn("git push --force", find_block_reason("git -C repo push --force origin main"))
         self.assertIn("git push --force", find_block_reason("git push --force-with-lease origin main"))
+        self.assertIn("git push --force", find_block_reason("sudo git push --force origin main"))
+        self.assertIn("git push --force", find_block_reason("env GIT_DIR=.git git push -f origin main"))
         self.assertTrue(has_forced_git_push("cd repo && git push -f"))
         self.assertFalse(has_forced_git_push("git push origin main"))
 

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -6,7 +6,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from block_destructive import find_block_reason, has_forced_git_push, has_rm_recursive_force
+from block_destructive import (
+    find_block_reason,
+    has_block_device_write,
+    has_forced_git_push,
+    has_rm_recursive_force,
+)
 from install import command_for, install
 
 
@@ -17,6 +22,7 @@ class DetectionTests(unittest.TestCase):
         self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))
         self.assertIsNone(find_block_reason("rm -r build"))
         self.assertIsNone(find_block_reason("rm -f package-lock.json"))
+        self.assertIsNone(find_block_reason("truncate -s 0 app.log"))
 
     def test_blocks_rm_rf_variants(self):
         self.assertIn("rm -rf", find_block_reason("rm -rf /tmp/build"))
@@ -35,6 +41,7 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("DROP TABLE", find_block_reason("DROP DATABASE prod"))
         self.assertIn("DROP TABLE", find_block_reason("DROP SCHEMA public"))
         self.assertIn("TRUNCATE", find_block_reason("TRUNCATE audit_log"))
+        self.assertIn("TRUNCATE", find_block_reason("TRUNCATE TABLE audit_log"))
         self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users"))
 
     def test_delete_from_requires_where_per_statement(self):
@@ -49,6 +56,17 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("git push --force", find_block_reason("git push --force-with-lease origin main"))
         self.assertTrue(has_forced_git_push("cd repo && git push -f"))
         self.assertFalse(has_forced_git_push("git push origin main"))
+
+    def test_blocks_direct_block_device_writes(self):
+        self.assertIn("block devices", find_block_reason("mkfs.ext4 /dev/sda1"))
+        self.assertIn("block devices", find_block_reason("dd if=image.iso of=/dev/sdb bs=4M"))
+        self.assertTrue(has_block_device_write("echo 1 > /dev/sda"))
+        self.assertFalse(has_block_device_write("dd if=/dev/zero of=./disk.img bs=1M count=1"))
+
+    def test_blocks_permissive_root_chmod(self):
+        self.assertIn("chmod 777", find_block_reason("chmod -R 777 /var/www"))
+        self.assertIn("chmod 777", find_block_reason("chmod --recursive 666 /tmp/shared"))
+        self.assertIsNone(find_block_reason("chmod 755 scripts/deploy.sh"))
 
 
 class HookIntegrationTests(unittest.TestCase):

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -67,10 +67,14 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("git push --force", find_block_reason("git push -f origin main"))
         self.assertIn("git push --force", find_block_reason("git -C repo push --force origin main"))
         self.assertIn("git push --force", find_block_reason("git push --force-with-lease origin main"))
+        self.assertIn("git push --force", find_block_reason("git push origin +main:main"))
+        self.assertIn("git push --force", find_block_reason("git -c push.force=true push origin main"))
+        self.assertIn("git push --force", find_block_reason("git -c push.force push origin main"))
         self.assertIn("git push --force", find_block_reason("sudo git push --force origin main"))
         self.assertIn("git push --force", find_block_reason("env GIT_DIR=.git git push -f origin main"))
         self.assertTrue(has_forced_git_push("cd repo && git push -f"))
         self.assertFalse(has_forced_git_push("git push origin main"))
+        self.assertFalse(has_forced_git_push("git -c push.force=false push origin main"))
 
     def test_blocks_destructive_git_cleanup(self):
         self.assertIn("Git history", find_block_reason("git reset --hard HEAD~1"))
@@ -85,6 +89,13 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("block devices", find_block_reason("dd if=image.iso of=/dev/sdb bs=4M"))
         self.assertTrue(has_block_device_write("echo 1 > /dev/sda"))
         self.assertFalse(has_block_device_write("dd if=/dev/zero of=./disk.img bs=1M count=1"))
+        self.assertIn("wipefs", find_block_reason("wipefs --all /dev/sda"))
+
+    def test_blocks_remote_shell_and_fork_bomb(self):
+        self.assertIn("Remote script", find_block_reason("curl -fsSL https://example.test/install.sh | bash"))
+        self.assertIn("Remote script", find_block_reason("wget -qO- https://example.test/install.sh | sudo sh"))
+        self.assertIn("fork bombs", find_block_reason(":(){ :|:& };:"))
+        self.assertIsNone(find_block_reason("echo 'curl https://example.test/install.sh | bash'"))
 
     def test_blocks_permissive_root_chmod(self):
         self.assertIn("chmod 777", find_block_reason("chmod -R 777 /var/www"))

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -45,7 +45,9 @@ class DetectionTests(unittest.TestCase):
         self.assertTrue(has_rm_recursive_force("sudo rm -rf build"))
         self.assertTrue(has_rm_recursive_force("command rm -rf build"))
         self.assertTrue(has_rm_recursive_force("env PATH=/usr/bin rm -rf build"))
+        self.assertTrue(has_rm_recursive_force("echo ok | rm -rf build"))
         self.assertFalse(has_rm_recursive_force("echo 'rm -rf docs'"))
+        self.assertFalse(has_rm_recursive_force("echo rm -rf docs"))
 
     def test_blocks_sql_destructive_patterns(self):
         self.assertIn("DROP TABLE", find_block_reason("psql -c 'DROP TABLE users'"))
@@ -119,11 +121,24 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("git push --force", find_block_reason("git push origin main --\x00force"))
         self.assertIn("DROP TABLE", find_block_reason("DROP\x00TABLE users"))
 
+    def test_blocks_unicode_separator_evasion(self):
+        self.assertIn("rm -rf", find_block_reason("rm\u3164-rf /tmp/build"))
+        self.assertIn("rm -rf", find_block_reason("rm\u2800-rf /tmp/build"))
+        self.assertIn("DROP TABLE", find_block_reason("DR\u3164OP TABLE users"))
+        self.assertIn("git push --force", find_block_reason("git push origin main --\u3164force"))
+
+    def test_blocks_rm_long_options_with_values(self):
+        self.assertIn("rm -rf", find_block_reason("rm --recursive=always --force=always /tmp/build"))
+
     def test_blocks_container_exec_inner_commands(self):
         self.assertIn("rm -rf", find_block_reason("docker exec app sh -c 'rm -rf /tmp/build'"))
         self.assertIn("git push --force", find_block_reason("kubectl exec pod -- sh -c 'git push --force origin main'"))
         self.assertIn("DROP TABLE", find_block_reason("docker compose exec app psql -c 'DROP TABLE users'"))
         self.assertIsNone(find_block_reason("echo \"docker exec app sh -c 'rm -rf /tmp/build'\""))
+
+    def test_allows_display_only_rm_text_inside_shell_wrapper(self):
+        self.assertIsNone(find_block_reason("bash -lc 'echo rm -rf /'"))
+        self.assertIn("rm -rf", find_block_reason("bash -c 'echo safe; rm -rf /'"))
 
 
 class HookIntegrationTests(unittest.TestCase):

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -114,6 +114,11 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("chmod 777", find_block_reason("chmod --recursive 666 /tmp/shared"))
         self.assertIsNone(find_block_reason("chmod 755 scripts/deploy.sh"))
 
+    def test_blocks_null_byte_evasion(self):
+        self.assertIn("rm -rf", find_block_reason("rm\x00-rf /tmp/build"))
+        self.assertIn("git push --force", find_block_reason("git push origin main --\x00force"))
+        self.assertIn("DROP TABLE", find_block_reason("DROP\x00TABLE users"))
+
 
 class HookIntegrationTests(unittest.TestCase):
     def run_hook(self, payload, home):

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from block_destructive import find_block_reason
+from install import command_for
+
+
+class DetectionTests(unittest.TestCase):
+    def test_allows_normal_bash_commands(self):
+        self.assertIsNone(find_block_reason("npm test"))
+        self.assertIsNone(find_block_reason("git push origin feature-branch"))
+        self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))
+
+    def test_blocks_rm_rf_variants(self):
+        self.assertIn("rm -rf", find_block_reason("rm -rf /tmp/build"))
+        self.assertIn("rm -rf", find_block_reason("rm -fr node_modules"))
+
+    def test_blocks_sql_destructive_patterns(self):
+        self.assertIn("DROP TABLE", find_block_reason("psql -c 'DROP TABLE users'"))
+        self.assertIn("TRUNCATE", find_block_reason("TRUNCATE audit_log"))
+        self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users"))
+
+    def test_blocks_force_push(self):
+        self.assertIn("git push --force", find_block_reason("git push --force origin main"))
+        self.assertIn("git push --force", find_block_reason("git push -f origin main"))
+
+
+class HookIntegrationTests(unittest.TestCase):
+    def run_hook(self, payload, home):
+        script = Path(__file__).with_name("block_destructive.py")
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=True,
+            env={"HOME": str(home), "USERPROFILE": str(home)},
+        )
+        return json.loads(result.stdout)
+
+    def test_safe_command_continues(self):
+        with tempfile.TemporaryDirectory() as temp_home:
+            output = self.run_hook(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "npm test"},
+                    "cwd": "/work/project",
+                },
+                Path(temp_home),
+            )
+        self.assertTrue(output["continue"])
+
+    def test_blocked_command_denies_and_logs(self):
+        with tempfile.TemporaryDirectory() as temp_home:
+            home = Path(temp_home)
+            output = self.run_hook(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "rm -rf /important"},
+                    "cwd": "/work/project",
+                },
+                home,
+            )
+            log_path = home / ".claude" / "hooks" / "blocked.log"
+            log_entry = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+
+        hook_output = output["hookSpecificOutput"]
+        self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+        self.assertEqual(hook_output["permissionDecision"], "deny")
+        self.assertIn("rm -rf", hook_output["permissionDecisionReason"])
+        self.assertEqual(log_entry["command"], "rm -rf /important")
+        self.assertEqual(log_entry["project_path"], "/work/project")
+
+
+class InstallerTests(unittest.TestCase):
+    def test_command_quotes_python_and_hook_paths(self):
+        command = command_for(Path("/tmp/claude hooks/block_destructive.py"))
+        self.assertIn("block_destructive.py", command)
+        self.assertTrue(command.startswith('"'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -26,6 +26,9 @@ class DetectionTests(unittest.TestCase):
         self.assertIsNone(find_block_reason("rg 'DROP TABLE' docs/"))
         self.assertIsNone(find_block_reason("grep -R 'DELETE FROM users' docs/"))
         self.assertIsNone(find_block_reason("ag 'UPDATE users SET admin = true' docs/"))
+        self.assertIsNone(find_block_reason("echo 'DROP TABLE users'"))
+        self.assertIsNone(find_block_reason("printf 'TRUNCATE sessions'"))
+        self.assertIsNone(find_block_reason("cat schema.sql | grep 'DELETE FROM users'"))
 
     def test_blocks_rm_rf_variants(self):
         self.assertIn("rm -rf", find_block_reason("rm -rf /tmp/build"))
@@ -53,6 +56,7 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("UPDATE", find_block_reason("UPDATE users SET admin = true"))
         self.assertIn("ALTER TABLE DROP", find_block_reason("ALTER TABLE users DROP COLUMN email"))
         self.assertIn("DROP TABLE", find_block_reason("rg 'DROP TABLE' docs && psql -c 'DROP TABLE users'"))
+        self.assertIn("DROP TABLE", find_block_reason("cat destructive.sql | psql -c 'DROP TABLE users'"))
 
     def test_delete_from_requires_where_per_statement(self):
         self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from block_destructive import find_block_reason
+from block_destructive import find_block_reason, has_forced_git_push, has_rm_recursive_force
 from install import command_for
 
 
@@ -14,19 +14,40 @@ class DetectionTests(unittest.TestCase):
         self.assertIsNone(find_block_reason("npm test"))
         self.assertIsNone(find_block_reason("git push origin feature-branch"))
         self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))
+        self.assertIsNone(find_block_reason("rm -r build"))
+        self.assertIsNone(find_block_reason("rm -f package-lock.json"))
 
     def test_blocks_rm_rf_variants(self):
         self.assertIn("rm -rf", find_block_reason("rm -rf /tmp/build"))
         self.assertIn("rm -rf", find_block_reason("rm -fr node_modules"))
+        self.assertIn("rm -rf", find_block_reason("rm -Rf dist"))
+        self.assertIn("rm -rf", find_block_reason("rm --recursive --force dist"))
+        self.assertIn("rm -rf", find_block_reason("cd app && rm -rf .next"))
+
+    def test_rm_parser_handles_quoted_paths_and_separators(self):
+        self.assertTrue(has_rm_recursive_force("rm -rf 'folder with spaces'"))
+        self.assertTrue(has_rm_recursive_force("echo ok; rm -fR build"))
+        self.assertFalse(has_rm_recursive_force("echo 'rm -rf docs'"))
 
     def test_blocks_sql_destructive_patterns(self):
         self.assertIn("DROP TABLE", find_block_reason("psql -c 'DROP TABLE users'"))
+        self.assertIn("DROP TABLE", find_block_reason("DROP DATABASE prod"))
+        self.assertIn("DROP TABLE", find_block_reason("DROP SCHEMA public"))
         self.assertIn("TRUNCATE", find_block_reason("TRUNCATE audit_log"))
         self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users"))
+
+    def test_delete_from_requires_where_per_statement(self):
+        self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))
+        self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users; SELECT 1"))
+        self.assertIn("DELETE FROM", find_block_reason("SELECT 1; DELETE FROM users"))
 
     def test_blocks_force_push(self):
         self.assertIn("git push --force", find_block_reason("git push --force origin main"))
         self.assertIn("git push --force", find_block_reason("git push -f origin main"))
+        self.assertIn("git push --force", find_block_reason("git -C repo push --force origin main"))
+        self.assertIn("git push --force", find_block_reason("git push --force-with-lease origin main"))
+        self.assertTrue(has_forced_git_push("cd repo && git push -f"))
+        self.assertFalse(has_forced_git_push("git push origin main"))
 
 
 class HookIntegrationTests(unittest.TestCase):
@@ -76,6 +97,19 @@ class HookIntegrationTests(unittest.TestCase):
         self.assertIn("rm -rf", hook_output["permissionDecisionReason"])
         self.assertEqual(log_entry["command"], "rm -rf /important")
         self.assertEqual(log_entry["project_path"], "/work/project")
+
+    def test_non_bash_tool_is_allowed(self):
+        with tempfile.TemporaryDirectory() as temp_home:
+            output = self.run_hook(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "README.md"},
+                    "cwd": "/work/project",
+                },
+                Path(temp_home),
+            )
+        self.assertTrue(output["continue"])
 
 
 class InstallerTests(unittest.TestCase):

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -43,14 +43,20 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("DROP TABLE", find_block_reason("psql -c 'DROP TABLE users'"))
         self.assertIn("DROP TABLE", find_block_reason("DROP DATABASE prod"))
         self.assertIn("DROP TABLE", find_block_reason("DROP SCHEMA public"))
+        self.assertIn("DROP TABLE", find_block_reason("DROP INDEX users_email_idx"))
         self.assertIn("TRUNCATE", find_block_reason("TRUNCATE audit_log"))
         self.assertIn("TRUNCATE", find_block_reason("TRUNCATE TABLE audit_log"))
         self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users"))
+        self.assertIn("UPDATE", find_block_reason("UPDATE users SET admin = true"))
+        self.assertIn("ALTER TABLE DROP", find_block_reason("ALTER TABLE users DROP COLUMN email"))
 
     def test_delete_from_requires_where_per_statement(self):
         self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))
+        self.assertIsNone(find_block_reason("UPDATE users SET name = 'a' WHERE id = 1"))
         self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users; SELECT 1"))
         self.assertIn("DELETE FROM", find_block_reason("SELECT 1; DELETE FROM users"))
+        self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users -- WHERE id = 1"))
+        self.assertIn("UPDATE", find_block_reason("UPDATE users SET admin = true /* WHERE id = 1 */"))
 
     def test_blocks_force_push(self):
         self.assertIn("git push --force", find_block_reason("git push --force origin main"))
@@ -62,8 +68,16 @@ class DetectionTests(unittest.TestCase):
         self.assertTrue(has_forced_git_push("cd repo && git push -f"))
         self.assertFalse(has_forced_git_push("git push origin main"))
 
+    def test_blocks_destructive_git_cleanup(self):
+        self.assertIn("Git history", find_block_reason("git reset --hard HEAD~1"))
+        self.assertIn("Git history", find_block_reason("sudo git clean -fdx"))
+        self.assertIn("Git history", find_block_reason("git -C repo clean --force -d"))
+        self.assertIsNone(find_block_reason("git reset --soft HEAD~1"))
+        self.assertIsNone(find_block_reason("git clean -nfd"))
+
     def test_blocks_direct_block_device_writes(self):
         self.assertIn("block devices", find_block_reason("mkfs.ext4 /dev/sda1"))
+        self.assertIn("block devices", find_block_reason("mkswap /dev/sdb2"))
         self.assertIn("block devices", find_block_reason("dd if=image.iso of=/dev/sdb bs=4M"))
         self.assertTrue(has_block_device_write("echo 1 > /dev/sda"))
         self.assertFalse(has_block_device_write("dd if=/dev/zero of=./disk.img bs=1M count=1"))

--- a/hooks/pre-tool-use-block-destructive/test_block_destructive.py
+++ b/hooks/pre-tool-use-block-destructive/test_block_destructive.py
@@ -23,6 +23,9 @@ class DetectionTests(unittest.TestCase):
         self.assertIsNone(find_block_reason("rm -r build"))
         self.assertIsNone(find_block_reason("rm -f package-lock.json"))
         self.assertIsNone(find_block_reason("truncate -s 0 app.log"))
+        self.assertIsNone(find_block_reason("rg 'DROP TABLE' docs/"))
+        self.assertIsNone(find_block_reason("grep -R 'DELETE FROM users' docs/"))
+        self.assertIsNone(find_block_reason("ag 'UPDATE users SET admin = true' docs/"))
 
     def test_blocks_rm_rf_variants(self):
         self.assertIn("rm -rf", find_block_reason("rm -rf /tmp/build"))
@@ -49,6 +52,7 @@ class DetectionTests(unittest.TestCase):
         self.assertIn("DELETE FROM", find_block_reason("DELETE FROM users"))
         self.assertIn("UPDATE", find_block_reason("UPDATE users SET admin = true"))
         self.assertIn("ALTER TABLE DROP", find_block_reason("ALTER TABLE users DROP COLUMN email"))
+        self.assertIn("DROP TABLE", find_block_reason("rg 'DROP TABLE' docs && psql -c 'DROP TABLE users'"))
 
     def test_delete_from_requires_where_per_statement(self):
         self.assertIsNone(find_block_reason("DELETE FROM users WHERE id = 1"))


### PR DESCRIPTION
## Summary
- Adds a Claude Code PreToolUse hook that blocks destructive Bash commands before execution
- Logs blocked attempts to ~/.claude/hooks/blocked.log with timestamp, command, project path, and reason
- Includes a one-command installer, settings example, README, and unit tests

## Blocked patterns
- rm -rf / rm -fr
- DROP TABLE
- git push --force / git push -f
- TRUNCATE
- DELETE FROM without WHERE

## Tests
- python -m unittest discover -s hooks/pre-tool-use-block-destructive -p 'test_*.py'

Closes #3