### PR TITLE
Add Next.js SQLite CLAUDE template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ You're in the right place.
 
 ---
 
+## Submission: Next.js + SQLite CLAUDE.md Template
+
+This repository includes an opinionated CLAUDE.md template for bounty #2.
+
+See TEMPLATE_NEXTJS_SQLITE.md and templates/nextjs-sqlite-saas/CLAUDE.md for project structure, naming conventions, DB migration rules, dev commands, and implementation patterns.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ This repository includes an opinionated CLAUDE.md template for bounty #2.
 
 See TEMPLATE_NEXTJS_SQLITE.md and templates/nextjs-sqlite-saas/CLAUDE.md for project structure, naming conventions, DB migration rules, dev commands, and implementation patterns.
 
+Validate the template with:
+
+    node scripts/verify-nextjs-sqlite-template.mjs
+
+Manual smoke prompts for checking Claude Code behavior are in templates/nextjs-sqlite-saas/smoke-prompts.md.
+
 ---
 
 ## Rules

--- a/TEMPLATE_NEXTJS_SQLITE.md
+++ b/TEMPLATE_NEXTJS_SQLITE.md
@@ -21,4 +21,8 @@ Then edit command names only if the target project uses a package manager or ORM
 
 ## Validation
 
-The template is plain Markdown and does not require runtime dependencies. Review it for project-specific command names before use.
+Run the zero-dependency verifier:
+
+    node scripts/verify-nextjs-sqlite-template.mjs
+
+Then copy the template into a greenfield project and try the smoke prompts in templates/nextjs-sqlite-saas/smoke-prompts.md. Claude Code should apply the SQLite, migration, tenant-scoping, billing, and testing rules without asking for a different stack or generic project context.

--- a/TEMPLATE_NEXTJS_SQLITE.md
+++ b/TEMPLATE_NEXTJS_SQLITE.md
@@ -1,0 +1,24 @@
+# Next.js + SQLite SaaS CLAUDE.md Template
+
+This submission adds an opinionated CLAUDE.md template for bounty #2.
+
+## Contents
+
+- Project structure for App Router SaaS projects.
+- Naming conventions for components, hooks, server actions, routes, schema, migrations, and environment variables.
+- Database and SQLite rules for prepared queries, transactions, indexes, timestamps, and tenant scoping.
+- Migration rules, including append-only migrations and destructive-change safeguards.
+- Auth/session, billing, UI, testing, and finish-check guidance.
+- Commands for install, development, linting, typechecking, tests, and database migration workflows.
+
+## Usage
+
+Copy the template into a Next.js + SQLite SaaS repository:
+
+    cp templates/nextjs-sqlite-saas/CLAUDE.md CLAUDE.md
+
+Then edit command names only if the target project uses a package manager or ORM script with different names.
+
+## Validation
+
+The template is plain Markdown and does not require runtime dependencies. Review it for project-specific command names before use.

--- a/scripts/verify-nextjs-sqlite-template.mjs
+++ b/scripts/verify-nextjs-sqlite-template.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const template = readFileSync('templates/nextjs-sqlite-saas/CLAUDE.md', 'utf8');
+
+const requiredSections = [
+  '## Project Shape',
+  '## Commands',
+  '## Naming',
+  '## Data And SQLite',
+  '## Migrations',
+  '## Auth And Sessions',
+  '## Billing',
+  '## Testing',
+  '## Patterns To Follow',
+  '## Patterns To Avoid',
+  '## Before Finishing A Change',
+];
+
+const requiredPhrases = [
+  'Next.js App Router',
+  'SQLite',
+  'prepared statements',
+  'transactions',
+  'tenant-owned query',
+  'workspace/account ownership checks',
+  'Migrations are append-only after merge',
+  'Do not run production migrations from build scripts',
+  'Do not trust client-sent user IDs',
+  'webhook signatures',
+  'idempotent',
+  'Running worker infrastructure during next build',
+];
+
+const forbiddenGenericMarkers = [
+  '[PROJECT_NAME]',
+  '[TODO]',
+  'your project here',
+  'lorem ipsum',
+];
+
+const problems = [];
+
+for (const section of requiredSections) {
+  if (!template.includes(section)) {
+    problems.push('Missing required section: ' + section);
+  }
+}
+
+for (const phrase of requiredPhrases) {
+  if (!template.includes(phrase)) {
+    problems.push('Missing required guidance: ' + phrase);
+  }
+}
+
+for (const marker of forbiddenGenericMarkers) {
+  if (template.toLowerCase().includes(marker.toLowerCase())) {
+    problems.push('Template still contains generic placeholder: ' + marker);
+  }
+}
+
+if (!/## Patterns To Avoid[\s\S]*because|## Patterns To Avoid[\s\S]*why|Do not/.test(template)) {
+  problems.push('Anti-pattern section must include concrete reasons or clear prohibitions.');
+}
+
+if (problems.length > 0) {
+  console.error('Next.js SQLite CLAUDE.md verification failed:');
+  for (const problem of problems) {
+    console.error('- ' + problem);
+  }
+  process.exit(1);
+}
+
+console.log('Next.js SQLite CLAUDE.md verification passed.');

