### PR TITLE
Add changelog generator script

### DIFF
--- a/README-changelog-generator.md
+++ b/README-changelog-generator.md
@@ -1,0 +1,19 @@
+# Git Changelog Generator
+
+Generate a structured `CHANGELOG.md` from commits since the latest git tag.
+
+## Setup / usage
+
+1. Copy `changelog.sh` into any git repo.
+2. Run `bash changelog.sh` (or `bash changelog.sh RELEASE_NOTES.md`).
+3. Review the generated Added / Fixed / Changed / Removed sections before release.
+
+## Categorization
+
+The script reads non-merge commits since the latest tag (`git describe --tags --abbrev=0`). If no tag exists, it uses the full repo history.
+
+- `feat`, `feature`, `add` → Added
+- `fix`, `bugfix`, `hotfix` → Fixed
+- `remove`, `delete`, `drop` → Removed
+- `refactor`, `change`, `update`, `docs`, `chore`, `ci`, `test` → Changed
+- uncategorized commits → Other

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+Generated 2026-05-21 from git history from repository start.
+
+### Added
+- feat: initial README with bounty board (1aeae2a)
+
+### Fixed
+- None
+
+### Changed
+- None
+
+### Removed
+- None
+

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out="${1:-CHANGELOG.md}"
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: run inside a git repository" >&2
+  exit 1
+fi
+
+last_tag=""
+if last_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+  range="${last_tag}..HEAD"
+  since="since ${last_tag}"
+else
+  range="HEAD"
+  since="from repository start"
+fi
+
+added=()
+fixed=()
+changed=()
+removed=()
+other=()
+while IFS=$'\t' read -r hash subject; do
+  [ -n "${hash:-}" ] || continue
+  line="- ${subject} (${hash})"
+  lower=$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    feat:*|feature:*|add:*|added:*|*" add "*|*" adds "*) added+=("$line") ;;
+    fix:*|bugfix:*|hotfix:*|*" fix "*|*" fixes "*|*" bug "*) fixed+=("$line") ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|*" remove "*|*" delete "*) removed+=("$line") ;;
+    refactor:*|change:*|changed:*|update:*|docs:*|chore:*|ci:*|test:*) changed+=("$line") ;;
+    *) other+=("$line") ;;
+  esac
+done < <(git log --no-merges --pretty=format:'%h%x09%s' "$range")
+
+emit_section() {
+  local title="$1"
+  local array_name="$2"
+  local -n items="$array_name"
+  printf '### %s\n' "$title"
+  if ((${#items[@]})); then printf '%s\n' "${items[@]}"; else printf -- '- None\n'; fi
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated %s from git history %s.\n\n' "$(date -u +%Y-%m-%d)" "$since"
+  emit_section Added added
+  emit_section Fixed fixed
+  emit_section Changed changed
+  emit_section Removed removed
+  if ((${#other[@]})); then emit_section Other other; fi
+} > "$out"
+
+echo "wrote $out"


### PR DESCRIPTION
/claim #1

## Summary
- add `changelog.sh` to generate a structured `CHANGELOG.md` from git history
- categorize commits into Added / Fixed / Changed / Removed, plus Other when needed
- include 3-step usage docs and a generated sample output

## Test
- `bash changelog.sh SAMPLE_CHANGELOG.md`
- `bash -n changelog.sh`

## Sample output
See `SAMPLE_CHANGELOG.md` generated against this repo.
