### PR TITLE
feat: Add destructive bash command blocker hook for Claude Code (Bounty #3)

### DIFF
--- a/.attribution.json
+++ b/.attribution.json
@@ -1,0 +1,5 @@
+{
+    "date": "2026-05-23T13:21:43Z",
+    "platform_config": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding. You are pair programming with a USER to solve their coding task.",
+    "tool": "Antigravity"
+}

--- a/hooks/destructive-bash-blocker/README.md
+++ b/hooks/destructive-bash-blocker/README.md
@@ -1,0 +1,45 @@
+# Destructive Command Blocker Hook for Claude Code
+
+A robust `pre-tool-use` security hook for Claude Code that intercepts and blocks dangerous bash commands before they run, preventing accidental data loss or destructive operations.
+
+## Features
+
+Blocks the following destructive patterns case-insensitively with regex word-boundary checks to prevent false positives:
+- `rm -rf` (recursive force removals)
+- `DROP TABLE` (SQL database drops)
+- `git push --force` and `git push -f` (force-pushing git branches)
+- `TRUNCATE` (SQL truncate table commands)
+- `DELETE FROM` (SQL deletes missing a `WHERE` clause)
+
+All blocked attempts are logged to `~/.claude/hooks/blocked.log` with a timestamp, attempted command, and directory path.
+
+---
+
+## Installation
+
+Install in a single command:
+
+```bash
+chmod +x install.sh && ./install.sh
+```
+
+---
+
+## Verification
+
+To run the automated test suite:
+
+```bash
+python3 test_hook.py
+```
+
+### Manual Verification
+You can manually test command interception using `echo`:
+
+```bash
+# Verify safe command is allowed (exits 0 and prints original input)
+echo '{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}' | ~/.claude/hooks/pre-tool-use
+
+# Verify destructive command is blocked (exits 2 and prints error details)
+echo '{"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}}' | ~/.claude/hooks/pre-tool-use
+```

--- a/hooks/destructive-bash-blocker/install.sh
+++ b/hooks/destructive-bash-blocker/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Make hook executable locally
+chmod +x pre-tool-use.py
+
+# Create the hook directory
+mkdir -p ~/.claude/hooks
+
+# Copy and rename script to pre-tool-use in the hooks directory
+cp pre-tool-use.py ~/.claude/hooks/pre-tool-use
+chmod +x ~/.claude/hooks/pre-tool-use
+
+echo "Destructive command blocker hook installed successfully to ~/.claude/hooks/pre-tool-use"

--- a/hooks/destructive-bash-blocker/pre-tool-use.py
+++ b/hooks/destructive-bash-blocker/pre-tool-use.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import sys
+import os
+import json
+import re
+from datetime import datetime
+
+def log_blocked(command, reason):
+    log_dir = os.path.expanduser("~/.claude/hooks")
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, "blocked.log")
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    project_path = os.getcwd()
+    log_entry = f"[{timestamp}] Project: {project_path} | Command: {command.strip()} | Reason: {reason}\n"
+    with open(log_path, "a") as f:
+        f.write(log_entry)
+
+def main():
+    try:
+        input_data = sys.stdin.read()
+        if not input_data.strip():
+            sys.exit(0)
+            
+        try:
+            data = json.loads(input_data)
+        except json.JSONDecodeError:
+            # Fallback to raw string command
+            data = {"tool_name": "Bash", "tool_input": {"command": input_data}}
+            
+        command = ""
+        tool_input = data.get("tool_input", {})
+        if isinstance(tool_input, dict):
+            command = tool_input.get("command", "")
+        elif isinstance(tool_input, str):
+            command = tool_input
+            
+        if not command:
+            command = data.get("command", "")
+            
+        if not command:
+            sys.stdout.write(input_data)
+            sys.exit(0)
+            
+        blocked = False
+        reason = ""
+        
+        # 1. rm -rf
+        if re.search(r"\brm\s+-[a-zA-Z]*rf[a-zA-Z]*\b", command) or "rm -rf" in command:
+            blocked = True
+            reason = "rm -rf pattern detected"
+            
+        # 2. DROP TABLE
+        elif re.search(r"\bDROP\s+TABLE\b", command, re.IGNORECASE):
+            blocked = True
+            reason = "DROP TABLE pattern detected"
+            
+        # 3. git push --force (or -f)
+        elif re.search(r"\bgit\s+push\b.*?(?:--force|\s-f\b)", command):
+            blocked = True
+            reason = "git push --force pattern detected"
+            
+        # 4. TRUNCATE
+        elif re.search(r"\bTRUNCATE\b", command, re.IGNORECASE):
+            blocked = True
+            reason = "TRUNCATE pattern detected"
+            
+        # 5. DELETE FROM without WHERE
+        elif re.search(r"\bDELETE\s+FROM\b", command, re.IGNORECASE):
+            if not re.search(r"\bWHERE\b", command, re.IGNORECASE):
+                blocked = True
+                reason = "DELETE FROM without WHERE clause detected"
+                
+        if blocked:
+            log_blocked(command, reason)
+            sys.stderr.write(f"ERROR: Command execution blocked by security hook.\n")
+            sys.stderr.write(f"Reason: {reason}\n")
+            sys.stderr.write(f"Attempted command: {command.strip()}\n")
+            sys.exit(2)
+            
+        # Not blocked
+        sys.stdout.write(input_data)
+        sys.exit(0)
+        
+    except Exception as e:
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/hooks/destructive-bash-blocker/test_hook.py
+++ b/hooks/destructive-bash-blocker/test_hook.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import unittest
+import subprocess
+import json
+import os
+
+HOOK_PATH = "./pre-tool-use.py"
+LOG_DIR = os.path.expanduser("~/.claude/hooks")
+LOG_PATH = os.path.join(LOG_DIR, "blocked.log")
+
+class TestSecurityHook(unittest.TestCase):
+    
+    def setUp(self):
+        os.chmod(HOOK_PATH, 0o755)
+        if os.path.exists(LOG_PATH):
+            os.remove(LOG_PATH)
+            
+    def run_hook(self, input_json):
+        process = subprocess.Popen(
+            [HOOK_PATH],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        stdout, stderr = process.communicate(input=json.dumps(input_json))
+        return process.returncode, stdout, stderr
+
+    def test_allow_safe_commands(self):
+        safe_cases = [
+            {"tool_name": "Bash", "tool_input": {"command": "ls -la"}},
+            {"tool_name": "Bash", "tool_input": {"command": "git push origin main"}},
+            {"tool_name": "Bash", "tool_input": {"command": "DELETE FROM users WHERE id = 5"}},
+            {"tool_name": "Bash", "tool_input": {"command": "echo 'hello world'"}},
+            {"tool_name": "Bash", "tool_input": {"command": "rm -f file.txt"}}
+        ]
+        for case in safe_cases:
+            code, stdout, stderr = self.run_hook(case)
+            self.assertEqual(code, 0, f"Failed for safe case: {case}")
+            self.assertEqual(json.loads(stdout), case)
+            self.assertEqual(stderr, "")
+
+    def test_block_rm_rf(self):
+        input_data = {"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/my-app"}}
+        code, stdout, stderr = self.run_hook(input_data)
+        self.assertEqual(code, 2)
+        self.assertIn("rm -rf pattern detected", stderr)
+        self.assertTrue(os.path.exists(LOG_PATH))
+        with open(LOG_PATH, "r") as f:
+            log_content = f.read()
+            self.assertIn("rm -rf pattern detected", log_content)
+            self.assertIn("rm -rf /tmp/my-app", log_content)
+
+    def test_block_drop_table(self):
+        input_data = {"tool_name": "Bash", "tool_input": {"command": "DROP TABLE users;"}}
+        code, stdout, stderr = self.run_hook(input_data)
+        self.assertEqual(code, 2)
+        self.assertIn("DROP TABLE pattern detected", stderr)
+
+    def test_block_git_force_push(self):
+        input_data = {"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}
+        code, stdout, stderr = self.run_hook(input_data)
+        self.assertEqual(code, 2)
+        self.assertIn("git push --force pattern detected", stderr)
+        
+        input_data_short = {"tool_name": "Bash", "tool_input": {"command": "git push -f origin main"}}
+        code, stdout, stderr = self.run_hook(input_data_short)
+        self.assertEqual(code, 2)
+
+    def test_block_truncate(self):
+        input_data = {"tool_name": "Bash", "tool_input": {"command": "TRUNCATE TABLE logs;"}}
+        code, stdout, stderr = self.run_hook(input_data)
+        self.assertEqual(code, 2)
+        self.assertIn("TRUNCATE pattern detected", stderr)
+
+    def test_block_delete_without_where(self):
+        input_data = {"tool_name": "Bash", "tool_input": {"command": "DELETE FROM users;"}}
+        code, stdout, stderr = self.run_hook(input_data)
+        self.assertEqual(code, 2)
+        self.assertIn("DELETE FROM without WHERE clause detected", stderr)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Outcome
Adds a robust, cross-platform pre-tool-use security hook for Claude Code that intercepts and blocks destructive bash commands (e.g. `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without a `WHERE` clause) and logs them securely.

## Acceptance Criteria Checklist
- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks these patterns: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without a WHERE clause
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with: timestamp, attempted command, project path
- [x] Displays a clear message to Claude explaining why the command was blocked
- [x] Does not interfere with normal bash commands
- [x] README with installation in 2 commands or fewer

## Files Changed
- `hooks/destructive-bash-blocker/pre-tool-use.py`: Main hook logic in Python (zero external dependencies, using native `json` and `re`).
- `hooks/destructive-bash-blocker/test_hook.py`: Complete unit tests verifying safe commands and all blocked command criteria.
- `hooks/destructive-bash-blocker/install.sh`: Setup script that copies and configures the hook in the correct directory.
- `hooks/destructive-bash-blocker/README.md`: Concise installation and manual verification guide.
- `.attribution.json`: Verification metadata.

## Verification & Testing
### Automated Tests
Run the unit test suite:
```bash
python3 test_hook.py
```
Output:
```
......
----------------------------------------------------------------------
Ran 6 tests in 0.228s

OK
```

### Manual Validation
```bash
# Allow normal command (prints JSON representation back to stdout)
echo '{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}' | ./pre-tool-use.py

# Block destructive commands (exits 2 and prints stderr details)
echo '{"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/my-app"}}' | ./pre-tool-use.py
```
Outputs:
```
ERROR: Command execution blocked by security hook.
Reason: rm -rf pattern detected
Attempted command: rm -rf /tmp/my-app
```
And appends a log entry to `~/.claude/hooks/blocked.log`:
```
[2026-05-23T08:02:50Z] Project: /Users/ronny/Documents/antigravity/excited-salk/claude-builders-bounty/hooks/destructive-bash-blocker | Command: rm -rf /tmp/my-app | Reason: rm -rf pattern detected
```

## Compatibility & Safety
- Written in Python 3 with no external dependencies (e.g. doesn't require `jq`) for maximum cross-platform compatibility and reliability.
- Uses word boundaries (`\b`) and regular expressions for precision, avoiding false positive matches on words like `truncated` or `drops`.
