### PR TITLE
Add destructive command guard hook

### DIFF
--- a/.claude/hooks/destructive_command_guard.py
+++ b/.claude/hooks/destructive_command_guard.py
@@ -15,15 +15,11 @@ from typing import Iterable
 
 BLOCKED_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
 SHELL_SEPARATORS = {";", "&&", "||", "|", "\n"}
-RM_WRAPPERS = {"sudo", "doas", "command", "builtin", "time", "env"}
+COMMAND_WRAPPERS = {"sudo", "doas", "command", "builtin", "time"}
 
 DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
 TRUNCATE_RE = re.compile(r"\btruncate(?:\s+table)?\b", re.IGNORECASE)
 DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
-GIT_FORCE_PUSH_RE = re.compile(
-    r"(?:^|[;&|]\s*)git\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?|-f)\b",
-    re.IGNORECASE,
-)
 
 
 def tokenize(command: str) -> list[str]:
@@ -48,6 +44,46 @@ def command_segments(tokens: Iterable[str]) -> Iterable[list[str]]:
 
 def is_assignment(token: str) -> bool:
     return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=.*", token))
+
+
+def strip_env_args(segment: list[str]) -> list[str]:
+    segment = segment[1:]
+    while segment:
+        token = segment[0]
+        if is_assignment(token):
+            segment = segment[1:]
+            continue
+        if token in {"-i", "--ignore-environment"}:
+            segment = segment[1:]
+            continue
+        if token in {"-u", "--unset"} and len(segment) > 1:
+            segment = segment[2:]
+            continue
+        if token.startswith("--unset="):
+            segment = segment[1:]
+            continue
+        break
+    return segment
+
+
+def strip_command_prefix(segment: list[str]) -> list[str]:
+    while segment:
+        while segment and is_assignment(segment[0]):
+            segment = segment[1:]
+        if not segment:
+            return segment
+
+        command_name = os.path.basename(segment[0])
+        if command_name in COMMAND_WRAPPERS:
+            segment = segment[1:]
+            if segment and segment[0] == "--":
+                segment = segment[1:]
+            continue
+        if command_name == "env":
+            segment = strip_env_args(segment)
+            continue
+        return segment
+    return segment
 
 
 def rm_has_recursive_force_options(args: Iterable[str]) -> bool:
@@ -84,15 +120,61 @@ def contains_rm_rf(command: str) -> bool:
         return bool(re.search(r"\brm\s+-[A-Za-z]*r[A-Za-z]*f|rm\s+-[A-Za-z]*f[A-Za-z]*r", command))
 
     for segment in command_segments(tokens):
-        while segment and is_assignment(segment[0]):
-            segment = segment[1:]
-        while segment and segment[0] in RM_WRAPPERS:
-            segment = segment[1:]
-            if segment and segment[0] == "--":
-                segment = segment[1:]
+        segment = strip_command_prefix(segment)
         if segment and os.path.basename(segment[0]) == "rm" and rm_has_recursive_force_options(segment[1:]):
             return True
 
+    return False
+
+
+def skip_git_global_option(args: list[str], index: int) -> int:
+    option = args[index]
+    if option in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
+        return index + 2
+    if option.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
+        return index + 1
+    return index
+
+
+def git_push_has_force(args: Iterable[str]) -> bool:
+    for arg in args:
+        if arg == "--":
+            continue
+        if arg.startswith("--force"):
+            return True
+        if arg.startswith("-") and not arg.startswith("--") and "f" in arg.lstrip("-"):
+            return True
+    return False
+
+
+def contains_git_force_push(command: str) -> bool:
+    try:
+        tokens = tokenize(command)
+    except ValueError:
+        return bool(
+            re.search(
+                r"(?:^|[;&|]\s*)git\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?(?:=\S+)?|-f)\b",
+                command,
+                re.IGNORECASE,
+            )
+        )
+
+    for segment in command_segments(tokens):
+        segment = strip_command_prefix(segment)
+        if not segment or os.path.basename(segment[0]) != "git":
+            continue
+
+        index = 1
+        while index < len(segment):
+            next_index = skip_git_global_option(segment, index)
+            if next_index != index:
+                index = next_index
+                continue
+            break
+
+        if index < len(segment) and segment[index] == "push":
+            if git_push_has_force(segment[index + 1 :]):
+                return True
     return False
 
 
