### PR TITLE
Add Claude Code hook to block destructive Bash commands

### DIFF
--- a/hooks/block-destructive-bash/README.md
+++ b/hooks/block-destructive-bash/README.md
@@ -1,0 +1,51 @@
+# Block Destructive Bash Commands
+
+Claude Code `PreToolUse` hook that blocks dangerous Bash commands before they execute.
+
+## Install
+
+```bash
+chmod +x hooks/block-destructive-bash/install.sh
+./hooks/block-destructive-bash/install.sh
+```
+
+The installer copies the hook into `~/.claude/hooks/` and adds a `PreToolUse` matcher for the Bash tool in `~/.claude/settings.json`.
+
+## What It Blocks
+
+- `rm -rf` and `rm -fr` style recursive forced deletion
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+- `git push --force`, `git push --force-with-lease`, and `git push -f`
+
+Normal Bash commands continue through the default Claude Code permission flow.
+
+## Logging
+
+Every blocked attempt is appended to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each JSONL entry includes:
+
+- UTC timestamp
+- Attempted command
+- Project path
+- Block reason
+
+## Manual Test
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/demo"},"cwd":"/tmp/project"}' | ~/.claude/hooks/block_destructive_bash.py
+```
+
+Expected output:
+
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked destructive Bash command: rm -rf style recursive forced deletion."}}
+```
+
+Safe commands produce no output and exit successfully.

--- a/hooks/block-destructive-bash/block_destructive_bash.py
+++ b/hooks/block-destructive-bash/block_destructive_bash.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+RM_RF_PATTERN = re.compile(
+    r"(?<!\S)rm\s+(?:-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*|-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*|(?:--recursive\s+--force|--force\s+--recursive))\b",
+    re.IGNORECASE,
+)
+DROP_TABLE_PATTERN = re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE)
+TRUNCATE_PATTERN = re.compile(r"\bTRUNCATE\b", re.IGNORECASE)
+GIT_FORCE_PUSH_PATTERN = re.compile(r"\bgit\s+push\b[^\n;&|]*(?:\s--force(?:-with-lease)?\b|\s-f\b)", re.IGNORECASE)
+DELETE_FROM_PATTERN = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+WHERE_PATTERN = re.compile(r"\bWHERE\b", re.IGNORECASE)
+
+
+def load_input() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+
+
+def sql_statements(command: str) -> list[str]:
+    return [part.strip() for part in re.split(r";|\n", command) if part.strip()]
+
+
+def detect(command: str) -> str | None:
+    checks = [
+        (RM_RF_PATTERN, "rm -rf style recursive forced deletion"),
+        (DROP_TABLE_PATTERN, "DROP TABLE statement"),
+        (TRUNCATE_PATTERN, "TRUNCATE statement"),
+        (GIT_FORCE_PUSH_PATTERN, "git force push"),
+    ]
+    for pattern, reason in checks:
+        if pattern.search(command):
+            return reason
+
+    for statement in sql_statements(command):
+        if DELETE_FROM_PATTERN.search(statement) and not WHERE_PATTERN.search(statement):
+            return "DELETE FROM statement without WHERE clause"
+
+    return None
+
+
+def append_log(command: str, cwd: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": cwd,
+        "reason": reason,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=True) + "\n")
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Blocked destructive Bash command: {reason}.",
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    payload = load_input()
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    if not command.strip():
+        return 0
+
+    reason = detect(command)
+    if not reason:
+        return 0
+
+    cwd = str(payload.get("cwd") or os.getcwd())
+    append_log(command, cwd, reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/block-destructive-bash/install.sh
+++ b/hooks/block-destructive-bash/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_DIR="${HOME}/.claude/hooks"
+SETTINGS_FILE="${HOME}/.claude/settings.json"
+
+mkdir -p "${HOOK_DIR}"
+cp "${SCRIPT_DIR}/block_destructive_bash.py" "${HOOK_DIR}/block_destructive_bash.py"
+chmod +x "${HOOK_DIR}/block_destructive_bash.py"
+
+python3 - "$SETTINGS_FILE" "$HOOK_DIR/block_destructive_bash.py" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1]).expanduser()
+hook_path = sys.argv[2]
+
+if settings_path.exists():
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        raise SystemExit(f"Refusing to overwrite invalid JSON: {settings_path}")
+else:
+    settings = {}
+
+settings.setdefault("hooks", {})
+pre_tool = settings["hooks"].setdefault("PreToolUse", [])
+
+entry = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": hook_path,
+        }
+    ],
+}
+
+def same_entry(existing):
+    return (
+        existing.get("matcher") == "Bash"
+        and any(hook.get("command") == hook_path for hook in existing.get("hooks", []))
+    )
+
+if not any(same_entry(existing) for existing in pre_tool):
+    pre_tool.append(entry)
+
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+print(f"Installed destructive Bash guard in {settings_path}")
+PY

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block-destructive-bash" / "block_destructive_bash.py"
+
+
+class BlockDestructiveBashTests(unittest.TestCase):
+    def run_hook(self, command: str, home: Path) -> subprocess.CompletedProcess[str]:
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": "/tmp/example-project",
+        }
+        return subprocess.run(
+            ["python3", str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+            env={"HOME": str(home), "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"},
+        )
+
+    def assert_blocked(self, command: str, expected: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_hook(command, Path(tmp))
+            self.assertEqual(result.returncode, 0)
+            self.assertIn('"permissionDecision": "deny"', result.stdout)
+            self.assertIn(expected, result.stdout)
+
+            log_path = Path(tmp) / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log_path.exists())
+            log_entry = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(log_entry["attempted_command"], command)
+            self.assertEqual(log_entry["project_path"], "/tmp/example-project")
+
+    def test_blocks_rm_rf(self) -> None:
+        self.assert_blocked("rm -rf build", "rm -rf style recursive forced deletion")
+
+    def test_blocks_drop_table(self) -> None:
+        self.assert_blocked('psql -c "DROP TABLE users"', "DROP TABLE statement")
+
+    def test_blocks_truncate(self) -> None:
+        self.assert_blocked('mysql -e "TRUNCATE audit_log"', "TRUNCATE statement")
+
+    def test_blocks_delete_without_where(self) -> None:
+        self.assert_blocked('psql -c "DELETE FROM sessions"', "DELETE FROM statement without WHERE clause")
+
+    def test_allows_delete_with_where(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_hook('psql -c "DELETE FROM sessions WHERE id = 1"', Path(tmp))
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_blocks_force_push(self) -> None:
+        self.assert_blocked("git push origin main --force", "git force push")
+
+    def test_allows_safe_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_hook("git status && npm test", Path(tmp))
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((Path(tmp) / ".claude" / "hooks" / "blocked.log").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a Claude Code `PreToolUse` hook for issue #3.

What it includes:

- Python hook that inspects Bash tool calls before execution
- Blocks `rm -rf`, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without `WHERE`, and force pushes
- Appends blocked attempts to `~/.claude/hooks/blocked.log`
- Two-command installer that copies the hook and updates `~/.claude/settings.json`
- README with setup and manual test instructions
- Unit tests covering blocked and allowed commands

Verification:

```text
python3 tests/test_block_destructive_bash.py

Ran 7 tests
OK
```

Also checked:

```text
git diff --cached --check
```

No whitespace errors.

Closes #3.