### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/destructive-bash-hook/README.md
+++ b/destructive-bash-hook/README.md
@@ -1,0 +1,48 @@
+# Destructive Bash PreToolUse Hook
+
+A Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run, then logs each blocked attempt to `~/.claude/hooks/blocked.log`.
+
+## Install in 2 commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block_destructive_bash.py ~/.claude/hooks/block_destructive_bash.py
+python3 tests/test_block_destructive_bash.py
+```
+
+Add this hook to your Claude Code settings:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## What it blocks
+
+- `rm -rf`, including variants like `rm -fr`, `rm -r -f`, and `rm --recursive --force`
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+
+When a command is blocked, the hook returns a Claude Code `PreToolUse` deny decision with a clear reason. Safe Bash commands produce no output and exit successfully, so normal permission flow continues.
+
+## Log format
+
+Blocked attempts append one tab-separated line to `~/.claude/hooks/blocked.log`:
+
+```text
+2026-05-24T04:00:00+00:00	project=/path/to/project	reason=...	command=...
+```

--- a/destructive-bash-hook/hooks/block_destructive_bash.py
+++ b/destructive-bash-hook/hooks/block_destructive_bash.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+Reads a Claude Code hook JSON payload from stdin. If the payload is a Bash tool
+call whose command matches a destructive pattern, it logs the attempt and returns
+a PreToolUse deny decision. Safe commands exit 0 with no output so normal Claude
+Code permission flow continues.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def _normalise_space(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+def _shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        # If the command is syntactically incomplete, fall back to a lossy split;
+        # destructive text should still be blocked conservatively.
+        return command.split()
+
+
+def _has_rm_rf(command: str) -> bool:
+    """Return True for rm invocations whose flags include both r and f."""
+    tokens = _shell_tokens(command)
+    for idx, tok in enumerate(tokens):
+        if tok != "rm":
+            continue
+        # Inspect flags immediately after rm. Stop when the first non-flag arg
+        # appears. Handles rm -rf, rm -fr, rm -r -f, rm --recursive --force.
+        has_recursive = False
+        has_force = False
+        for arg in tokens[idx + 1 :]:
+            if arg == "--":
+                break
+            if not arg.startswith("-") or arg == "-":
+                break
+            if arg in ("--recursive", "--dir"):
+                has_recursive = True
+            if arg == "--force":
+                has_force = True
+            if arg.startswith("--"):
+                continue
+            flags = arg[1:]
+            if "r" in flags or "R" in flags:
+                has_recursive = True
+            if "f" in flags:
+                has_force = True
+        if has_recursive and has_force:
+            return True
+    # Conservative fallback for shell constructs shlex may not model well.
+    return bool(re.search(r"(?:^|[;&|`$()\s])rm\s+(?:-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*|-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*|(?:--recursive|-[A-Za-z]*[rR][A-Za-z]*)\s+(?:--force|-[A-Za-z]*f[A-Za-z]*))", command))
+
+
+def _has_git_push_force(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    for i in range(len(tokens) - 2):
+        if tokens[i] == "git" and tokens[i + 1] == "push":
+            push_args = tokens[i + 2 :]
+            return any(
+                arg == "-f"
+                or arg == "--force"
+                or arg.startswith("--force-with-lease")
+                for arg in push_args
+            )
+    return bool(re.search(r"\bgit\s+push\b[^\n;|&]*(?:\s-f\b|\s--force(?:\b|=)|\s--force-with-lease(?:\b|=))", command))
+
+
+def _sql_statements(command: str) -> Iterable[str]:
+    for part in re.split(r";|&&|\|\||\n", command):
+        statement = _normalise_space(part)
+        if statement:
+            yield statement
+
+
+def _has_dangerous_sql(command: str) -> tuple[bool, str | None]:
+    upper = command.upper()
+    if re.search(r"\bDROP\s+TABLE\b", upper):
+        return True, "DROP TABLE is destructive"
+    if re.search(r"\bTRUNCATE\b", upper):
+        return True, "TRUNCATE is destructive"
+    for stmt in _sql_statements(command):
+        if re.search(r"\bDELETE\s+FROM\b", stmt, re.IGNORECASE) and not re.search(r"\bWHERE\b", stmt, re.IGNORECASE):
+            return True, "DELETE FROM without WHERE can delete every row"
+    return False, None
+
+
+def classify(command: str) -> str | None:
+    if _has_rm_rf(command):
+        return "rm with recursive force flags can delete large directory trees"
+    sql_blocked, sql_reason = _has_dangerous_sql(command)
+    if sql_blocked:
+        return sql_reason
+    if _has_git_push_force(command):
+        return "git push --force can rewrite shared history"
+    return None
+
+
+def _project_path(payload: dict) -> str:
+    for key in ("cwd", "project_dir", "workspace", "transcript_path"):
+        val = payload.get(key)
+        if isinstance(val, str) and val:
+            if key == "transcript_path":
+                return str(Path(val).parent)
+            return val
+    return os.getcwd()
+
+
+def _log_block(command: str, project_path: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ts = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(f"{ts}\tproject={project_path}\treason={reason}\tcommand={safe_command}\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"Invalid hook JSON: {exc}", file=sys.stderr)
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = classify(command)
+    if not reason:
+        return 0
+
+    project_path = _project_path(payload)
+    _log_block(command, project_path, reason)
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": f"Blocked destructive Bash command: {reason}.",
+        }
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/destructive-bash-hook/tests/test_block_destructive_bash.py
+++ b/destructive-bash-hook/tests/test_block_destructive_bash.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block_destructive_bash.py"
+
+spec = importlib.util.spec_from_file_location("hook", HOOK)
+hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook)
+
+blocked = [
+    ("rm -rf /tmp/build", "rm"),
+    ("rm -fr dist", "rm"),
+    ("rm -r -f ./cache", "rm"),
+    ("psql -c 'DROP TABLE users'", "DROP"),
+    ("sqlite3 app.db 'TRUNCATE sessions'", "TRUNCATE"),
+    ("mysql -e 'DELETE FROM users'", "DELETE"),
+    ("git push --force origin main", "force"),
+    ("git push -f", "force"),
+]
+allowed = [
+    "rm ./single-file.txt",
+    "git push origin main",
+    "sqlite3 app.db 'DELETE FROM users WHERE id = 1'",
+    "npm test",
+]
+
+for command, expected in blocked:
+    reason = hook.classify(command)
+    assert reason, f"expected blocked: {command}"
+
+for command in allowed:
+    assert hook.classify(command) is None, f"expected allowed: {command}"
+
+payload = {"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/demo"}, "cwd": "/tmp/project"}
+proc = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(payload), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+out = json.loads(proc.stdout)
+assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+safe_payload = {"tool_name": "Bash", "tool_input": {"command": "npm test"}, "cwd": "/tmp/project"}
+proc = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(safe_payload), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+assert proc.stdout == ""
+
+print("All destructive Bash hook tests passed.")


### PR DESCRIPTION
## Summary

Implements a Claude Code `PreToolUse` hook that blocks destructive Bash commands before execution.

Fixes #3

## What is included

- `destructive-bash-hook/hooks/block_destructive_bash.py`
  - Blocks `rm -rf` variants
  - Blocks `DROP TABLE`
  - Blocks `TRUNCATE`
  - Blocks `DELETE FROM` without `WHERE`
  - Blocks `git push --force` / `-f` / `--force-with-lease`
  - Logs blocked attempts to `~/.claude/hooks/blocked.log`
- `destructive-bash-hook/tests/test_block_destructive_bash.py`
- `destructive-bash-hook/README.md` with install instructions in 2 commands

## Test proof

```text
$ python3 destructive-bash-hook/tests/test_block_destructive_bash.py
All destructive Bash hook tests passed.
```
