### PR TITLE
feat: add destructive Bash PreToolUse guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README-destructive-bash-guard.md
+++ b/README-destructive-bash-guard.md
@@ -1,0 +1,82 @@
+# Destructive Bash Guard for Claude Code
+
+A zero-dependency Claude Code `PreToolUse` hook that blocks destructive Bash
+commands before they run.
+
+## Install
+
+From this repository:
+
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+The installer copies the hook to `~/.claude/hooks/destructive-bash-guard.py`,
+marks it executable, and adds a `PreToolUse` hook entry for the `Bash` tool in
+`~/.claude/settings.json`.
+
+## What it blocks
+
+- `rm -rf` style recursive forced removals
+- `DROP TABLE`
+- `TRUNCATE`
+- `git push --force`, `git push --force-with-lease`, and `git push -f`
+- `DELETE FROM ...` statements that do not include a `WHERE` clause
+
+Normal commands such as `ls`, `npm test`, `git status`, `SELECT ...`, and
+`DELETE FROM table WHERE id = 1` are allowed.
+
+## Logging
+
+Every blocked attempt is appended as JSON Lines to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each log entry includes:
+
+- UTC timestamp
+- attempted command
+- project path
+- block reason
+
+Example:
+
+```json
+{"timestamp":"2026-05-24T00:00:00+00:00","project_path":"/repo","command":"rm -rf .","reason":"Blocked recursive forced removal: `rm -rf` can irreversibly delete project or system files."}
+```
+
+## Manual configuration
+
+If you prefer to configure Claude Code manually, add this to
+`~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/you/.claude/hooks/destructive-bash-guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Behavior
+
+When a dangerous command is detected, the hook:
+
+1. writes a JSONL entry to `~/.claude/hooks/blocked.log`,
+2. prints a clear block decision and explanation for Claude, and
+3. exits non-zero so the command is not executed.
+
+If a blocked command is intentional, run it manually after human review.

--- a/hooks/destructive-bash-guard.py
+++ b/hooks/destructive-bash-guard.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+Reads the hook event JSON from stdin. If the event targets the Bash tool and the
+command matches a destructive pattern, writes a blocked-attempt log entry to
+~/.claude/hooks/blocked.log, prints a JSON block decision, and exits 2.
+
+Normal/non-Bash commands exit 0 without output so ordinary tool use is not
+interrupted.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+BLOCK_PATTERNS = [
+    (
+        "recursive forced removal",
+        re.compile(r"(?:^|[;&|()\s])rm\s+(?=[^\n;&|]*-[A-Za-z]*r)(?=[^\n;&|]*-[A-Za-z]*f)", re.I),
+        "`rm -rf` can irreversibly delete project or system files.",
+    ),
+    (
+        "DROP TABLE statement",
+        re.compile(r"\bdrop\s+table\b", re.I),
+        "`DROP TABLE` can permanently remove database tables.",
+    ),
+    (
+        "TRUNCATE statement",
+        re.compile(r"\btruncate\b", re.I),
+        "`TRUNCATE` can permanently remove all rows from a table.",
+    ),
+    (
+        "forced git push",
+        re.compile(r"\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?|-f)\b", re.I),
+        "forced pushes can rewrite shared Git history.",
+    ),
+]
+
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.I)
+WHERE_RE = re.compile(r"\bwhere\b", re.I)
+
+def _strip_sql_comments(statement: str) -> str:
+    statement = re.sub(r"--.*?(?=\n|$)", " ", statement)
+    statement = re.sub(r"/\*.*?\*/", " ", statement, flags=re.S)
+    return statement
+
+
+def _sql_statements(command: str) -> list[str]:
+    # Good enough for hook screening: split on semicolons/newlines. We prefer
+    # a conservative block over letting a broad DELETE pass.
+    return [part.strip() for part in re.split(r"[;\n]", command) if part.strip()]
+
+
+def blocked_reason(command: str) -> str | None:
+    for name, pattern, reason in BLOCK_PATTERNS:
+        if pattern.search(command):
+            return f"Blocked {name}: {reason}"
+
+    for statement in _sql_statements(command):
+        cleaned = _strip_sql_comments(statement)
+        if DELETE_FROM_RE.search(cleaned) and not WHERE_RE.search(cleaned):
+            return "Blocked DELETE FROM without WHERE: this can remove every row in a table."
+
+    return None
+
+
+def extract_command(event: dict[str, Any]) -> str:
+    tool_input = event.get("tool_input") or event.get("input") or {}
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd", "script"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+    if isinstance(tool_input, str):
+        return tool_input
+    value = event.get("command")
+    return value if isinstance(value, str) else ""
+
+
+def is_bash_event(event: dict[str, Any]) -> bool:
+    tool_name = str(event.get("tool_name") or event.get("tool") or "")
+    if tool_name.lower() == "bash":
+        return True
+    # Some test harnesses only pass tool_input.command. Treat that as Bash-like.
+    return bool(extract_command(event)) and not tool_name
+
+
+def project_path(event: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "workspace", "session_path"):
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return os.getcwd()
+
+
+def log_block(command: str, path: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_path": path,
+        "command": command,
+        "reason": reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def block(command: str, path: str, reason: str) -> int:
+    log_block(command, path, reason)
+    message = (
+        "Destructive Bash command blocked by destructive-bash-guard. "
+        f"{reason} If this is intentional, run it manually after review."
+    )
+    print(json.dumps({"decision": "block", "reason": message}), file=sys.stdout)
+    print(message, file=sys.stderr)
+    return 2
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read().strip()
+        event = json.loads(raw) if raw else {}
+    except json.JSONDecodeError as exc:
+        print(f"destructive-bash-guard: invalid hook JSON: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(event, dict) or not is_bash_event(event):
+        return 0
+
+    command = extract_command(event)
+    reason = blocked_reason(command)
+    if reason:
+        return block(command, project_path(event), reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_DIR="$HOME/.claude/hooks"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+HOOK_SOURCE="$REPO_DIR/hooks/destructive-bash-guard.py"
+HOOK_TARGET="$HOOK_DIR/destructive-bash-guard.py"
+
+mkdir -p "$HOOK_DIR"
+cp "$HOOK_SOURCE" "$HOOK_TARGET"
+chmod +x "$HOOK_TARGET"
+
+python3 - "$SETTINGS_FILE" "$HOOK_TARGET" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1]).expanduser()
+hook_path = Path(sys.argv[2]).expanduser()
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+if settings_path.exists() and settings_path.read_text().strip():
+    data = json.loads(settings_path.read_text())
+else:
+    data = {}
+
+hooks = data.setdefault("hooks", {})
+pre = hooks.setdefault("PreToolUse", [])
+entry = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": str(hook_path),
+        }
+    ],
+}
+
+# Avoid duplicate installer entries.
+needle = str(hook_path)
+for existing in pre:
+    for hook in existing.get("hooks", []) if isinstance(existing, dict) else []:
+        if hook.get("command") == needle:
+            break
+    else:
+        continue
+    break
+else:
+    pre.append(entry)
+
+settings_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+echo "Installed destructive-bash-guard at $HOOK_TARGET"
+echo "Updated Claude Code settings at $SETTINGS_FILE"
+echo "Blocked attempts will be logged to $HOOK_DIR/blocked.log"

--- a/tests/test_destructive_bash_guard.py
+++ b/tests/test_destructive_bash_guard.py
@@ -1,0 +1,104 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "destructive-bash-guard.py"
+
+
+def run_hook(command, *, tool_name="Bash", home=None):
+    env = os.environ.copy()
+    if home is not None:
+        env["HOME"] = str(home)
+    payload = {
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+        "cwd": "/tmp/example-project",
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class DestructiveBashGuardTests(unittest.TestCase):
+    def assert_blocked(self, command, tmp_path):
+        result = run_hook(command, home=tmp_path)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("destructive-bash-guard", result.stderr)
+        self.assertIn('"decision": "block"', result.stdout)
+        log_path = tmp_path / ".claude" / "hooks" / "blocked.log"
+        self.assertTrue(log_path.exists())
+        entry = json.loads(log_path.read_text().strip().splitlines()[-1])
+        self.assertEqual(entry["command"], command)
+        self.assertEqual(entry["project_path"], "/tmp/example-project")
+        return result
+
+    def test_blocks_rm_rf(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            self.assert_blocked("rm -rf build", tmp_path)
+            self.assert_blocked("sudo rm -fr /tmp/demo", tmp_path)
+
+    def test_blocks_dangerous_sql(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            self.assert_blocked("psql -c 'DROP TABLE users'", tmp_path)
+            self.assert_blocked("mysql -e 'TRUNCATE sessions'", tmp_path)
+            self.assert_blocked("psql -c 'DELETE FROM users'", tmp_path)
+
+    def test_blocks_force_push(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            self.assert_blocked("git push --force origin main", tmp_path)
+            self.assert_blocked("git push -f origin main", tmp_path)
+            self.assert_blocked("git push --force-with-lease", tmp_path)
+
+    def test_allows_safe_commands(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            safe = [
+                "ls -la",
+                "npm test",
+                "git status --short",
+                "psql -c 'SELECT * FROM users'",
+                "psql -c 'DELETE FROM users WHERE id = 1'",
+                "rm -r build",
+                "rm -f file.txt",
+            ]
+            for command in safe:
+                with self.subTest(command=command):
+                    result = run_hook(command, home=tmp_path)
+                    self.assertEqual(result.returncode, 0, command)
+                    self.assertEqual(result.stdout, "")
+                    self.assertEqual(result.stderr, "")
+
+    def test_ignores_non_bash_tool(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            result = run_hook("rm -rf build", tool_name="Read", home=tmp_path)
+            self.assertEqual(result.returncode, 0)
+            self.assertFalse((tmp_path / ".claude" / "hooks" / "blocked.log").exists())
+
+    def test_invalid_json_fails_cleanly(self):
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input="not-json",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("invalid hook JSON", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a zero-dependency Claude Code `PreToolUse` hook for the `Bash` tool.
- Blocks `rm -rf`, `DROP TABLE`, `TRUNCATE`, `git push --force` / `-f` / `--force-with-lease`, and `DELETE FROM` without `WHERE`.
- Logs every blocked attempt as JSONL to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
- Includes a two-command install flow via `install.sh`, manual settings example, and unit tests.

## Validation
- `python3 -m unittest discover -s tests -v`
- Installer smoke test with temporary `HOME` confirmed hook copy, executable bit, and `PreToolUse` settings entry.

Closes #3
