### PR TITLE
Add Claude Code destructive Bash guard hook

### DIFF
--- a/block_destructive_bash.py
+++ b/block_destructive_bash.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+Reads Claude Code hook JSON from stdin. If the event is a Bash tool call with a
+command matching destructive patterns, logs the attempt and returns a Claude Code
+permissionDecision=deny response. Safe commands exit 0 with no output.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Tuple
+
+DANGEROUS_PATTERNS: Tuple[Tuple[str, re.Pattern[str]], ...] = (
+    (
+        "rm -rf / rm -fr style recursive force deletion",
+        re.compile(r"(?:^|[;&|()\n])\s*rm\s+-[^\n;&|]*[rR][^\n;&|]*[fF]|(?:^|[;&|()\n])\s*rm\s+-[^\n;&|]*[fF][^\n;&|]*[rR]"),
+    ),
+    ("DROP TABLE statement", re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE)),
+    ("TRUNCATE statement", re.compile(r"\bTRUNCATE\b", re.IGNORECASE)),
+    (
+        "git push --force / -f",
+        re.compile(r"\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?\b|\s-f\b)", re.IGNORECASE),
+    ),
+)
+
+DELETE_FROM_RE = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bWHERE\b", re.IGNORECASE)
+
+
+def iter_sql_statements(command: str) -> Iterable[str]:
+    """Split enough for the DELETE-without-WHERE safety check.
+
+    This intentionally favors safety over SQL completeness. It catches common
+    inline shell SQL such as psql -c "DELETE FROM users" and sqlite3 db
+    'DELETE FROM sessions;'.
+    """
+    for part in re.split(r"[;\n]", command):
+        stripped = part.strip()
+        if stripped:
+            yield stripped
+
+
+def dangerous_reason(command: str) -> str | None:
+    for label, pattern in DANGEROUS_PATTERNS:
+        if pattern.search(command):
+            return label
+
+    for statement in iter_sql_statements(command):
+        if DELETE_FROM_RE.search(statement) and not WHERE_RE.search(statement):
+            return "DELETE FROM without WHERE clause"
+    return None
+
+
+def log_block(command: str, project_path: str, reason: str) -> None:
+    log_dir = Path(os.environ.get("HOME", str(Path.home()))) / ".claude" / "hooks"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "blocked.log"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    safe_project = project_path.replace("\n", " ")
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp}\tproject={safe_project}\treason={reason}\tcommand={safe_command}\n")
+
+
+def deny(reason: str) -> None:
+    response = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "Blocked destructive Bash command: "
+                f"{reason}. Review the command and choose a safer, reversible action."
+            ),
+        }
+    }
+    print(json.dumps(response, separators=(",", ":")))
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Malformed hook input should not break normal Claude Code usage.
+        return 0
+
+    if payload.get("hook_event_name") not in (None, "PreToolUse"):
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = dangerous_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = (
+        payload.get("cwd")
+        or payload.get("project_dir")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+    log_block(command, str(project_path), reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,54 @@
+# Destructive Bash Guard for Claude Code
+
+A Claude Code `PreToolUse` hook that blocks common destructive Bash commands before they run.
+
+## What it blocks
+
+- `rm -rf` / `rm -fr` style recursive force deletion
+- `DROP TABLE`
+- `git push --force`, `git push --force-with-lease`, and `git push -f`
+- `TRUNCATE`
+- `DELETE FROM` statements that do not include a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` with timestamp, attempted command, reason, and project path.
+
+## Install in 2 commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp block_destructive_bash.py ~/.claude/hooks/ && chmod +x ~/.claude/hooks/block_destructive_bash.py
+python3 - <<'PY'
+import json, pathlib
+p = pathlib.Path.home() / '.claude' / 'settings.json'
+p.parent.mkdir(parents=True, exist_ok=True)
+config = json.loads(p.read_text()) if p.exists() else {}
+config.setdefault('hooks', {}).setdefault('PreToolUse', []).append({
+    'matcher': 'Bash',
+    'hooks': [{'type': 'command', 'command': '$HOME/.claude/hooks/block_destructive_bash.py'}]
+})
+p.write_text(json.dumps(config, indent=2) + '\n')
+PY
+```
+
+Alternatively, merge `settings.example.json` into your Claude Code settings manually.
+
+## How it works
+
+Claude Code sends hook event JSON on stdin before each Bash tool call. For dangerous commands, this hook returns:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Blocked destructive Bash command: ..."
+  }
+}
+```
+
+For normal commands, it exits successfully with no output, so it does not interfere.
+
+## Test locally
+
+```bash
+python3 tests/test_block_destructive_bash.py
+```

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands.
+
+Reads Claude Code hook JSON from stdin. If the event is a Bash tool call with a
+command matching destructive patterns, logs the attempt and returns a Claude Code
+permissionDecision=deny response. Safe commands exit 0 with no output.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Tuple
+
+DANGEROUS_PATTERNS: Tuple[Tuple[str, re.Pattern[str]], ...] = (
+    (
+        "rm -rf / rm -fr style recursive force deletion",
+        re.compile(r"(?:^|[;&|()\n])\s*rm\s+-[^\n;&|]*[rR][^\n;&|]*[fF]|(?:^|[;&|()\n])\s*rm\s+-[^\n;&|]*[fF][^\n;&|]*[rR]"),
+    ),
+    ("DROP TABLE statement", re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE)),
+    ("TRUNCATE statement", re.compile(r"\bTRUNCATE\b", re.IGNORECASE)),
+    (
+        "git push --force / -f",
+        re.compile(r"\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?\b|\s-f\b)", re.IGNORECASE),
+    ),
+)
+
+DELETE_FROM_RE = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bWHERE\b", re.IGNORECASE)
+
+
+def iter_sql_statements(command: str) -> Iterable[str]:
+    """Split enough for the DELETE-without-WHERE safety check.
+
+    This intentionally favors safety over SQL completeness. It catches common
+    inline shell SQL such as psql -c "DELETE FROM users" and sqlite3 db
+    'DELETE FROM sessions;'.
+    """
+    for part in re.split(r"[;\n]", command):
+        stripped = part.strip()
+        if stripped:
+            yield stripped
+
+
+def dangerous_reason(command: str) -> str | None:
+    for label, pattern in DANGEROUS_PATTERNS:
+        if pattern.search(command):
+            return label
+
+    for statement in iter_sql_statements(command):
+        if DELETE_FROM_RE.search(statement) and not WHERE_RE.search(statement):
+            return "DELETE FROM without WHERE clause"
+    return None
+
+
+def log_block(command: str, project_path: str, reason: str) -> None:
+    log_dir = Path(os.environ.get("HOME", str(Path.home()))) / ".claude" / "hooks"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "blocked.log"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    safe_project = project_path.replace("\n", " ")
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp}\tproject={safe_project}\treason={reason}\tcommand={safe_command}\n")
+
+
+def deny(reason: str) -> None:
+    response = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "Blocked destructive Bash command: "
+                f"{reason}. Review the command and choose a safer, reversible action."
+            ),
+        }
+    }
+    print(json.dumps(response, separators=(",", ":")))
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Malformed hook input should not break normal Claude Code usage.
+        return 0
+
+    if payload.get("hook_event_name") not in (None, "PreToolUse"):
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = dangerous_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = (
+        payload.get("cwd")
+        or payload.get("project_dir")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+    log_block(command, str(project_path), reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/settings.example.json
+++ b/hooks/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "block_destructive_bash.py"
+
+
+def run_hook(command: str, home: Path):
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/tmp/example-project",
+    }
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def assert_blocked(command: str, expected: str, home: Path):
+    result = run_hook(command, home)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip(), f"expected block output for {command!r}"
+    data = json.loads(result.stdout)
+    hook_out = data["hookSpecificOutput"]
+    assert hook_out["permissionDecision"] == "deny"
+    assert expected in hook_out["permissionDecisionReason"]
+
+
+def assert_allowed(command: str, home: Path):
+    result = run_hook(command, home)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "", f"expected allow/no output for {command!r}, got {result.stdout!r}"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        home = Path(tmp)
+        assert_blocked("rm -rf build/", "rm -rf", home)
+        assert_blocked("git push --force origin main", "git push", home)
+        assert_blocked("psql -c 'DROP TABLE users'", "DROP TABLE", home)
+        assert_blocked("sqlite3 app.db 'TRUNCATE sessions'", "TRUNCATE", home)
+        assert_blocked("sqlite3 app.db 'DELETE FROM sessions'", "DELETE FROM", home)
+        assert_allowed("sqlite3 app.db 'DELETE FROM sessions WHERE id = 1'", home)
+        assert_allowed("rm -r build/", home)
+        assert_allowed("git push origin main", home)
+        log_path = home / ".claude" / "hooks" / "blocked.log"
+        assert log_path.exists(), "blocked.log was not created"
+        log_text = log_path.read_text()
+        assert "rm -rf build/" in log_text
+        assert "project=/tmp/example-project" in log_text
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a Claude Code `PreToolUse` hook that denies destructive Bash commands before execution.
- Cover `rm -rf`/`rm -fr`, `DROP TABLE`, `TRUNCATE`, `git push --force`/`-f`, and `DELETE FROM` without `WHERE`.
- Include example Claude Code hook settings, install docs, and local tests.

## Test
- `python3 tests/test_block_destructive_bash.py`
- `python3 -m py_compile block_destructive_bash.py hooks/block_destructive_bash.py`
- `git diff --check upstream/main..HEAD`

Addresses https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3
