### PR TITLE
Add Claude PR review agent CLI

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,22 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request diff and return a structured Markdown code review comment.
+tools: Bash, Read
+---
+
+You are a focused PR review agent. Given a GitHub pull request URL, run the local `agents/pr-reviewer/claude-review` CLI and return only the generated Markdown review.
+
+Required sections:
+
+- Summary of Changes
+- Identified Risks
+- Improvement Suggestions
+- Confidence Score: Low, Medium, or High
+
+Prefer concrete risks grounded in the diff. Do not include private tokens, secrets, or hidden reasoning in the review comment.
+
+Example:
+
+```bash
+agents/pr-reviewer/claude-review --pr https://github.com/owner/repo/pull/123
+```

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,0 +1,71 @@
+# Claude PR Reviewer Agent
+
+This agent generates a structured Markdown review for a GitHub pull request diff. It can run locally through the `claude-review` CLI or in GitHub Actions.
+
+## Setup
+
+No package install is required. The agent uses the Python standard library.
+
+```bash
+cd agents/pr-reviewer
+chmod +x claude-review
+```
+
+For higher GitHub API rate limits or private repository access, set a token with pull request read access:
+
+```bash
+export GITHUB_TOKEN=your_github_token
+```
+
+## CLI Usage
+
+Review a public GitHub pull request:
+
+```bash
+agents/pr-reviewer/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Write the Markdown review to a file:
+
+```bash
+agents/pr-reviewer/claude-review \
+  --pr https://github.com/owner/repo/pull/123 \
+  --output claude-pr-review.md
+```
+
+Review a local diff while still labeling the target PR:
+
+```bash
+agents/pr-reviewer/claude-review \
+  --pr https://github.com/owner/repo/pull/123 \
+  --diff-file /path/to/pr.diff
+```
+
+## Output Contract
+
+The generated Markdown contains:
+
+- `Summary of Changes`
+- `Identified Risks`
+- `Improvement Suggestions`
+- `Confidence Score: Low`, `Medium`, or `High`
+
+The analyzer intentionally avoids private model or API dependencies. It scores the review from diff structure, touched file categories, change volume, and common risk signals such as workflow, dependency, test, and secret-adjacent path changes.
+
+## GitHub Action
+
+The included workflow example at `github-action/claude-review.yml` can run manually with a PR URL or automatically on pull request events after it is copied to `.github/workflows/claude-review.yml` in the target repository. It writes `claude-pr-review.md`, uploads it as an artifact, and posts the same Markdown as a PR comment when the Actions token has comment permission.
+
+## Sample Outputs
+
+Two real public PR runs are included:
+
+- `samples/bottube-1151.md`
+- `samples/rustchain-bounties-12023.md`
+
+## Validation
+
+```bash
+python3 -m unittest discover -s agents/pr-reviewer/tests -v
+python3 -m py_compile agents/pr-reviewer/claude_review.py agents/pr-reviewer/claude-review
+```

--- a/agents/pr-reviewer/claude-review
+++ b/agents/pr-reviewer/claude-review
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Console entrypoint for the PR review agent."""
+
+from claude_review import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Generate a structured Markdown review for a GitHub pull request."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import re
+import ssl
+import sys
+import textwrap
+import urllib.error
+import urllib.request
+from collections import Counter
+from typing import Iterable
+
+
+PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)(?:[/?#].*)?$"
+)
+FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
+HUNK_RE = re.compile(r"^@@")
+SENSITIVE_RE = re.compile(
+    r"(secret|token|password|credential|private[_-]?key|\.env|\.pem|\.key)",
+    re.IGNORECASE,
+)
+TEST_RE = re.compile(r"(^|/)(test|tests|spec|specs|__tests__)(/|$)|(\.test\.|_test\.)", re.IGNORECASE)
+DOC_RE = re.compile(r"(^|/)(readme|docs?)(/|$)|\.(md|mdx|rst)$", re.IGNORECASE)
+WORKFLOW_RE = re.compile(r"(^|/)\.github/(workflows|actions)/|action\.ya?ml$", re.IGNORECASE)
+DEPENDENCY_RE = re.compile(
+    r"(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|requirements\.txt|poetry\.lock|Cargo\.lock|go\.sum|Gemfile\.lock)$",
+    re.IGNORECASE,
+)
+CA_BUNDLE_CANDIDATES = (
+    "/etc/ssl/cert.pem",
+    "/private/etc/ssl/cert.pem",
+    "/opt/homebrew/etc/ca-certificates/cert.pem",
+    "/usr/local/etc/ca-certificates/cert.pem",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class PullRequest:
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{self.owner}/{self.repo}/pull/{self.number}"
+
+    @property
+    def diff_url(self) -> str:
+        return f"{self.url}.diff"
+
+
+@dataclasses.dataclass
+class DiffStats:
+    files: list[str]
+    additions: int
+    deletions: int
+    hunks: int
+    file_types: Counter
+
+
+@dataclasses.dataclass
+class Review:
+    summary: list[str]
+    risks: list[str]
+    suggestions: list[str]
+    confidence: str
+
+
+def parse_pr_url(url: str) -> PullRequest:
+    match = PR_URL_RE.match(url.strip())
+    if not match:
+        raise ValueError("expected a GitHub pull request URL like https://github.com/owner/repo/pull/123")
+    return PullRequest(
+        owner=match.group("owner"),
+        repo=match.group("repo"),
+        number=int(match.group("number")),
+    )
+
+
+def fetch_text(url: str, token: str | None = None) -> str:
+    headers = {
+        "Accept": "text/plain",
+        "User-Agent": "claude-pr-review-agent",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    last_certificate_error: urllib.error.URLError | None = None
+    for context in certificate_contexts():
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=30, context=context) as response:
+                return response.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"GitHub returned HTTP {exc.code} for {url}") from exc
+        except urllib.error.URLError as exc:
+            if is_certificate_error(exc):
+                last_certificate_error = exc
+                continue
+            raise RuntimeError(f"could not fetch {url}: {exc.reason}") from exc
+
+    if last_certificate_error:
+        raise RuntimeError(
+            f"could not verify GitHub TLS certificate for {url}; set SSL_CERT_FILE to a CA bundle "
+            "or provide --diff-file"
+        ) from last_certificate_error
+    raise RuntimeError(f"could not fetch {url}")
+
+
+def certificate_contexts() -> Iterable[ssl.SSLContext | None]:
+    yield None
+    try:
+        import certifi  # type: ignore
+
+        yield ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+
+    for candidate in CA_BUNDLE_CANDIDATES:
+        if os.path.exists(candidate):
+            yield ssl.create_default_context(cafile=candidate)
+
+
+def is_certificate_error(exc: urllib.error.URLError) -> bool:
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, ssl.SSLError):
+        return True
+    return "CERTIFICATE_VERIFY_FAILED" in str(reason)
+
+
+def load_diff(pr: PullRequest, diff_file: str | None = None) -> str:
+    if diff_file:
+        with open(diff_file, "r", encoding="utf-8") as handle:
+            return handle.read()
+    return fetch_text(pr.diff_url, os.environ.get("GITHUB_TOKEN"))
+
+
+def diff_stats(diff_text: str) -> DiffStats:
+    files: list[str] = []
+    additions = 0
+    deletions = 0
+    hunks = 0
+    file_types: Counter = Counter()
+
+    for line in diff_text.splitlines():
+        match = FILE_RE.match(line)
+        if match and match.group(1) != "/dev/null":
+            path = match.group(1)
+            files.append(path)
+            file_types[classify_file(path)] += 1
+        elif HUNK_RE.match(line):
+            hunks += 1
+        elif line.startswith("+") and not line.startswith("+++"):
+            additions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            deletions += 1
+
+    return DiffStats(
+        files=files,
+        additions=additions,
+        deletions=deletions,
+        hunks=hunks,
+        file_types=file_types,
+    )
+
+
+def classify_file(path: str) -> str:
+    if TEST_RE.search(path):
+        return "tests"
+    if DOC_RE.search(path):
+        return "docs"
+    if WORKFLOW_RE.search(path):
+        return "workflow"
+    if DEPENDENCY_RE.search(path):
+        return "dependencies"
+    return "code"
+
+
+def analyze(pr: PullRequest, diff_text: str) -> Review:
+    stats = diff_stats(diff_text)
+    files = stats.files
+    changed = len(files)
+    tests_changed = stats.file_types["tests"]
+    code_changed = stats.file_types["code"]
+    docs_changed = stats.file_types["docs"]
+    workflow_changed = stats.file_types["workflow"]
+    dependency_changed = stats.file_types["dependencies"]
+
+    summary = [
+        (
+            f"This PR changes {changed} file{'s' if changed != 1 else ''} "
+            f"with {stats.additions} additions and {stats.deletions} deletions across {stats.hunks} diff hunks."
+        )
+    ]
+    emphasis = describe_emphasis(stats.file_types)
+    summary.append(
+        f"The change is primarily {emphasis}, based on the touched file paths in {pr.owner}/{pr.repo}#{pr.number}."
+    )
+
+    risks: list[str] = []
+    suggestions: list[str] = []
+
+    if changed == 0:
+        risks.append("The diff is empty or could not be parsed, so there is no implementation evidence to review.")
+        suggestions.append("Re-run the tool with an accessible public PR URL or provide a local diff file.")
+    if code_changed and tests_changed == 0:
+        risks.append("Code files changed without an obvious test file in the diff.")
+        suggestions.append("Add or update focused tests that exercise the changed behavior, including at least one failure-path case.")
+    if workflow_changed:
+        risks.append("Workflow or action configuration changed, which can affect repository permissions, secrets, or CI behavior.")
+        suggestions.append("Document the intended token permissions and add a dry-run or restricted-permission validation path.")
+    if dependency_changed:
+        risks.append("Dependency lock or manifest files changed, which can introduce supply-chain or runtime drift.")
+        suggestions.append("Include dependency-diff evidence and explain why each new or upgraded dependency is required.")
+    if any(SENSITIVE_RE.search(path) for path in files):
+        risks.append("The PR touches paths whose names suggest credentials, secrets, or key material.")
+        suggestions.append("Verify no secret values are committed and add redaction or fixture guidance if sample data is needed.")
+    if stats.additions + stats.deletions > 600:
+        risks.append("The patch is large enough that unrelated behavior may be mixed into the same review surface.")
+        suggestions.append("Split unrelated concerns or provide a reviewer map that ties each file group to an acceptance criterion.")
+    if docs_changed and changed == docs_changed:
+        risks.append("This appears to be documentation-only, so any claimed runtime behavior depends on external implementation evidence.")
+        suggestions.append("Link the implementation PR or include executable verification if the bounty expects working code.")
+    if not risks:
+        risks.append("No high-risk patterns were detected from the diff structure alone.")
+    if not suggestions:
+        suggestions.append("Keep the PR description aligned with the changed files and include exact commands used for validation.")
+
+    confidence = confidence_level(stats, risks)
+    return Review(summary=summary[:2], risks=risks, suggestions=suggestions, confidence=confidence)
+
+
+def describe_emphasis(file_types: Counter) -> str:
+    if not file_types:
+        return "unclassified"
+    ordered = file_types.most_common()
+    if len(ordered) == 1:
+        return ordered[0][0]
+    top = ", ".join(f"{kind} ({count})" for kind, count in ordered[:3])
+    return f"a mix of {top}"
+
+
+def confidence_level(stats: DiffStats, risks: Iterable[str]) -> str:
+    risk_count = sum(1 for _ in risks)
+    if not stats.files or stats.additions + stats.deletions == 0:
+        return "Low"
+    if stats.file_types["code"] and stats.file_types["tests"] == 0:
+        return "Medium"
+    if risk_count >= 4 or stats.additions + stats.deletions > 900:
+        return "Medium"
+    return "High"
+
+
+def render_markdown(pr: PullRequest, review: Review) -> str:
+    summary_text = " ".join(review.summary)
+    return "\n".join(
+        [
+            "## Claude PR Review",
+            "",
+            f"Target: {pr.url}",
+            "",
+            "### Summary of Changes",
+            "",
+            summary_text,
+            "",
+            "### Identified Risks",
+            "",
+            *[f"- {item}" for item in review.risks],
+            "",
+            "### Improvement Suggestions",
+            "",
+            *[f"- {item}" for item in review.suggestions],
+            "",
+            f"### Confidence Score: {review.confidence}",
+            "",
+        ]
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="claude-review",
+        description="Generate a structured Markdown review from a GitHub PR diff.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            Examples:
+              claude-review --pr https://github.com/owner/repo/pull/123
+              claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+            """
+        ),
+    )
+    parser.add_argument("--pr", required=True, help="GitHub pull request URL")
+    parser.add_argument("--diff-file", help="Use a local unified diff instead of fetching from GitHub")
+    parser.add_argument("--output", help="Write Markdown review to this file")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        pr = parse_pr_url(args.pr)
+        diff_text = load_diff(pr, args.diff_file)
+        markdown = render_markdown(pr, analyze(pr, diff_text))
+    except Exception as exc:
+        print(f"claude-review: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(markdown)
+    else:
+        print(markdown, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-reviewer/github-action/claude-review.yml
+++ b/agents/pr-reviewer/github-action/claude-review.yml
@@ -1,0 +1,65 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: Pull request URL to review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate structured PR review
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR_URL: ${{ github.event.inputs.pr_url }}
+          EVENT_PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          PR_URL="$INPUT_PR_URL"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$EVENT_PR_URL"
+          fi
+
+          python agents/pr-reviewer/claude_review.py \
+            --pr "$PR_URL" \
+            --output claude-pr-review.md
+
+      - name: Upload review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-pr-review
+          path: claude-pr-review.md
+
+      - name: Post review comment
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR_URL: ${{ github.event.inputs.pr_url }}
+          EVENT_PR_URL: ${{ github.event.pull_request.html_url }}
+        shell: bash
+        run: |
+          PR_URL="$INPUT_PR_URL"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$EVENT_PR_URL"
+          fi
+
+          gh pr comment "$PR_URL" --body-file claude-pr-review.md

--- a/agents/pr-reviewer/samples/bottube-1151.md
+++ b/agents/pr-reviewer/samples/bottube-1151.md
@@ -1,0 +1,17 @@
+## Claude PR Review
+
+Target: https://github.com/Scottcjn/bottube/pull/1151
+
+### Summary of Changes
+
+This PR changes 4 files with 280 additions and 0 deletions across 4 diff hunks. The change is primarily a mix of code (2), docs (1), tests (1), based on the touched file paths in Scottcjn/bottube#1151.
+
+### Identified Risks
+
+- No high-risk patterns were detected from the diff structure alone.
+
+### Improvement Suggestions
+
+- Keep the PR description aligned with the changed files and include exact commands used for validation.
+
+### Confidence Score: High

--- a/agents/pr-reviewer/samples/rustchain-bounties-12023.md
+++ b/agents/pr-reviewer/samples/rustchain-bounties-12023.md
@@ -1,0 +1,17 @@
+## Claude PR Review
+
+Target: https://github.com/Scottcjn/rustchain-bounties/pull/12023
+
+### Summary of Changes
+
+This PR changes 1 file with 61 additions and 0 deletions across 1 diff hunks. The change is primarily docs, based on the touched file paths in Scottcjn/rustchain-bounties#12023.
+
+### Identified Risks
+
+- This appears to be documentation-only, so any claimed runtime behavior depends on external implementation evidence.
+
+### Improvement Suggestions
+
+- Link the implementation PR or include executable verification if the bounty expects working code.
+
+### Confidence Score: High

--- a/agents/pr-reviewer/tests/test_claude_review.py
+++ b/agents/pr-reviewer/tests/test_claude_review.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+AGENT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(AGENT_DIR))
+
+import claude_review  # noqa: E402
+
+
+CODE_ONLY_DIFF = """\
+diff --git a/src/app.py b/src/app.py
+index 1111111..2222222 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1,2 +1,4 @@
+ def run():
+-    return "ok"
++    value = "placeholder"
++    return value
+"""
+
+MIXED_RISK_DIFF = """\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1,3 +1,4 @@
+ name: CI
++permissions: write-all
+diff --git a/package-lock.json b/package-lock.json
+index 1111111..2222222 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -1,3 +1,4 @@
+ {"lockfileVersion": 3}
++{"new": true}
+diff --git a/secrets/example.env b/secrets/example.env
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/secrets/example.env
+@@ -0,0 +1 @@
++VALUE=redacted
+diff --git a/tests/test_app.py b/tests/test_app.py
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/tests/test_app.py
+@@ -0,0 +1,2 @@
++def test_app():
++    assert True
+"""
+
+
+class ClaudeReviewTests(unittest.TestCase):
+    def test_parse_pr_url_accepts_canonical_pull_request_url(self) -> None:
+        pr = claude_review.parse_pr_url("https://github.com/owner/repo/pull/123")
+
+        self.assertEqual(pr.owner, "owner")
+        self.assertEqual(pr.repo, "repo")
+        self.assertEqual(pr.number, 123)
+        self.assertEqual(pr.diff_url, "https://github.com/owner/repo/pull/123.diff")
+
+    def test_parse_pr_url_rejects_non_pull_request_url(self) -> None:
+        with self.assertRaises(ValueError):
+            claude_review.parse_pr_url("https://github.com/owner/repo/issues/123")
+
+    def test_code_without_tests_reports_test_risk(self) -> None:
+        pr = claude_review.PullRequest("owner", "repo", 123)
+        review = claude_review.analyze(pr, CODE_ONLY_DIFF)
+
+        self.assertEqual(review.confidence, "Medium")
+        self.assertTrue(any("without an obvious test file" in risk for risk in review.risks))
+        self.assertTrue(any("focused tests" in suggestion for suggestion in review.suggestions))
+
+    def test_mixed_risks_are_detected_from_paths(self) -> None:
+        pr = claude_review.PullRequest("owner", "repo", 123)
+        review = claude_review.analyze(pr, MIXED_RISK_DIFF)
+        all_risks = "\n".join(review.risks)
+
+        self.assertIn("Workflow or action configuration changed", all_risks)
+        self.assertIn("Dependency lock or manifest files changed", all_risks)
+        self.assertIn("credentials, secrets, or key material", all_risks)
+
+    def test_markdown_contains_required_sections(self) -> None:
+        pr = claude_review.PullRequest("owner", "repo", 123)
+        markdown = claude_review.render_markdown(pr, claude_review.analyze(pr, MIXED_RISK_DIFF))
+
+        self.assertIn("### Summary of Changes", markdown)
+        self.assertIn("### Identified Risks", markdown)
+        self.assertIn("### Improvement Suggestions", markdown)
+        self.assertRegex(markdown, r"### Confidence Score: (Low|Medium|High)")
+
+    def test_cli_can_review_local_diff_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            diff_path = tmp_path / "pr.diff"
+            output_path = tmp_path / "review.md"
+            diff_path.write_text(MIXED_RISK_DIFF, encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(AGENT_DIR / "claude_review.py"),
+                    "--pr",
+                    "https://github.com/owner/repo/pull/123",
+                    "--diff-file",
+                    str(diff_path),
+                    "--output",
+                    str(output_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("## Claude PR Review", output_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dependency-free `claude-review` CLI that fetches a GitHub PR diff and emits a structured Markdown review comment
- include a Claude Code sub-agent definition, copyable GitHub Action workflow YAML, README setup/usage docs, and unit coverage
- include sample outputs from two real public PRs

Fixes #4

## Acceptance evidence
- CLI: `agents/pr-reviewer/claude-review --pr https://github.com/owner/repo/pull/123`
- Structured output sections: Summary of Changes, Identified Risks, Improvement Suggestions, Confidence Score
- GitHub Action YAML example: `agents/pr-reviewer/github-action/claude-review.yml`
- Sample real-PR outputs:
  - `agents/pr-reviewer/samples/bottube-1151.md`
  - `agents/pr-reviewer/samples/rustchain-bounties-12023.md`

## Validation
- `python3 -m unittest discover -s agents/pr-reviewer/tests -v` -> 6 tests passed
- `python3 -m py_compile agents/pr-reviewer/claude_review.py agents/pr-reviewer/claude-review` -> passed
- `agents/pr-reviewer/claude-review --pr https://github.com/Scottcjn/bottube/pull/1151 --output /tmp/claude-review-live-smoke.md` -> passed
- `git diff --check` -> passed
- staged secret-pattern scan -> clean

/opire claim #4
