### PR TITLE
feat: add git changelog generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README-generate-changelog.md
+++ b/README-generate-changelog.md
@@ -1,0 +1,52 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from git history since the last tag.
+
+## Setup and usage
+
+1. Copy `changelog.sh` into any git repository and make it executable:
+   ```bash
+   chmod +x changelog.sh
+   ```
+2. Run it from the repository root:
+   ```bash
+   ./changelog.sh
+   ```
+3. Review the generated `CHANGELOG.md` and commit it.
+
+## Optional usage
+
+Generate for an explicit range:
+
+```bash
+./changelog.sh v1.2.0..HEAD
+```
+
+Write to a custom file:
+
+```bash
+CHANGELOG_FILE=RELEASE-NOTES.md ./changelog.sh
+```
+
+## Categorization
+
+The script reads non-merge commit subjects from `git log`, defaulting to commits
+since the latest git tag. If no tag exists, it uses the repository history.
+
+It groups commits into:
+
+- `Added`: `feat:`, `feature:`, `add`, `created`, `introduced`
+- `Fixed`: `fix:`, `bugfix:`, `fixed`, `resolved`, `patched`
+- `Changed`: `change:`, `refactor:`, `perf:`, `chore:`, `docs:`, `test:`, `ci:`, `updated`, `improved`, `renamed`
+- `Removed`: `remove:`, `delete:`, `drop`, `removed`, `deleted`
+
+Empty categories are rendered as `- None` so the generated file is always a
+properly structured changelog.
+
+## Sample output
+
+A real sample generated from this repository is included at:
+
+```text
+samples/generated-changelog.md
+```

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_FILE="${CHANGELOG_FILE:-CHANGELOG.md}"
+TITLE="${CHANGELOG_TITLE:-Changelog}"
+RANGE="${1:-}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+if [[ -z "$RANGE" ]]; then
+  LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+  if [[ -n "$LAST_TAG" ]]; then
+    RANGE="$LAST_TAG..HEAD"
+    RANGE_LABEL="since $LAST_TAG"
+  else
+    RANGE="HEAD"
+    RANGE_LABEL="from repository history"
+  fi
+else
+  RANGE_LABEL="for $RANGE"
+fi
+
+TMP_COMMITS="$(mktemp)"
+trap 'rm -f "$TMP_COMMITS"' EXIT
+
+git log "$RANGE" --no-merges --pretty=format:'%s' > "$TMP_COMMITS"
+
+section_items() {
+  local regex="$1"
+  local fallback_regex="$2"
+  local seen=0
+  while IFS= read -r subject || [[ -n "$subject" ]]; do
+    [[ -z "$subject" ]] && continue
+    if [[ "$subject" =~ $regex ]] || { [[ -n "$fallback_regex" ]] && [[ "$subject" =~ $fallback_regex ]]; }; then
+      clean_subject "$subject"
+      seen=1
+    fi
+  done < "$TMP_COMMITS"
+  if [[ "$seen" -eq 0 ]]; then
+    echo "- None"
+  fi
+}
+
+clean_subject() {
+  local subject="$1"
+  subject="${subject#feat: }"; subject="${subject#feat!: }"; subject="${subject#feature: }"
+  subject="${subject#fix: }"; subject="${subject#bugfix: }"
+  subject="${subject#refactor: }"; subject="${subject#perf: }"; subject="${subject#chore: }"
+  subject="${subject#docs: }"; subject="${subject#test: }"; subject="${subject#ci: }"
+  subject="${subject#remove: }"; subject="${subject#removed: }"; subject="${subject#delete: }"
+  printf -- '- %s\n' "$subject"
+}
+
+TODAY="$(date -u +%Y-%m-%d)"
+{
+  echo "# $TITLE"
+  echo
+  echo "Generated on $TODAY $RANGE_LABEL."
+  echo
+  echo "## Unreleased"
+  echo
+  echo "### Added"
+  section_items '^(feat|feature)(\([^)]*\))?!?:' '^(add|added|create|created|introduce|introduced)([[:space:]:]|$)'
+  echo
+  echo "### Fixed"
+  section_items '^(fix|bugfix)(\([^)]*\))?!?:' '^(fix|fixed|repair|patched|resolve|resolved)([[:space:]:]|$)'
+  echo
+  echo "### Changed"
+  section_items '^(change|changed|refactor|perf|chore|docs|test|ci)(\([^)]*\))?!?:' '^(update|updated|improve|improved|refactor|rename|renamed)([[:space:]:]|$)'
+  echo
+  echo "### Removed"
+  section_items '^(remove|removed|delete|deleted)(\([^)]*\))?!?:' '^(remove|removed|delete|deleted|drop|dropped)([[:space:]:]|$)'
+} > "$OUT_FILE"
+
+echo "Wrote $OUT_FILE using commits $RANGE_LABEL"

