### PR TITLE
feat: add pre-tool-use hook to block destructive bash commands (bounty #3)

### DIFF
--- a/pre-tool-use/README.md
+++ b/pre-tool-use/README.md
@@ -1,0 +1,52 @@
+# Pre-Tool-Use Safety Hook
+
+Blocks destructive bash commands before they execute in Claude Code.
+
+## 🚫 Blocked Patterns
+
+| Pattern | Reason |
+|---------|--------|
+| `rm -rf /`, `rm -rf ~` | Recursive directory deletion |
+| `DROP TABLE` | Destructive SQL |
+| `git push --force` | Force push (destroy history) |
+| `TRUNCATE` | Destructive SQL |
+| `DELETE FROM` *without* `WHERE` | Mass data deletion |
+| `dd if= of=` | Device overwrite |
+| `mkfs.*` | Filesystem creation |
+| Writing to `/dev/*` | Device file access |
+
+## 📦 Installation
+
+```bash
+ln -sf "$(pwd)" ~/.claude/hooks/pre-tool-use
+```
+
+That's it. Claude Code will automatically pick it up on the next request.
+
+## 📋 Logs
+
+Blocked attempts are logged to `~/.claude/hooks/blocked.log`:
+
+```
+[2026-05-26T22:00:00] BLOCKED: rm -rf / recursive delete
+  Command: rm -rf /some/dir
+  Project: /home/user/project
+  ------------------------------------------------------------
+```
+
+## 🧪 Testing
+
+```bash
+chmod +x pre-tool-use/block-bash.py
+echo '{"name":"bash","input":{"command":"rm -rf /tmp/test"}}' | python3 pre-tool-use/block-bash.py
+# → {"is_blocked": true, "message": "⛔ Blocked: ..."}
+
+echo '{"name":"bash","input":{"command":"ls -la"}}' | python3 pre-tool-use/block-bash.py
+# → {"is_blocked": false}
+```
+
+## 📝 Notes
+
+- Written in Python 3 (no external dependencies)
+- Does not interfere with normal bash commands
+- Falls back to **allow** if input is malformed

--- a/pre-tool-use/block-bash.py
+++ b/pre-tool-use/block-bash.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Claude Code pre-tool-use hook: blocks destructive bash commands.
+
+Install: ln -sf "$(pwd)/pre-tool-use" ~/.claude/hooks/
+"""
+
+import json
+import re
+import sys
+import os
+from datetime import datetime
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+DANGEROUS_PATTERNS = [
+    (re.compile(r'\brm\s+(-[rfR]+|--recursive\b|--force\b)', re.IGNORECASE), 'rm -rf / recursive delete'),
+    (re.compile(r'\bDROP\s+TABLE', re.IGNORECASE), 'DROP TABLE (destructive SQL)'),
+    (re.compile(r'\bgit\s+push\s+--force', re.IGNORECASE), 'git push --force (force push)'),
+    (re.compile(r'\bTRUNCATE\b', re.IGNORECASE), 'TRUNCATE (destructive SQL)'),
+    (re.compile(r'\bDELETE\s+FROM\b(?!.*\bWHERE\b)', re.IGNORECASE), 'DELETE FROM without WHERE clause'),
+    (re.compile(r'\brm\s+-rf\s*[/~]', re.IGNORECASE), 'rm -rf on root/home directory'),
+    (re.compile(r'>\s*/dev/\w+', re.IGNORECASE), 'Writing to /dev/ special files'),
+    (re.compile(r'\bdd\s+if=.*\sof=', re.IGNORECASE), 'dd command overwriting device'),
+    (re.compile(r'\bmkfs\.', re.IGNORECASE), 'Filesystem creation tool'),
+]
+
+def log_block(cmd, cwd, reason):
+    """Log blocked command attempt."""
+    try:
+        os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+        with open(LOG_FILE, 'a') as f:
+            f.write(f"[{datetime.now().isoformat()}] BLOCKED: {reason}\n")
+            f.write(f"  Command: {cmd}\n")
+            f.write(f"  Project: {cwd}\n")
+            f.write(f"  { '-' * 60 }\n")
+    except Exception:
+        pass
+
+
+def check_command(cmd, cwd):
+    """Check a command against dangerous patterns. Returns (blocked, reason)."""
+    for pattern, reason in DANGEROUS_PATTERNS:
+        if pattern.search(cmd):
+            return True, reason
+    return False, None
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # If we can't parse input, allow by default
+        print(json.dumps({"is_blocked": False}))
+        return
+
+    tool_name = data.get("name", "")
+    tool_input = data.get("input", {})
+
+    # Only check bash tool calls
+    if tool_name != "bash":
+        print(json.dumps({"is_blocked": False}))
+        return
+
+    command = tool_input.get("command", "")
+    cwd = tool_input.get("cwd", os.getcwd())
+
+    if not command.strip():
+        print(json.dumps({"is_blocked": False}))
+        return
+
+    blocked, reason = check_command(command, cwd)
+    if blocked:
+        log_block(command, cwd, reason)
+        print(json.dumps({
+            "is_blocked": True,
+            "message": f"⛔ Blocked: {reason}\n\n"
+                       f"This command was blocked by the pre-tool-use safety hook.\n"
+                       f"If you need to run this command, manually execute it outside Claude Code."
+        }))
+    else:
+        print(json.dumps({"is_blocked": False}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Bounty #3: Pre-Tool-Use Safety Hook 💰 $100

### What this PR does
Adds a Claude Code `pre-tool-use` hook that intercepts and blocks dangerous bash commands before execution.

### Blocked patterns
- `rm -rf` / recursive delete
- `git push --force` (force push)
- `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without WHERE
- `dd` device overwrites, `mkfs.*`, writes to `/dev/*`

### What it provides
- ✅ Follows Claude Code hooks format
- ✅ Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp + project path
- ✅ Clear block messages explaining why
- ✅ Does NOT interfere with normal bash commands
- ✅ README with 1-command install

### Installation
```bash
ln -sf "$(pwd)/pre-tool-use" ~/.claude/hooks/
```

### Testing
```bash
echo '{"name":"bash","input":{"command":"rm -rf /tmp"}}' | python3 pre-tool-use/block-bash.py
echo '{"name":"bash","input":{"command":"ls -la"}}' | python3 pre-tool-use/block-bash.py
```