### PR TITLE
Add generate changelog skill

### DIFF
--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -7,3 +7,11 @@
 - feat: initial README with bounty board
 
 ### Fixed
+- Nothing recorded.
+
+### Changed
+- Nothing recorded.
+
+### Removed
+- Nothing recorded.
+

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-05-26 — generated for all history
+
+### Added
+- feat: initial README with bounty board
+
+### Fixed

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-05-26 — generated for all history
 
 ### Added
+- Add generate changelog skill
 - feat: initial README with bounty board
 
 ### Fixed

--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,18 @@
+# Generate Changelog Skill
+
+Creates a structured `CHANGELOG.md` from git commits since the latest tag.
+
+## Setup / usage
+
+```bash
+chmod +x generate-changelog/changelog.sh
+./generate-changelog/changelog.sh
+```
+
+Optional output path:
+
+```bash
+./generate-changelog/changelog.sh docs/CHANGELOG.md
+```
+
+The script categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed` using common commit prefixes and keywords. If the repo has no tags, it uses the full git history.

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT=${1:-CHANGELOG.md}
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [[ -n "$LAST_TAG" ]]; then
+  RANGE="$LAST_TAG..HEAD"
+  SINCE="since $LAST_TAG"
+else
+  RANGE="HEAD"
+  SINCE="for all history"
+fi
+
+COMMITS=$(git log --no-merges --pretty=format:'%s' "$RANGE" 2>/dev/null || true)
+TODAY=$(date +%Y-%m-%d)
+
+declare -a ADDED FIXED CHANGED REMOVED
+while IFS= read -r msg; do
+  [[ -z "$msg" ]] && continue
+  low=$(printf '%s' "$msg" | tr '[:upper:]' '[:lower:]')
+  case "$low" in
+    fix:*|fixed:*|bugfix:*|*fix*|*bug*) FIXED+=("$msg") ;;
+    remove:*|removed:*|delete:*|deleted:*|*remove*|*delete*) REMOVED+=("$msg") ;;
+    add:*|added:*|feat:*|feature:*|*add*|*implement*) ADDED+=("$msg") ;;
+    change:*|changed:*|refactor:*|update:*|updated:*|*change*|*update*|*refactor*) CHANGED+=("$msg") ;;
+    *) CHANGED+=("$msg") ;;
+  esac
+done <<< "$COMMITS"
+
+section() {
+  local title=$1
+  local arr_name=$2
+  local -n arr="$arr_name"
+  printf '### %s\n' "$title"
+  if ((${#arr[@]} == 0)); then
+    printf -- '- Nothing recorded.\n\n'
+  else
+    printf '%s\n' "${arr[@]}" | sed 's/^/- /'
+    printf '\n'
+  fi
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## %s — generated %s\n\n' "$TODAY" "$SINCE"
+  section Added ADDED
+  section Fixed FIXED
+  section Changed CHANGED
+  section Removed REMOVED
+} > "$OUT"
+
+echo "Generated $OUT ($SINCE)"

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -32,7 +32,9 @@ section() {
   local arr_name=$2
   local -n arr="$arr_name"
   printf '### %s\n' "$title"
-  if ((${#arr[@]} == 0)); then
+  if [[ $(declare -p "$arr_name" 2>/dev/null) == "declare -a $arr_name=()" ]]; then
+    printf -- '- Nothing recorded.\n\n'
+  elif ((${#arr[@]} == 0)); then
     printf -- '- Nothing recorded.\n\n'
   else
     printf '%s\n' "${arr[@]}" | sed 's/^/- /'

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -14,30 +14,31 @@ fi
 COMMITS=$(git log --no-merges --pretty=format:'%s' "$RANGE" 2>/dev/null || true)
 TODAY=$(date +%Y-%m-%d)
 
-declare -a ADDED FIXED CHANGED REMOVED
+ADDED_FILE=$(mktemp)
+FIXED_FILE=$(mktemp)
+CHANGED_FILE=$(mktemp)
+REMOVED_FILE=$(mktemp)
+trap 'rm -f "$ADDED_FILE" "$FIXED_FILE" "$CHANGED_FILE" "$REMOVED_FILE"' EXIT
 while IFS= read -r msg; do
   [[ -z "$msg" ]] && continue
   low=$(printf '%s' "$msg" | tr '[:upper:]' '[:lower:]')
   case "$low" in
-    fix:*|fixed:*|bugfix:*|*fix*|*bug*) FIXED+=("$msg") ;;
-    remove:*|removed:*|delete:*|deleted:*|*remove*|*delete*) REMOVED+=("$msg") ;;
-    add:*|added:*|feat:*|feature:*|*add*|*implement*) ADDED+=("$msg") ;;
-    change:*|changed:*|refactor:*|update:*|updated:*|*change*|*update*|*refactor*) CHANGED+=("$msg") ;;
-    *) CHANGED+=("$msg") ;;
+    fix:*|fixed:*|bugfix:*|*fix*|*bug*) printf '%s\n' "$msg" >> "$FIXED_FILE" ;;
+    remove:*|removed:*|delete:*|deleted:*|*remove*|*delete*) printf '%s\n' "$msg" >> "$REMOVED_FILE" ;;
+    add:*|added:*|feat:*|feature:*|*add*|*implement*) printf '%s\n' "$msg" >> "$ADDED_FILE" ;;
+    change:*|changed:*|refactor:*|update:*|updated:*|*change*|*update*|*refactor*) printf '%s\n' "$msg" >> "$CHANGED_FILE" ;;
+    *) printf '%s\n' "$msg" >> "$CHANGED_FILE" ;;
   esac
 done <<< "$COMMITS"
 
 section() {
   local title=$1
-  local arr_name=$2
-  local -n arr="$arr_name"
+  local file=$2
   printf '### %s\n' "$title"
-  if [[ $(declare -p "$arr_name" 2>/dev/null) == "declare -a $arr_name=()" ]]; then
-    printf -- '- Nothing recorded.\n\n'
-  elif ((${#arr[@]} == 0)); then
+  if [[ ! -s "$file" ]]; then
     printf -- '- Nothing recorded.\n\n'
   else
-    printf '%s\n' "${arr[@]}" | sed 's/^/- /'
+    sed 's/^/- /' "$file"
     printf '\n'
   fi
 }
@@ -45,10 +46,10 @@ section() {
 {
   printf '# Changelog\n\n'
   printf '## %s — generated %s\n\n' "$TODAY" "$SINCE"
-  section Added ADDED
-  section Fixed FIXED
-  section Changed CHANGED
-  section Removed REMOVED
+  section Added "$ADDED_FILE"
+  section Fixed "$FIXED_FILE"
+  section Changed "$CHANGED_FILE"
+  section Removed "$REMOVED_FILE"
 } > "$OUT"
 
 echo "Generated $OUT ($SINCE)"


### PR DESCRIPTION
Implements issue #1.

What is included:
- `generate-changelog/changelog.sh`: Bash changelog generator
- Fetches commits since latest git tag, or full history when no tag exists
- Categorizes commits into Added / Fixed / Changed / Removed
- Writes formatted `CHANGELOG.md` or custom output path
- `generate-changelog/README.md`: setup in 2 commands
- `SAMPLE_CHANGELOG.md`: sample output generated against this repo

Tested with:
```bash
./generate-changelog/changelog.sh SAMPLE_CHANGELOG.md
```