### PR TITLE
Add destructive command blocker hook

### DIFF
--- a/.claude/hooks/destructive-command-blocker.py
+++ b/.claude/hooks/destructive-command-blocker.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Claude Code pre-tool-use hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCK_EXIT_CODE = 2
+
+
+def hook_dir() -> Path:
+    return Path.home() / ".claude" / "hooks"
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+        return payload if isinstance(payload, dict) else {}
+    except json.JSONDecodeError:
+        return {"tool_input": {"command": raw}}
+
+
+def command_from_payload(payload: dict[str, Any]) -> str:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command") or tool_input.get("cmd")
+        if isinstance(command, str):
+            return command
+    command = payload.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def project_path_from_payload(payload: dict[str, Any]) -> str:
+    candidates = [
+        payload.get("cwd"),
+        payload.get("project_path"),
+        payload.get("workspace"),
+    ]
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        candidates.extend([tool_input.get("cwd"), tool_input.get("workdir")])
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return os.getcwd()
+
+
+def is_bash_tool(payload: dict[str, Any]) -> bool:
+    tool_name = payload.get("tool_name") or payload.get("tool")
+    if not tool_name:
+        return True
+    return str(tool_name).lower() in {"bash", "shell", "terminal"}
+
+
+def delete_from_without_where(command: str) -> bool:
+    for statement in re.split(r";|\n", command, flags=re.IGNORECASE):
+        normalized = " ".join(statement.split()).lower()
+        if normalized.startswith("delete from ") and " where " not in f" {normalized} ":
+            return True
+    return False
+
+
+def blocked_reason(command: str) -> str | None:
+    checks: list[tuple[str, str]] = [
+        (r"(?i)(^|[;&|]\s*)rm\s+-(?:[^\s]*r[^\s]*f|[^\s]*f[^\s]*r)\b", "rm -rf recursively deletes files without confirmation"),
+        (r"(?i)\bdrop\s+table\b", "DROP TABLE can delete database tables"),
+        (r"(?i)\bgit\s+push\b[^\n;]*\s--force(?:\b|=)", "git push --force can overwrite remote history"),
+        (r"(?i)\btruncate\b", "TRUNCATE can remove table data"),
+    ]
+    for pattern, reason in checks:
+        if re.search(pattern, command):
+            return reason
+    if delete_from_without_where(command):
+        return "DELETE FROM without a WHERE clause can remove all rows"
+    return None
+
+
+def log_blocked(command: str, project_path: str, reason: str) -> None:
+    directory = hook_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    log_path = directory / "blocked.log"
+    is_new = not log_path.exists()
+    with log_path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        if is_new:
+            writer.writerow(["timestamp", "attempted_command", "project_path", "reason"])
+        writer.writerow([
+            datetime.now(timezone.utc).isoformat(),
+            command,
+            project_path,
+            reason,
+        ])
+
+
+def main() -> int:
+    payload = load_payload()
+    if not is_bash_tool(payload):
+        return 0
+
+    command = command_from_payload(payload)
+    if not command:
+        return 0
+
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    project_path = project_path_from_payload(payload)
+    log_blocked(command, project_path, reason)
+    print(
+        "Blocked destructive Bash command: "
+        + reason
+        + ". Review the command manually before proceeding.",
+        file=sys.stderr,
+    )
+    return BLOCK_EXIT_CODE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/destructive-command-blocker.py
+++ b/.claude/hooks/destructive-command-blocker.py
@@ -13,9 +13,6 @@ from pathlib import Path
 from typing import Any
 
 
-BLOCK_EXIT_CODE = 2
-
-
 def hook_dir() -> Path:
     return Path.home() / ".claude" / "hooks"
 
@@ -103,6 +100,16 @@ def log_blocked(command: str, project_path: str, reason: str) -> None:
         ])
 
 