--- a/samples/generated-changelog.md
+++ b/samples/generated-changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Generated on 2026-05-24 from repository history.
+
+## Unreleased
+
+### Added
+- initial README with bounty board
+
+### Fixed
+- None
+
+### Changed
+- None
+
+### Removed
+- None

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -1,0 +1,68 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "changelog.sh"
+
+
+def run(cmd, cwd, env=None):
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(cmd, cwd=cwd, env=merged, text=True, capture_output=True, check=True)
+
+
+class GenerateChangelogTests(unittest.TestCase):
+    def test_generates_expected_sections_since_last_tag(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            run(["git", "init"], repo)
+            run(["git", "config", "user.email", "test@example.com"], repo)
+            run(["git", "config", "user.name", "Tester"], repo)
+            (repo / "file.txt").write_text("base\n")
+            run(["git", "add", "."], repo)
+            run(["git", "commit", "-m", "chore: initial release"], repo)
+            run(["git", "tag", "v1.0.0"], repo)
+
+            commits = [
+                ("feat: add export button", "add\n"),
+                ("fix: correct login redirect", "fix\n"),
+                ("refactor: simplify billing service", "change\n"),
+                ("remove: legacy webhook handler", "remove\n"),
+            ]
+            for message, content in commits:
+                (repo / "file.txt").write_text(content)
+                run(["git", "add", "."], repo)
+                run(["git", "commit", "-m", message], repo)
+
+            run([str(SCRIPT)], repo)
+            changelog = (repo / "CHANGELOG.md").read_text()
+            self.assertIn("### Added", changelog)
+            self.assertIn("- add export button", changelog)
+            self.assertIn("### Fixed", changelog)
+            self.assertIn("- correct login redirect", changelog)
+            self.assertIn("### Changed", changelog)
+            self.assertIn("- simplify billing service", changelog)
+            self.assertIn("### Removed", changelog)
+            self.assertIn("- legacy webhook handler", changelog)
+            self.assertNotIn("initial release", changelog)
+
+    def test_custom_output_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            run(["git", "init"], repo)
+            run(["git", "config", "user.email", "test@example.com"], repo)
+            run(["git", "config", "user.name", "Tester"], repo)
+            (repo / "file.txt").write_text("content\n")
+            run(["git", "add", "."], repo)
+            run(["git", "commit", "-m", "feat: add first thing"], repo)
+            run([str(SCRIPT)], repo, env={"CHANGELOG_FILE": "RELEASE-NOTES.md"})
+            self.assertTrue((repo / "RELEASE-NOTES.md").exists())
+            self.assertFalse((repo / "CHANGELOG.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `changelog.sh`, a Bash changelog generator that fetches commits since the latest git tag by default.
- Auto-categorizes commit subjects into Added, Fixed, Changed, and Removed.
- Writes a structured `CHANGELOG.md` with stable headings and `- None` placeholders for empty categories.
- Includes setup/usage docs in 3 steps and a real sample output generated from this repository.

## Sample output
- `samples/generated-changelog.md`

## Validation
- `python3 -m unittest discover -s tests -v`
- `CHANGELOG_FILE=samples/generated-changelog.md ./changelog.sh`

Closes #1