@@ -111,7 +193,7 @@ def contains_delete_without_where(command: str) -> bool:
 def blocked_reason(command: str) -> str | None:
     if contains_rm_rf(command):
         return "Blocked destructive rm command using recursive and force options."
-    if GIT_FORCE_PUSH_RE.search(command):
+    if contains_git_force_push(command):
         return "Blocked force push command."
     if DROP_TABLE_RE.search(command):
         return "Blocked destructive SQL DROP TABLE command."

--- a/.claude/hooks/destructive_command_guard.py
+++ b/.claude/hooks/destructive_command_guard.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+BLOCKED_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
+SHELL_SEPARATORS = {";", "&&", "||", "|", "\n"}
+RM_WRAPPERS = {"sudo", "doas", "command", "builtin", "time", "env"}
+
+DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\btruncate(?:\s+table)?\b", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+GIT_FORCE_PUSH_RE = re.compile(
+    r"(?:^|[;&|]\s*)git\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?|-f)\b",
+    re.IGNORECASE,
+)
+
+
+def tokenize(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def command_segments(tokens: Iterable[str]) -> Iterable[list[str]]:
+    current: list[str] = []
+    for token in tokens:
+        if token in SHELL_SEPARATORS:
+            if current:
+                yield current
+                current = []
+            continue
+        current.append(token)
+    if current:
+        yield current
+
+
+def is_assignment(token: str) -> bool:
+    return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=.*", token))
+
+
+def rm_has_recursive_force_options(args: Iterable[str]) -> bool:
+    has_recursive = False
+    has_force = False
+
+    for arg in args:
+        if arg == "--":
+            break
+        if not arg.startswith("-") or arg == "-":
+            continue
+        if arg in {"--recursive", "--dir"}:
+            has_recursive = True
+            continue
+        if arg == "--force":
+            has_force = True
+            continue
+        if arg.startswith("--"):
+            continue
+
+        short_opts = arg.lstrip("-")
+        if "r" in short_opts or "R" in short_opts:
+            has_recursive = True
+        if "f" in short_opts:
+            has_force = True
+
+    return has_recursive and has_force
+
+
+def contains_rm_rf(command: str) -> bool:
+    try:
+        tokens = tokenize(command)
+    except ValueError:
+        return bool(re.search(r"\brm\s+-[A-Za-z]*r[A-Za-z]*f|rm\s+-[A-Za-z]*f[A-Za-z]*r", command))
+
+    for segment in command_segments(tokens):
+        while segment and is_assignment(segment[0]):
+            segment = segment[1:]
+        while segment and segment[0] in RM_WRAPPERS:
+            segment = segment[1:]
+            if segment and segment[0] == "--":
+                segment = segment[1:]
+        if segment and os.path.basename(segment[0]) == "rm" and rm_has_recursive_force_options(segment[1:]):
+            return True
+
+    return False
+
+
+def contains_delete_without_where(command: str) -> bool:
+    statements = re.split(r";|&&|\|\|", command)
+    for statement in statements:
+        match = DELETE_FROM_RE.search(statement)
+        if not match:
+            continue
+        tail = statement[match.end() :]
+        if not re.search(r"\bwhere\b", tail, re.IGNORECASE):
+            return True
+    return False
+
+
+def blocked_reason(command: str) -> str | None:
+    if contains_rm_rf(command):
+        return "Blocked destructive rm command using recursive and force options."
+    if GIT_FORCE_PUSH_RE.search(command):
+        return "Blocked force push command."
+    if DROP_TABLE_RE.search(command):
+        return "Blocked destructive SQL DROP TABLE command."
+    if TRUNCATE_RE.search(command):
+        return "Blocked destructive SQL TRUNCATE command."
+    if contains_delete_without_where(command):
+        return "Blocked SQL DELETE FROM command without a WHERE clause."
+    return None
+
+
+def log_block(command: str, project_path: str, reason: str) -> None:
+    BLOCKED_LOG.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_path": project_path,
+        "command": command,
+        "reason": reason,
+    }
+    with BLOCKED_LOG.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def deny(reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        deny("Blocked Bash command because the hook received invalid JSON.")
+        return 0
+
+    if event.get("tool_name") != "Bash":
+        return 0
+
+    command = event.get("tool_input", {}).get("command", "")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    project_path = (
+        event.get("cwd")
+        or event.get("project_path")
+        or event.get("workspace")
+        or os.getcwd()
+    )
+    log_block(command, str(project_path), reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/destructive_command_guard.py
+++ b/.claude/hooks/destructive_command_guard.py
@@ -53,6 +53,9 @@ def strip_env_args(segment: list[str]) -> list[str]:
         if is_assignment(token):
             segment = segment[1:]
             continue
+        if token == "--":
+            segment = segment[1:]
+            break
         if token in {"-i", "--ignore-environment"}:
             segment = segment[1:]
             continue
@@ -131,6 +134,18 @@ def skip_git_global_option(args: list[str], index: int) -> int:
     option = args[index]
     if option in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
         return index + 2
+    if option in {
+        "--bare",
+        "--no-pager",
+        "--no-replace-objects",
+        "--literal-pathspecs",
+        "--glob-pathspecs",
+        "--noglob-pathspecs",
+        "--icase-pathspecs",
+        "--no-optional-locks",
+        "-P",
+    }:
+        return index + 1
     if option.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
         return index + 1
     return index

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ It blocks high-risk Bash commands before execution, logs each blocked attempt to
 Blocked patterns:
 
 - `rm` commands using both recursive and force options, including `rm -rf`, `rm -fr`,
-  and `rm --recursive --force`.
+  `rm --recursive --force`, and wrapper forms like `sudo rm -rf` or
+  `env VAR=value rm -rf`.
 - `DROP TABLE`.
 - `TRUNCATE` and `TRUNCATE TABLE`.
 - `DELETE FROM` when the statement has no `WHERE` clause.
-- `git push --force`, `git push --force-with-lease`, and `git push -f`.
+- `git push --force`, `git push --force-with-lease`, and `git push -f`,
+  including common global-option forms like `git -C repo push -f`.
 
 Install in 2 commands:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,71 @@ You're in the right place.
 
 ---
 
+## Destructive Command Guard Hook
+
+This repository includes a Claude Code `PreToolUse` hook at `.claude/hooks/destructive_command_guard.py`.
+It blocks high-risk Bash commands before execution, logs each blocked attempt to
+`~/.claude/hooks/blocked.log`, and returns a clear denial message to Claude Code.
+
+Blocked patterns:
+
+- `rm` commands using both recursive and force options, including `rm -rf`, `rm -fr`,
+  and `rm --recursive --force`.
+- `DROP TABLE`.
+- `TRUNCATE` and `TRUNCATE TABLE`.
+- `DELETE FROM` when the statement has no `WHERE` clause.
+- `git push --force`, `git push --force-with-lease`, and `git push -f`.
+
+Install in 2 commands:
+
+```bash
+mkdir -p ~/.claude/hooks && cp .claude/hooks/destructive_command_guard.py ~/.claude/hooks/destructive_command_guard.py && chmod +x ~/.claude/hooks/destructive_command_guard.py
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+settings_path = Path.home() / ".claude" / "settings.json"
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+settings = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+hooks = settings.setdefault("hooks", {})
+pre_tool = hooks.setdefault("PreToolUse", [])
+entry = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": str(Path.home() / ".claude" / "hooks" / "destructive_command_guard.py"),
+        }
+    ],
+}
+if entry not in pre_tool:
+    pre_tool.append(entry)
+settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+PY
+```
+
+Example blocked event:
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/build"},"cwd":"/project"}' \
+  | ~/.claude/hooks/destructive_command_guard.py
+```
+
+Example allowed event:
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"npm test"},"cwd":"/project"}' \
+  | ~/.claude/hooks/destructive_command_guard.py
+```
+
+Run tests:
+
+```bash
+python3 -m unittest tests/test_destructive_command_guard.py
+```
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/tests/test_destructive_command_guard.py
+++ b/tests/test_destructive_command_guard.py
@@ -45,6 +45,7 @@ class DestructiveCommandGuardTests(unittest.TestCase):
         self.assertTrue(self.hook.blocked_reason("rm -rf /tmp/build"))
         self.assertTrue(self.hook.blocked_reason("sudo rm -fr ./dist"))
         self.assertTrue(self.hook.blocked_reason("env FOO=1 rm -rf ./dist"))
+        self.assertTrue(self.hook.blocked_reason("env -- rm -rf ./dist"))
         self.assertTrue(self.hook.blocked_reason("env -u FOO BAR=1 rm -Rf ./dist"))
         self.assertTrue(self.hook.blocked_reason("rm --recursive --force ./cache"))
 
@@ -54,6 +55,7 @@ class DestructiveCommandGuardTests(unittest.TestCase):
         self.assertTrue(self.hook.blocked_reason("git push --force origin main"))
         self.assertTrue(self.hook.blocked_reason("git -C repo push --force-with-lease origin main"))
         self.assertTrue(self.hook.blocked_reason("git -c safe.directory=* push -f origin main"))
+        self.assertTrue(self.hook.blocked_reason("git --no-pager push -f origin main"))
         self.assertTrue(self.hook.blocked_reason("git push -f origin main"))
         self.assertTrue(self.hook.blocked_reason("psql -c 'DELETE FROM users'"))
 

--- a/tests/test_destructive_command_guard.py
+++ b/tests/test_destructive_command_guard.py
@@ -44,12 +44,16 @@ class DestructiveCommandGuardTests(unittest.TestCase):
     def test_blocks_rm_recursive_force_variants(self):
         self.assertTrue(self.hook.blocked_reason("rm -rf /tmp/build"))
         self.assertTrue(self.hook.blocked_reason("sudo rm -fr ./dist"))
+        self.assertTrue(self.hook.blocked_reason("env FOO=1 rm -rf ./dist"))
+        self.assertTrue(self.hook.blocked_reason("env -u FOO BAR=1 rm -Rf ./dist"))
         self.assertTrue(self.hook.blocked_reason("rm --recursive --force ./cache"))
 
     def test_blocks_sql_and_force_push_patterns(self):
         self.assertTrue(self.hook.blocked_reason("psql -c 'DROP TABLE users'"))
         self.assertTrue(self.hook.blocked_reason("mysql -e 'TRUNCATE TABLE sessions'"))
         self.assertTrue(self.hook.blocked_reason("git push --force origin main"))
+        self.assertTrue(self.hook.blocked_reason("git -C repo push --force-with-lease origin main"))
+        self.assertTrue(self.hook.blocked_reason("git -c safe.directory=* push -f origin main"))
         self.assertTrue(self.hook.blocked_reason("git push -f origin main"))
         self.assertTrue(self.hook.blocked_reason("psql -c 'DELETE FROM users'"))
 
@@ -57,6 +61,7 @@ class DestructiveCommandGuardTests(unittest.TestCase):
         self.assertIsNone(self.hook.blocked_reason("ls -la && npm test"))
         self.assertIsNone(self.hook.blocked_reason("rm -r ./build"))
         self.assertIsNone(self.hook.blocked_reason("git push origin main"))
+        self.assertIsNone(self.hook.blocked_reason("git -C repo status --short"))
         self.assertIsNone(
             self.hook.blocked_reason("psql -c 'DELETE FROM users WHERE id = 1'")
         )

--- a/tests/test_destructive_command_guard.py
+++ b/tests/test_destructive_command_guard.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / ".claude" / "hooks" / "destructive_command_guard.py"
+
+
+def load_hook_module():
+    sys.dont_write_bytecode = True
+    spec = importlib.util.spec_from_file_location("destructive_command_guard", HOOK)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_hook(command, tmp_path):
+    event = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/workspace/example",
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(event),
+        text=True,
+        capture_output=True,
+        env={"HOME": str(tmp_path)},
+        check=False,
+    )
+
+
+class DestructiveCommandGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.hook = load_hook_module()
+
+    def test_blocks_rm_recursive_force_variants(self):
+        self.assertTrue(self.hook.blocked_reason("rm -rf /tmp/build"))
+        self.assertTrue(self.hook.blocked_reason("sudo rm -fr ./dist"))
+        self.assertTrue(self.hook.blocked_reason("rm --recursive --force ./cache"))
+
+    def test_blocks_sql_and_force_push_patterns(self):
+        self.assertTrue(self.hook.blocked_reason("psql -c 'DROP TABLE users'"))
+        self.assertTrue(self.hook.blocked_reason("mysql -e 'TRUNCATE TABLE sessions'"))
+        self.assertTrue(self.hook.blocked_reason("git push --force origin main"))
+        self.assertTrue(self.hook.blocked_reason("git push -f origin main"))
+        self.assertTrue(self.hook.blocked_reason("psql -c 'DELETE FROM users'"))
+
+    def test_allows_normal_bash_and_delete_with_where(self):
+        self.assertIsNone(self.hook.blocked_reason("ls -la && npm test"))
+        self.assertIsNone(self.hook.blocked_reason("rm -r ./build"))
+        self.assertIsNone(self.hook.blocked_reason("git push origin main"))
+        self.assertIsNone(
+            self.hook.blocked_reason("psql -c 'DELETE FROM users WHERE id = 1'")
+        )
+
+    def test_hook_outputs_denial_and_logs_blocked_attempt(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            result = run_hook("rm -rf /tmp/build", tmp_path)
+            self.assertEqual(result.returncode, 0)
+            output = json.loads(result.stdout)
+            decision = output["hookSpecificOutput"]
+            self.assertEqual(decision["hookEventName"], "PreToolUse")
+            self.assertEqual(decision["permissionDecision"], "deny")
+            self.assertIn("rm command", decision["permissionDecisionReason"])
+
+            log_path = tmp_path / ".claude" / "hooks" / "blocked.log"
+            log_entry = json.loads(log_path.read_text().strip())
+            self.assertEqual(log_entry["command"], "rm -rf /tmp/build")
+            self.assertEqual(log_entry["project_path"], "/workspace/example")
+
+    def test_hook_allows_safe_command_without_output(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            result = run_hook("python3 -m unittest", tmp_path)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((tmp_path / ".claude" / "hooks" / "blocked.log").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses claude-builders-bounty/claude-builders-bounty#3.

Adds a Python Claude Code `PreToolUse` hook that blocks destructive Bash commands before execution.

Changes:

- Adds `.claude/hooks/destructive_command_guard.py`.
- Blocks recursive-force `rm` commands, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without a `WHERE` clause, and force pushes.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
- Returns a Claude Code hook denial payload with a clear reason.
- Documents installation in two commands and includes blocked/allowed examples.
- Adds standard-library unit tests for destructive and safe command paths.

Verification:

```bash
env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test_destructive_command_guard.py
```

Observed local result:

```text
Ran 5 tests in 0.045s
OK
```
