### PR TITLE
Add generate changelog skill

### DIFF
--- a/.claude/commands/generate-changelog.md
+++ b/.claude/commands/generate-changelog.md
@@ -1,0 +1,7 @@
+# Generate Changelog
+
+Run this command from the repository root:
+
+    bash changelog.sh
+
+The script finds the latest Git tag with git describe --tags --abbrev=0 and writes CHANGELOG.md from commits since that tag. If the repository has no tags, it documents all commits reachable from HEAD.

--- a/GENERATE_CHANGELOG.md
+++ b/GENERATE_CHANGELOG.md
@@ -6,7 +6,10 @@ This submission adds a Claude Code slash command and a Bash script for bounty #1
 
 Copy the command into a Claude-enabled repository and keep changelog.sh at the repository root:
 
-    mkdir -p .claude/commands && cp .claude/commands/generate-changelog.md .claude/commands/generate-changelog.md
+    mkdir -p .claude/commands
+    cp path/to/generate-changelog.md .claude/commands/generate-changelog.md
+    cp path/to/changelog.sh ./changelog.sh
+    chmod +x ./changelog.sh
 
 ## Usage
 
@@ -32,3 +35,4 @@ The script writes CHANGELOG.md. Pass a custom output path as the first argument:
 ## Validation
 
     bash changelog.sh /tmp/CHANGELOG.md
+    node scripts/verify-changelog-output.mjs /tmp/CHANGELOG.md

--- a/GENERATE_CHANGELOG.md
+++ b/GENERATE_CHANGELOG.md
@@ -1,0 +1,34 @@
+# Generate Changelog Skill
+
+This submission adds a Claude Code slash command and a Bash script for bounty #1.
+
+## Install
+
+Copy the command into a Claude-enabled repository and keep changelog.sh at the repository root:
+
+    mkdir -p .claude/commands && cp .claude/commands/generate-changelog.md .claude/commands/generate-changelog.md
+
+## Usage
+
+Run either:
+
+    /generate-changelog
+
+or:
+
+    bash changelog.sh
+
+The script writes CHANGELOG.md. Pass a custom output path as the first argument:
+
+    bash changelog.sh RELEASE_NOTES.md
+
+## Behavior
+
+- Fetches commits since the latest Git tag.
+- Falls back to all commits if no tag exists.
+- Groups entries into Features, Fixes, Documentation, Tests, Maintenance, and Other using conventional commit prefixes when available.
+- Includes subject, short hash, commit date, and author for each entry.
+
+## Validation
+
+    bash changelog.sh /tmp/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ You're in the right place.
 
 ---
 
+## Submission: Generate Changelog Skill
+
+This repository includes a Claude Code /generate-changelog command and a bash changelog.sh script for bounty #1.
+
+See GENERATE_CHANGELOG.md for setup, usage, behavior, and validation.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This repository includes a Claude Code /generate-changelog command and a bash ch
 
 See GENERATE_CHANGELOG.md for setup, usage, behavior, and validation.
 