+def deny_response(reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
 def main() -> int:
     payload = load_payload()
     if not is_bash_tool(payload):
@@ -118,13 +125,13 @@ def main() -> int:
 
     project_path = project_path_from_payload(payload)
     log_blocked(command, project_path, reason)
-    print(
+    message = (
         "Blocked destructive Bash command: "
         + reason
-        + ". Review the command manually before proceeding.",
-        file=sys.stderr,
+        + ". Review the command manually before proceeding."
     )
-    return BLOCK_EXIT_CODE
+    print(json.dumps(deny_response(message), indent=2))
+    return 0
 
 
 if __name__ == "__main__":

--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/hooks/destructive-command-blocker.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/DESTRUCTIVE_COMMAND_HOOK.md
+++ b/DESTRUCTIVE_COMMAND_HOOK.md
@@ -19,7 +19,7 @@ Run these two commands from the repository root:
 
 ## Behavior
 
-The hook reads Claude Code pre-tool-use JSON from stdin, checks Bash commands, and exits with code 2 when a command should be blocked. The stderr message explains the reason so Claude can revise its action. Normal Bash commands exit 0 and are not logged.
+The hook reads Claude Code pre-tool-use JSON from stdin, checks Bash commands, and returns Claude Code's documented hookSpecificOutput JSON with permissionDecision: "deny" when a command should be blocked. The denial reason explains why the command was blocked so Claude can revise its action. Normal Bash commands exit 0 with no output and are not logged.
 
 Blocked attempts are logged as CSV with:
 

--- a/DESTRUCTIVE_COMMAND_HOOK.md
+++ b/DESTRUCTIVE_COMMAND_HOOK.md
@@ -1,0 +1,33 @@
+# Destructive Command Blocker Hook
+
+This is a Claude Code pre-tool-use hook for Bash. It blocks dangerous commands before they run and logs every blocked attempt to ~/.claude/hooks/blocked.log.
+
+## Blocks
+
+- rm -rf
+- DROP TABLE
+- git push --force
+- TRUNCATE
+- DELETE FROM without a WHERE clause
+
+## Install
+
+Run these two commands from the repository root:
+
+    mkdir -p ~/.claude/hooks && cp .claude/hooks/destructive-command-blocker.py ~/.claude/hooks/destructive-command-blocker.py
+    cp .claude/settings.example.json ~/.claude/settings.json
+
+## Behavior
+
+The hook reads Claude Code pre-tool-use JSON from stdin, checks Bash commands, and exits with code 2 when a command should be blocked. The stderr message explains the reason so Claude can revise its action. Normal Bash commands exit 0 and are not logged.
+
+Blocked attempts are logged as CSV with:
+
+- timestamp
+- attempted command
+- project path
+- reason
+
+## Validate
+
+    python test_destructive_command_blocker.py

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ You're in the right place.
 
 ---
 
+## Submission: Destructive Command Blocker Hook
+
+This repository includes a Claude Code pre-tool-use Bash hook for bounty #3.
+
+See DESTRUCTIVE_COMMAND_HOOK.md for the two-command install, blocked command patterns, logging format, and validation command.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/test_destructive_command_blocker.py
+++ b/test_destructive_command_blocker.py
@@ -37,8 +37,12 @@ def run_hook(command: str, home: Path) -> subprocess.CompletedProcess[str]:
 
 def assert_blocked(command: str, home: Path) -> None:
     result = run_hook(command, home)
-    assert result.returncode == 2, (command, result.returncode, result.stderr)
-    assert "Blocked destructive Bash command" in result.stderr
+    assert result.returncode == 0, (command, result.returncode, result.stderr)
+    response = json.loads(result.stdout)
+    output = response["hookSpecificOutput"]
+    assert output["hookEventName"] == "PreToolUse"
+    assert output["permissionDecision"] == "deny"
+    assert "Blocked destructive Bash command" in output["permissionDecisionReason"]
 
 
 def assert_allowed(command: str, home: Path) -> None:

--- a/test_destructive_command_blocker.py
+++ b/test_destructive_command_blocker.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Smoke tests for the destructive command hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parent / ".claude" / "hooks" / "destructive-command-blocker.py"
+
+
+def run_hook(command: str, home: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": command,
+            "cwd": "/tmp/project",
+        },
+    }
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def assert_blocked(command: str, home: Path) -> None:
+    result = run_hook(command, home)
+    assert result.returncode == 2, (command, result.returncode, result.stderr)
+    assert "Blocked destructive Bash command" in result.stderr
+
+
+def assert_allowed(command: str, home: Path) -> None:
+    result = run_hook(command, home)
+    assert result.returncode == 0, (command, result.returncode, result.stderr)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temporary:
+        home = Path(temporary)
+        for command in [
+            "rm -rf build",
+            "DROP TABLE users",
+            "git push --force origin main",
+            "TRUNCATE audit_log",
+            "DELETE FROM users",
+        ]:
+            assert_blocked(command, home)
+
+        for command in [
+            "ls -la",
+            "git status --short",
+            "DELETE FROM users WHERE id = 1",
+            "rm -r build",
+        ]:
+            assert_allowed(command, home)
+
+        log_path = home / ".claude" / "hooks" / "blocked.log"
+        assert log_path.exists()
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "attempted_command" in log_text
+        assert "/tmp/project" in log_text
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Claude Code pre-tool-use hook for bounty #3.

The submission includes:

- Python hook under .claude/hooks/destructive-command-blocker.py
- Claude Code hooks settings example under .claude/settings.example.json
- Two-command installation instructions in DESTRUCTIVE_COMMAND_HOOK.md
- Smoke tests in test_destructive_command_blocker.py

## Coverage

The hook blocks:

- rm -rf
- DROP TABLE
- git push --force
- TRUNCATE
- DELETE FROM without a WHERE clause

Blocked attempts are logged to ~/.claude/hooks/blocked.log with timestamp, attempted command, project path, and reason. Normal Bash commands exit 0 and are not logged.

## Validation

- python test_destructive_command_blocker.py

## Bounty

Closes #3.
