### PR TITLE
Add PreToolUse hook to block destructive Bash commands

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,76 @@
+# Destructive Bash Command Guard
+
+This Claude Code `PreToolUse` hook blocks high-risk Bash commands before they run.
+It is intended as a small safety rail for projects that use Claude Code with shell access.
+
+## What It Blocks
+
+- `rm -rf` style recursive forced deletion
+- `DROP TABLE` SQL statements
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- `TRUNCATE` SQL statements
+- `DELETE FROM ...` SQL statements that do not include a `WHERE` clause
+
+Safe commands such as `ls`, `git status`, and `npm test` are allowed.
+
+When a command is blocked, the hook exits with status code `2`, writes a clear reason to
+stderr, and appends a JSON line to `~/.claude/hooks/blocked.log`.
+Each log entry includes a timestamp, project path, reason, and attempted command.
+
+## Install
+
+Run this from the repository root:
+
+```bash
+python .claude/hooks/install_destructive_bash_hook.py
+```
+
+The installer copies the hook into `~/.claude/hooks/` and merges this configuration
+into `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Example
+
+Claude Code sends hook input on stdin. For this payload:
+
+```json
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push --force origin main"
+  },
+  "cwd": "/path/to/project"
+}
+```
+
+The hook blocks the command and returns:
+
+```text
+Blocked destructive Bash command: force push. This command was not executed and was recorded in ~/.claude/hooks/blocked.log.
+```
+
+## Test
+
+Run the test suite from this directory:
+
+```bash
+python -m unittest discover -s tests
+```

--- a/.claude/hooks/block_destructive_bash.py
+++ b/.claude/hooks/block_destructive_bash.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Block destructive Bash commands in Claude Code PreToolUse hooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCKED_COMMANDS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "recursive forced deletion",
+        re.compile(
+            r"(?i)(?:^|[;&|]\s*)(?:sudo\s+)?rm\s+(?=[^;&|]*-[^\s;&|]*r)(?=[^;&|]*-[^\s;&|]*f)"
+        ),
+    ),
+    (
+        "SQL DROP TABLE statement",
+        re.compile(r"(?is)\bdrop\s+table\b"),
+    ),
+    (
+        "force push",
+        re.compile(r"(?i)(?:^|[;&|]\s*)git\s+push\b[^;&|]*(?:--force|-f\b|--force-with-lease)"),
+    ),
+    (
+        "SQL TRUNCATE statement",
+        re.compile(r"(?is)\btruncate(?:\s+table)?\b"),
+    ),
+    (
+        "DELETE statement without WHERE clause",
+        re.compile(r"(?is)\bdelete\s+from\b(?![^;&|]*\bwhere\b)"),
+    ),
+)
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid hook JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("hook JSON must be an object")
+
+    return payload
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    if payload.get("tool_name") != "Bash":
+        return ""
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return ""
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return ""
+
+    return command
+
+
+def find_block_reason(command: str) -> str | None:
+    command = command.strip()
+    if not command:
+        return None
+
+    for reason, pattern in BLOCKED_COMMANDS:
+        if pattern.search(command):
+            return reason
+
+    return None
+
+
+def project_dir(payload: dict[str, Any]) -> Path:
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        return Path(cwd)
+
+    env_project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_project_dir:
+        return Path(env_project_dir)
+
+    return Path.cwd()
+
+
+def hooks_dir() -> Path:
+    env_hooks_dir = os.environ.get("CLAUDE_HOOKS_DIR")
+    if env_hooks_dir:
+        return Path(env_hooks_dir)
+
+    return Path.home() / ".claude" / "hooks"
+
+
+def write_block_log(payload: dict[str, Any], command: str, reason: str) -> None:
+    log_dir = hooks_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "blocked.log"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    cwd = str(project_dir(payload))
+
+    entry = {
+        "timestamp": timestamp,
+        "project_path": cwd,
+        "reason": reason,
+        "command": command,
+    }
+
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    try:
+        payload = load_payload()
+    except ValueError as exc:
+        print(f"Hook input error: {exc}", file=sys.stderr)
+        return 0
+
+    command = extract_command(payload)
+    reason = find_block_reason(command)
+
+    if reason is None:
+        return 0
+
+    try:
+        write_block_log(payload, command, reason)
+    except OSError as exc:
+        print(
+            f"Blocked destructive command, but could not write ~/.claude/hooks/blocked.log: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        "Blocked destructive Bash command: "
+        f"{reason}. This command was not executed and was recorded in ~/.claude/hooks/blocked.log.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/install_destructive_bash_hook.py
+++ b/.claude/hooks/install_destructive_bash_hook.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash guard into the user's Claude Code hooks."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+HOOK_NAME = "block_destructive_bash.py"
+HOOK_COMMAND = f"python ~/.claude/hooks/{HOOK_NAME}"
+
+
+def claude_dir() -> Path:
+    return Path.home() / ".claude"
+
+
+def load_settings(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return data
+
+
+def install_hook_file() -> None:
+    source = Path(__file__).resolve().with_name(HOOK_NAME)
+    target_dir = claude_dir() / "hooks"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target_dir / HOOK_NAME)
+
+
+def merge_hook_settings(settings: dict[str, Any]) -> dict[str, Any]:
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    for matcher in pre_tool_use:
+        if not isinstance(matcher, dict):
+            continue
+        if matcher.get("matcher") != "Bash":
+            continue
+
+        handlers = matcher.setdefault("hooks", [])
+        if any(isinstance(handler, dict) and handler.get("command") == HOOK_COMMAND for handler in handlers):
+            return settings
+
+        handlers.append({"type": "command", "command": HOOK_COMMAND})
+        return settings
+
+    pre_tool_use.append(
+        {
+            "matcher": "Bash",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": HOOK_COMMAND,
+                }
+            ],
+        }
+    )
+    return settings
+
+
+def install_settings() -> Path:
+    settings_path = claude_dir() / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings = merge_hook_settings(load_settings(settings_path))
+
+    with settings_path.open("w", encoding="utf-8") as handle:
+        json.dump(settings, handle, indent=2)
+        handle.write("\n")
+
+    return settings_path
+
+
+def main() -> int:
+    install_hook_file()
+    settings_path = install_settings()
+    print(f"Installed {HOOK_NAME} and updated {settings_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / ".claude" / "hooks" / "block_destructive_bash.py"
+
+
+def run_hook(
+    command: str,
+    cwd: str | None = None,
+    hooks_dir: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    if cwd is not None:
+        payload["cwd"] = cwd
+
+    env = os.environ.copy()
+    if hooks_dir is not None:
+        env["CLAUDE_HOOKS_DIR"] = hooks_dir
+
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+class BlockDestructiveBashTest(unittest.TestCase):
+    def test_allows_safe_commands(self) -> None:
+        for command in ("ls -la", "git status", "npm test", "python -m pytest"):
+            with self.subTest(command=command):
+                result = run_hook(command)
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.stderr, "")
+
+    def test_blocks_recursive_forced_remove(self) -> None:
+        for command in ("rm -rf /tmp/build", "sudo rm -rf /tmp/build", "rm -r -f /tmp/build"):
+            with self.subTest(command=command):
+                result = run_hook(command)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("recursive forced deletion", result.stderr)
+
+    def test_blocks_drop_table(self) -> None:
+        result = run_hook("psql -c 'DROP TABLE users'")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("SQL DROP TABLE", result.stderr)
+
+    def test_blocks_force_push(self) -> None:
+        for command in (
+            "git push --force origin main",
+            "git push -f origin main",
+            "git push --force-with-lease",
+        ):
+            with self.subTest(command=command):
+                result = run_hook(command)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("force push", result.stderr)
+
+    def test_blocks_truncate(self) -> None:
+        result = run_hook("mysql -e 'TRUNCATE TABLE audit_log'")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("SQL TRUNCATE", result.stderr)
+
+    def test_blocks_delete_without_where(self) -> None:
+        result = run_hook("psql -c 'DELETE FROM users'")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("DELETE statement without WHERE", result.stderr)
+
+    def test_allows_delete_with_where(self) -> None:
+        result = run_hook("psql -c 'DELETE FROM users WHERE id = 1'")
+        self.assertEqual(result.returncode, 0)
+
+    def test_ignores_non_bash_tools(self) -> None:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "README.md"},
+        }
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_writes_blocked_log_in_project_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir, tempfile.TemporaryDirectory() as hooks_dir:
+            result = run_hook("git push --force origin main", cwd=temp_dir, hooks_dir=hooks_dir)
+            log_path = Path(hooks_dir) / "blocked.log"
+
+            self.assertEqual(result.returncode, 2)
+            self.assertTrue(log_path.exists())
+
+            entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+            self.assertEqual(entry["project_path"], temp_dir)
+            self.assertEqual(entry["reason"], "force push")
+            self.assertEqual(entry["command"], "git push --force origin main")
+            self.assertIn("timestamp", entry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements a Claude Code PreToolUse hook that blocks destructive Bash commands before execution.

Included:
- Python hook under .claude/hooks/
- Example hooks configuration
- One-command installer
- README with installation and usage
- Tests for safe and blocked commands
- blocked.log entries with timestamp, project path, reason, and attempted command

Tested with:
python -m unittest discover -s tests

Closes #3