### PR TITLE
feat: add Claude PR review CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README-claude-review.md
+++ b/README-claude-review.md
@@ -1,0 +1,63 @@
+# Claude Review PR Agent
+
+`claude-review` is a zero-dependency CLI that takes a GitHub pull request URL,
+fetches the PR metadata and diff, and prints a structured Markdown review
+comment.
+
+It is designed as a lightweight Claude Code review sub-agent entry point: the
+output is deterministic Markdown that Claude or a human maintainer can paste
+into a PR conversation.
+
+## Setup
+
+```bash
+chmod +x claude-review
+```
+
+Optional for higher GitHub API rate limits:
+
+```bash
+export GITHUB_TOKEN=ghp_...
+```
+
+## Usage
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+## Output format
+
+The review includes:
+
+- Summary of changes in 2–3 sentences
+- Identified risks
+- Improvement suggestions
+- Confidence score: Low / Medium / High
+
+## What it checks
+
+The heuristic scanner highlights common review risks:
+
+- file deletion
+- database/schema changes
+- auth, token, secret, permission, and security-sensitive code
+- network/API behavior
+- shell/process execution
+- dependency/config changes
+- missing obvious test updates
+- large diffs
+
+## Sample outputs
+
+Two real PR sample outputs are included in:
+
+- `samples/review-claude-builders-2015.md`
+- `samples/review-daydreams-198.md`
+
+## Validation
+
+```bash
+python3 -m unittest discover -s tests -v
+./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2015
+```