--- a/templates/nextjs-sqlite-saas/CLAUDE.md
+++ b/templates/nextjs-sqlite-saas/CLAUDE.md
@@ -1,0 +1,123 @@
+# CLAUDE.md - Next.js + SQLite SaaS
+
+Use this file as the project instruction file for a SaaS app built with Next.js App Router and SQLite through better-sqlite3, Drizzle, Prisma, or Turso/libSQL.
+
+## Project Shape
+
+- app/: routes, layouts, loading states, server actions, and route handlers.
+- components/: reusable UI components. Keep route-specific components near the route when they are not shared.
+- lib/: framework-neutral helpers, auth/session helpers, billing helpers, and typed service clients.
+- db/: schema, migrations, seed scripts, database client, and query helpers.
+- server/: server-only business workflows that do not belong in route files.
+- tests/: unit, integration, and end-to-end tests.
+- public/: static assets only.
+
+Prefer server components by default. Add "use client" only for interactive state, browser APIs, or client-only libraries.
+
+## Commands
+
+- pnpm install: install dependencies.
+- pnpm dev: run the local app.
+- pnpm lint: run lint checks.
+- pnpm typecheck: run TypeScript without emitting files.
+- pnpm test: run unit/integration tests.
+- pnpm db:generate: generate migration files when the ORM requires it.
+- pnpm db:migrate: apply local migrations.
+- pnpm db:studio: inspect local data when the project provides a studio.
+
+If the project uses npm, yarn, or bun instead of pnpm, keep the same command intent and use the repository's configured package manager.
+
+## Naming
+
+- React components: PascalCase.tsx.
+- Hooks: useThing.ts.
+- Server actions: thing.action.ts or colocated actions.ts.
+- Route handlers: app/**/route.ts.
+- Database schema files: db/schema.ts or db/schema/*.ts.
+- Migrations: timestamped, ordered, and immutable after merge.
+- Environment variables: uppercase snake case and documented in .env.example.
+
+Use clear domain names over generic nouns. Prefer SubscriptionPlan, WorkspaceMember, and InvoiceLineItem over Data, Item, or Record.
+
+## TypeScript
+
+- Keep strict TypeScript enabled.
+- Do not use any unless the external API is genuinely untyped and the value is narrowed immediately.
+- Validate untrusted input with a schema library such as Zod, Valibot, or the repository's existing validator.
+- Keep shared types close to the boundary that owns them. Export domain types from db/ or server/ only when multiple modules need them.
+
+## Data And SQLite
+
+- Treat SQLite as a production database with explicit transaction boundaries.
+- Use prepared statements or ORM query builders. Do not concatenate untrusted strings into SQL.
+- Wrap multi-step writes in transactions.
+- Add indexes for foreign keys and frequently filtered columns.
+- Store timestamps consistently as ISO strings or integer milliseconds; do not mix formats.
+- Keep soft-delete, audit, and tenant scoping rules consistent across all queries.
+- In SaaS code, every tenant-owned query must include workspace/account ownership checks.
+
+## Migrations
+
+- Migrations are append-only after merge.
+- Never edit a migration that has already been applied in a shared environment. Add a new migration instead.
+- Every schema change should include either a migration or a clear explanation for why one is not needed.
+- Destructive migrations require a data-preservation plan, rollback notes, and a test against a copy of representative data.
+- Backfills should be idempotent and safe to rerun.
+- Do not run production migrations from build scripts.
+
+## Auth And Sessions
+
+- Keep auth checks on the server.
+- Route handlers and server actions must verify the current user before reading or mutating tenant data.
+- Do not trust client-sent user IDs, workspace IDs, roles, plan names, or prices.
+- Store secrets only in environment variables or the platform secret store.
+- Never log session tokens, OAuth tokens, API keys, reset tokens, or payment provider secrets.
+
+## Billing
+
+- Treat billing webhooks as the source of truth for subscription state.
+- Verify webhook signatures before processing events.
+- Make webhook handlers idempotent by storing processed event IDs.
+- Keep pricing IDs in environment variables or a typed config module.
+- Do not calculate final invoice totals on the client.
+
+## UI Patterns
+
+- Use existing design system components before adding new primitives.
+- Keep forms accessible with labels, errors, disabled states, and pending states.
+- Prefer server-rendered data tables and paginated queries for large collections.
+- Client state should represent UI state, not authoritative business state.
+- Avoid marketing-style layouts inside operational SaaS dashboards.
+
+## Testing
+
+- Add focused tests for authorization checks, tenant scoping, billing webhooks, and migration/backfill behavior.
+- Test server actions and route handlers with authenticated and unauthenticated cases.
+- For SQLite query changes, include at least one test that exercises real SQL against a test database.
+- Update snapshots only when the rendered behavior intentionally changes.
+
+## Patterns To Follow
+
+- Small route handlers that call typed server functions.
+- Explicit input validation at the boundary.
+- Centralized database client creation.
+- Transaction helpers for multi-step writes.
+- Idempotent webhook and background job handlers.
+- .env.example kept in sync with required environment variables.
+
+## Patterns To Avoid
+
+- Client-side authorization gates as the only protection.
+- Raw SQL string interpolation with user input.
+- Hidden database writes inside React render paths.
+- Schema changes without migrations.
+- Running worker infrastructure during next build.
+- Committing local SQLite database files, .env, logs, or generated secrets.
+
+## Before Finishing A Change
+
+1. Run the smallest relevant test or typecheck.
+2. Confirm migrations are present and ordered when schema changed.
+3. Check tenant ownership on all new data reads and writes.
+4. Update .env.example and setup docs for new configuration.
+5. Summarize validation performed and any remaining risk.

--- a/templates/nextjs-sqlite-saas/smoke-prompts.md
+++ b/templates/nextjs-sqlite-saas/smoke-prompts.md
@@ -1,0 +1,36 @@
+# Next.js SQLite CLAUDE.md Smoke Prompts
+
+Use these prompts after copying templates/nextjs-sqlite-saas/CLAUDE.md into a greenfield Next.js App Router + SQLite SaaS repository as CLAUDE.md.
+
+## Prompt 1
+
+Add a workspace_members table, migration, and helper query for checking whether the current user can access a workspace.
+
+Expected behavior from Claude Code:
+
+- Places schema and migration work under the database layer.
+- Uses a migration instead of editing prior migrations.
+- Includes workspace/account ownership checks.
+- Adds a focused SQL-backed test or explains the exact missing test harness.
+
+## Prompt 2
+
+Add a billing webhook route for subscription updates.
+
+Expected behavior from Claude Code:
+
+- Verifies webhook signatures.
+- Stores processed event IDs for idempotency.
+- Keeps pricing IDs in typed server config or environment variables.
+- Avoids trusting client-provided plan names or prices.
+
+## Prompt 3
+
+Add a dashboard table listing invoices for the signed-in workspace.
+
+Expected behavior from Claude Code:
+
+- Uses server-side authorization before reading tenant data.
+- Keeps large lists paginated or query-limited.
+- Uses existing UI components before adding new primitives.
+- Keeps client state limited to UI state.


### PR DESCRIPTION
## Summary

Adds an opinionated CLAUDE.md template for a Next.js App Router + SQLite SaaS project for bounty #2.

The template covers:

- Project structure
- Naming conventions
- Database and SQLite rules
- Migration rules
- Auth/session and billing rules
- Dev commands
- Patterns to follow and avoid
- Testing and final validation checklist

## Validation

- rg -n "Project Shape|Naming|Migrations|pnpm dev|SQLite|Patterns To Avoid" templates/nextjs-sqlite-saas/CLAUDE.md TEMPLATE_NEXTJS_SQLITE.md

## Bounty

Closes #2.