+Validate the included smoke output with:
+
+    node scripts/verify-changelog-output.mjs generated-changelog-smoke.md
+
 ---
 
 ## Rules

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="CHANGELOG.md"
+if [ "$#" -gt 0 ]; then
+  output_file="$1"
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+if latest_tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+  range="$latest_tag..HEAD"
+  heading="Changes since $latest_tag"
+else
+  range="HEAD"
+  heading="All changes"
+fi
+
+repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+today="$(date +%Y-%m-%d)"
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+{
+  echo "# Changelog"
+  echo
+  echo "Generated for $repo_name on $today."
+  echo
+  echo "## $heading"
+  echo
+} >"$tmp_file"
+
+commit_count="$(git rev-list --count "$range" 2>/dev/null || echo 0)"
+if [ "$commit_count" = "0" ]; then
+  echo "- No commits found for this range." >>"$tmp_file"
+else
+  git log "$range" --date=short --pretty=format:'%H%x1f%h%x1f%ad%x1f%s%x1f%an' |
+  while IFS=$'\x1f' read -r full_hash short_hash commit_date subject author || [ -n "$full_hash" ]; do
+    type="Other"
+    case "$subject" in
+      feat:*|feat\(*) type="Features" ;;
+      fix:*|fix\(*) type="Fixes" ;;
+      docs:*|docs\(*) type="Documentation" ;;
+      test:*|tests:*|test\(*|tests\(*) type="Tests" ;;
+      chore:*|build:*|ci:*|refactor:*|perf:*|style:*|chore\(*|build\(*|ci\(*|refactor\(*|perf\(*|style\(*) type="Maintenance" ;;
+    esac
+    printf '%s\t- %s (%s, %s, %s)\n' "$type" "$subject" "$short_hash" "$commit_date" "$author"
+  done |
+  awk -F '\t' '
+    { entries[$1]=entries[$1] $2 "\n" }
+    END {
+      split("Features Fixes Documentation Tests Maintenance Other", preferred, " ")
+      for (i=1; i<=length(preferred); i++) {
+        bucket=preferred[i]
+        if (entries[bucket] != "") {
+          print "### " bucket
+          printf "%s\n", entries[bucket]
+        }
+      }
+    }
+  ' >>"$tmp_file"
+fi
+
+mv "$tmp_file" "$output_file"
+trap - EXIT
+echo "Wrote $output_file"

--- a/generated-changelog-smoke.md
+++ b/generated-changelog-smoke.md
@@ -1,0 +1,9 @@
+# Changelog
+
+Generated for claude-builders-bounty-changelog-git on 2026-05-22.
+
+## All changes
+
+### Features
+- feat: initial README with bounty board (1aeae2a, 2026-03-27, claudebounty)
+

--- a/scripts/verify-changelog-output.mjs
+++ b/scripts/verify-changelog-output.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const target = process.argv[2] || 'generated-changelog-smoke.md';
+const changelog = readFileSync(target, 'utf8');
+
+const required = [
+  '# Changelog',
+  'Generated for ',
+  '## ',
+];
+
+const problems = [];
+
+for (const token of required) {
+  if (!changelog.includes(token)) {
+    problems.push('Missing required changelog content: ' + token);
+  }
+}
+
+if (!/### (Features|Fixes|Documentation|Tests|Maintenance|Other)/.test(changelog) &&
+    !/- No commits found for this range\./.test(changelog)) {
+  problems.push('Missing a recognized category section or no-commits fallback.');
+}
+
+if (!/\([0-9a-f]{7,}, \d{4}-\d{2}-\d{2}, .+\)/.test(changelog) &&
+    !/- No commits found for this range\./.test(changelog)) {
+  problems.push('Commit entries should include short hash, date, and author metadata.');
+}
+
+if (problems.length > 0) {
+  console.error('Changelog verification failed for ' + target + ':');
+  for (const problem of problems) {
+    console.error('- ' + problem);
+  }
+  process.exit(1);
+}
+
+console.log('Changelog verification passed for ' + target + '.');


### PR DESCRIPTION
## Summary

Adds a Claude Code /generate-changelog command and a bash changelog.sh script for bounty #1.

The submission includes:

- Root changelog.sh script
- .claude/commands/generate-changelog.md slash-command instructions
- GENERATE_CHANGELOG.md setup and usage documentation
- generated-changelog-smoke.md output from a real run against this repository

## Validation

- C:\tools\msys64\usr\bin\bash.exe -lc "export PATH='/c/Program Files/Git/cmd':/usr/local/bin:/usr/bin:/bin:$PATH; export TMPDIR=/c/Projects/ehub-system/revenue-sprint/work/claude-builders-bounty-changelog-git; cd /c/Projects/ehub-system/revenue-sprint/work/claude-builders-bounty-changelog-git && /usr/bin/bash changelog.sh generated-changelog-smoke.md"

## Bounty

Closes #1.