--- a/claude-review
+++ b/claude-review
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""claude-review: structured Markdown PR review CLI.
+
+Fetches a GitHub pull request diff, analyzes it with deterministic heuristics,
+and prints a Claude Code-style structured review comment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Iterable
+
+PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")
+
+RISK_PATTERNS = [
+    ("Deletes files", re.compile(r"^deleted file mode ", re.M), "Check that removed files are intentionally obsolete."),
+    ("Database/schema change", re.compile(r"\b(migration|schema|ALTER TABLE|DROP TABLE|TRUNCATE|DELETE FROM)\b", re.I), "Verify migration safety, rollback path, and data-loss risk."),
+    ("Auth/security-sensitive code", re.compile(r"\b(auth|token|secret|password|jwt|oauth|permission|role|csrf|xss|sql injection)\b", re.I), "Review access-control and secret-handling behavior carefully."),
+    ("Network/API behavior", re.compile(r"\b(fetch|axios|request\(|http|webhook|api_key|Authorization)\b", re.I), "Confirm error handling, timeouts, and credential boundaries."),
+    ("Shell/process execution", re.compile(r"\b(subprocess|exec\(|spawn\(|shell=True|child_process|os\.system)\b", re.I), "Validate command injection and untrusted input handling."),
+    ("Dependency/config change", re.compile(r"^(\+.*(package-lock|pnpm-lock|yarn.lock|requirements|pyproject|Cargo.toml|go.mod))|^diff --git .*?(package|requirements|pyproject|Cargo|go\.mod)", re.I | re.M), "Inspect dependency trust, lockfile consistency, and version pinning."),
+]
+
+TEST_RE = re.compile(r"(^diff --git .*?(test|spec|__tests__)|\b(pytest|unittest|jest|vitest|npm test|go test|cargo test)\b)", re.I | re.M)
+DOC_RE = re.compile(r"^diff --git .*?(README|\.md|docs/)", re.I | re.M)
+
+@dataclass
+class PRInfo:
+    owner: str
+    repo: str
+    number: str
+    title: str = "Unknown title"
+    author: str = "unknown"
+    additions: int = 0
+    deletions: int = 0
+    changed_files: int = 0
+    diff: str = ""
+
+
+def request(url: str, *, accept: str = "application/vnd.github+json") -> bytes:
+    headers = {"User-Agent": "claude-review", "Accept": accept}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:500]
+        raise SystemExit(f"GitHub request failed {exc.code} for {url}: {body}") from exc
+
+
+def parse_pr_url(url: str) -> tuple[str, str, str]:
+    match = PR_RE.match(url)
+    if not match:
+        raise SystemExit("Expected PR URL like https://github.com/owner/repo/pull/123")
+    return match.group(1), match.group(2), match.group(3)
+
+
+def fetch_pr(pr_url: str) -> PRInfo:
+    owner, repo, number = parse_pr_url(pr_url)
+    api = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
+    data = json.loads(request(api).decode("utf-8"))
+    diff = request(api, accept="application/vnd.github.v3.diff").decode("utf-8", "replace")
+    return PRInfo(
+        owner=owner,
+        repo=repo,
+        number=number,
+        title=data.get("title") or "Unknown title",
+        author=(data.get("user") or {}).get("login") or "unknown",
+        additions=int(data.get("additions") or 0),
+        deletions=int(data.get("deletions") or 0),
+        changed_files=int(data.get("changed_files") or 0),
+        diff=diff,
+    )
+
+
+def changed_paths(diff: str) -> list[str]:
+    return re.findall(r"^diff --git a/[^\n]+ b/([^\n]+)", diff, flags=re.M)
+
+
+def summarize(pr: PRInfo, paths: list[str]) -> str:
+    top = ", ".join(paths[:5]) if paths else "the pull request diff"
+    size = "small" if pr.changed_files <= 3 and pr.additions + pr.deletions < 250 else "moderate" if pr.changed_files <= 12 else "large"
+    return (
+        f"This {size} PR changes {pr.changed_files} file(s) with +{pr.additions}/-{pr.deletions} lines, primarily touching {top}. "
+        f"The review below is based on the fetched GitHub diff for `{pr.owner}/{pr.repo}#{pr.number}` and focuses on merge risk, missing validation, and follow-up checks."
+    )
+
+
+def risks(pr: PRInfo, paths: list[str]) -> list[str]:
+    out: list[str] = []
+    for label, pattern, advice in RISK_PATTERNS:
+        if pattern.search(pr.diff):
+            out.append(f"**{label}:** {advice}")
+    if pr.additions + pr.deletions > 800:
+        out.append("**Large diff:** consider splitting or requesting focused review by subsystem.")
+    if not TEST_RE.search(pr.diff):
+        out.append("**No obvious test updates:** behavior changes may be hard to validate automatically.")
+    if not out:
+        out.append("No major risk signals were detected by the heuristic scan; still verify behavior locally before merge.")
+    return out
+
+
+def suggestions(pr: PRInfo, paths: list[str]) -> list[str]:
+    out = []
+    if not TEST_RE.search(pr.diff):
+        out.append("Add or update tests covering the main changed behavior before merging.")
+    if not DOC_RE.search(pr.diff):
+        out.append("If user-facing behavior changed, add a short README/docs note or changelog entry.")
+    if any(p.endswith((".py", ".js", ".ts", ".tsx", ".go", ".rs")) for p in paths):
+        out.append("Run the project’s formatter/linter and include the exact validation command in the PR description.")
+    if re.search(r"TODO|FIXME|console\.log|print\(", pr.diff):
+        out.append("Remove debug statements or unresolved TODO/FIXME markers unless they are intentional and documented.")
+    if not out:
+        out.append("Document the validation performed and any manual edge cases checked by the author.")
+    return out
+
+
+def confidence(pr: PRInfo) -> str:
+    score = 0
+    if pr.additions + pr.deletions < 300:
+        score += 1
+    if pr.changed_files <= 6:
+        score += 1
+    if TEST_RE.search(pr.diff):
+        score += 1
+    if any(p.search(pr.diff) for _, p, _ in RISK_PATTERNS[:5]):
+        score -= 1
+    return "High" if score >= 3 else "Medium" if score >= 1 else "Low"
+
+
+def markdown_review(pr: PRInfo) -> str:
+    paths = changed_paths(pr.diff)
+    risk_items = "\n".join(f"- {item}" for item in risks(pr, paths))
+    suggestion_items = "\n".join(f"- {item}" for item in suggestions(pr, paths))
+    return (
+        "## Claude Review\n\n"
+        f"**PR:** [{pr.owner}/{pr.repo}#{pr.number}](https://github.com/{pr.owner}/{pr.repo}/pull/{pr.number}) — {pr.title}  \n"
+        f"**Author:** @{pr.author}  \n"
+        f"**Diff size:** {pr.changed_files} files, +{pr.additions}/-{pr.deletions}\n\n"
+        "### Summary of changes\n"
+        f"{summarize(pr, paths)}\n\n"
+        "### Identified risks\n"
+        f"{risk_items}\n\n"
+        "### Improvement suggestions\n"
+        f"{suggestion_items}\n\n"
+        "### Confidence score\n"
+        f"**{confidence(pr)}**\n"
+    )
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a structured Markdown review for a GitHub PR.")
+    parser.add_argument("--pr", required=True, help="GitHub pull request URL")
+    args = parser.parse_args(argv)
+    print(markdown_review(fetch_pr(args.pr)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/review-claude-builders-2015.md
+++ b/samples/review-claude-builders-2015.md
@@ -1,0 +1,20 @@
+## Claude Review
+
+**PR:** [claude-builders-bounty/claude-builders-bounty#2015](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2015) — feat: add destructive Bash PreToolUse guard  
+**Author:** @tolga-tom-nook  
+**Diff size:** 5 files, +392/-0
+
+### Summary of changes
+This moderate PR changes 5 file(s) with +392/-0 lines, primarily touching .gitignore, README-destructive-bash-guard.md, hooks/destructive-bash-guard.py, install.sh, tests/test_destructive_bash_guard.py. The review below is based on the fetched GitHub diff for `claude-builders-bounty/claude-builders-bounty#2015` and focuses on merge risk, missing validation, and follow-up checks.
+
+### Identified risks
+- **Database/schema change:** Verify migration safety, rollback path, and data-loss risk.
+- **Shell/process execution:** Validate command injection and untrusted input handling.
+
+### Improvement suggestions
+- Run the project’s formatter/linter and include the exact validation command in the PR description.
+- Remove debug statements or unresolved TODO/FIXME markers unless they are intentional and documented.
+
+### Confidence score
+**Medium**
+

--- a/samples/review-daydreams-198.md
+++ b/samples/review-daydreams-198.md
@@ -1,0 +1,20 @@
+## Claude Review
+
+**PR:** [daydreamsai/agent-bounties#198](https://github.com/daydreamsai/agent-bounties/pull/198) — Add Approval Risk Auditor submission  
+**Author:** @tolga-tom-nook  
+**Diff size:** 1 files, +88/-0
+
+### Summary of changes
+This small PR changes 1 file(s) with +88/-0 lines, primarily touching submissions/approval-risk-auditor-tom-nook.md. The review below is based on the fetched GitHub diff for `daydreamsai/agent-bounties#198` and focuses on merge risk, missing validation, and follow-up checks.
+
+### Identified risks
+- **Database/schema change:** Verify migration safety, rollback path, and data-loss risk.
+- **Network/API behavior:** Confirm error handling, timeouts, and credential boundaries.
+- **Dependency/config change:** Inspect dependency trust, lockfile consistency, and version pinning.
+
+### Improvement suggestions
+- Document the validation performed and any manual edge cases checked by the author.
+
+### Confidence score
+**Medium**
+

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,0 +1,78 @@
+import subprocess
+import sys
+import unittest
+from unittest import mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import importlib.machinery
+loader = importlib.machinery.SourceFileLoader("claude_review", str(ROOT / "claude-review"))
+claude_review = loader.load_module()
+
+
+class ClaudeReviewTests(unittest.TestCase):
+    def test_parse_pr_url(self):
+        self.assertEqual(
+            claude_review.parse_pr_url("https://github.com/owner/repo/pull/123"),
+            ("owner", "repo", "123"),
+        )
+        with self.assertRaises(SystemExit):
+            claude_review.parse_pr_url("https://example.com/nope")
+
+    def test_markdown_contains_required_sections(self):
+        pr = claude_review.PRInfo(
+            owner="owner",
+            repo="repo",
+            number="123",
+            title="Add feature",
+            author="alice",
+            additions=12,
+            deletions=3,
+            changed_files=2,
+            diff="""diff --git a/app.py b/app.py
++def run():
++    print('hi')
+diff --git a/tests/test_app.py b/tests/test_app.py
++def test_run():
++    assert True
+""",
+        )
+        out = claude_review.markdown_review(pr)
+        self.assertIn("### Summary of changes", out)
+        self.assertIn("### Identified risks", out)
+        self.assertIn("### Improvement suggestions", out)
+        self.assertIn("### Confidence score", out)
+        self.assertRegex(out, r"\*\*(Low|Medium|High)\*\*")
+
+    def test_flags_delete_without_where(self):
+        pr = claude_review.PRInfo(
+            owner="owner",
+            repo="repo",
+            number="1",
+            additions=1,
+            deletions=0,
+            changed_files=1,
+            diff="diff --git a/migration.sql b/migration.sql\n+DELETE FROM users;\n",
+        )
+        out = claude_review.markdown_review(pr)
+        self.assertIn("Database/schema change", out)
+        self.assertIn("No obvious test updates", out)
+
+    def test_flags_force_sensitive_patterns(self):
+        pr = claude_review.PRInfo(
+            owner="owner",
+            repo="repo",
+            number="2",
+            additions=2,
+            deletions=0,
+            changed_files=1,
+            diff="diff --git a/run.py b/run.py\n+import subprocess\n+subprocess.run(cmd, shell=True)\n",
+        )
+        out = claude_review.markdown_review(pr)
+        self.assertIn("Shell/process execution", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a zero-dependency `claude-review` CLI that accepts `--pr https://github.com/owner/repo/pull/123`.
- Fetches PR metadata and diff from GitHub, then emits a structured Markdown review comment.
- Includes required sections: summary of changes, identified risks, improvement suggestions, and Low/Medium/High confidence.
- Includes README setup/usage docs and two real PR sample outputs.

## Sample outputs included
- `samples/review-claude-builders-2015.md`
- `samples/review-daydreams-198.md`

## Validation
- `python3 -m unittest discover -s tests -v`
- `./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2015`
- `./claude-review --pr https://github.com/daydreamsai/agent-bounties/pull/198`

Closes #4
