### PR TITLE
Add n8n weekly dev summary workflow

### DIFF
--- a/tests/test_weekly_dev_summary_workflow.py
+++ b/tests/test_weekly_dev_summary_workflow.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / "workflows" / "n8n-weekly-dev-summary" / "weekly-dev-summary.workflow.json"
+
+
+class WeeklyDevSummaryWorkflowTests(unittest.TestCase):
+    def test_workflow_has_required_nodes(self) -> None:
+        workflow = json.loads(WORKFLOW.read_text(encoding="utf-8"))
+        node_names = {node["name"] for node in workflow["nodes"]}
+
+        self.assertIn("Weekly Schedule", node_names)
+        self.assertIn("Fetch Commits", node_names)
+        self.assertIn("Fetch Issues", node_names)
+        self.assertIn("Fetch Pull Requests", node_names)
+        self.assertIn("Claude Summary", node_names)
+        self.assertIn("Send Slack Summary", node_names)
+
+    def test_claude_prompt_requires_no_invention(self) -> None:
+        workflow = json.loads(WORKFLOW.read_text(encoding="utf-8"))
+        claude = next(node for node in workflow["nodes"] if node["name"] == "Claude Summary")
+        body = claude["parameters"]["jsonBody"]
+
+        self.assertIn("Do not invent facts", body)
+        self.assertIn("Executive Summary", body)
+        self.assertIn("Suggested Next Actions", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -1,0 +1,58 @@
+# n8n Weekly Dev Summary
+
+Automated weekly engineering summary workflow for issue #5.
+
+The workflow:
+
+1. Runs every Monday morning.
+2. Pulls recent GitHub commits, issues, and pull requests.
+3. Sends the collected activity to Claude.
+4. Produces a concise weekly dev summary.
+5. Sends the summary to Slack.
+
+## Import
+
+1. Open n8n.
+2. Import `weekly-dev-summary.workflow.json`.
+3. Configure credentials:
+   - GitHub API credential
+   - Anthropic API credential
+   - Slack credential
+4. Set workflow variables:
+   - `owner`
+   - `repo`
+   - `slackChannel`
+5. Run manually once, then activate.
+
+## Required n8n Variables
+
+```text
+owner=your-org
+repo=your-repo
+slackChannel=#engineering
+```
+
+## Claude Prompt
+
+The prompt asks Claude to produce:
+
+- Executive summary
+- Shipped changes
+- Open risks
+- PRs needing attention
+- Suggested next actions
+
+It also asks Claude to avoid inventing facts and to cite the activity items it used.
+
+## Test Instructions
+
+1. Import the workflow into a local n8n instance.
+2. Replace credentials with test credentials or mock nodes.
+3. Run the workflow manually.
+4. Confirm Slack receives a Markdown summary.
+5. Confirm the summary contains commits, issues, PRs, risks, and next actions.
+
+## Files
+
+- `weekly-dev-summary.workflow.json`: importable n8n workflow.
+- `sample-summary.md`: example final Slack message shape.

--- a/workflows/n8n-weekly-dev-summary/sample-summary.md
+++ b/workflows/n8n-weekly-dev-summary/sample-summary.md
@@ -1,0 +1,27 @@
+# Weekly Dev Summary
+
+## Executive Summary
+
+The team shipped several focused changes this week, with most activity around workflow reliability, dependency hygiene, and review throughput.
+
+## Shipped Changes
+
+- Updated release verification documentation.
+- Pinned workflow actions to immutable references.
+- Closed stale dependency update work.
+
+## Open Risks
+
+- Release-only workflow paths should be checked before the next production release.
+- Dependency bumps should be watched for transitive runtime changes.
+
+## PRs Needing Attention
+
+- Review security-sensitive workflow changes before merge.
+- Confirm generated changelog/release notes still match the final commit range.
+
+## Suggested Next Actions
+
+1. Run the release workflow in a dry-run environment.
+2. Review open PRs older than one week.
+3. Convert repeated review comments into a checklist.

--- a/workflows/n8n-weekly-dev-summary/weekly-dev-summary.workflow.json
+++ b/workflows/n8n-weekly-dev-summary/weekly-dev-summary.workflow.json
@@ -1,0 +1,326 @@
+{
+  "name": "Weekly Dev Summary",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "weeks",
+              "triggerAtDay": [
+                1
+              ],
+              "triggerAtHour": 9,
+              "triggerAtMinute": 0
+            }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Weekly Schedule",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -900,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "owner",
+              "name": "owner",
+              "type": "string",
+              "value": "={{ $vars.owner || 'owner' }}"
+            },
+            {
+              "id": "repo",
+              "name": "repo",
+              "type": "string",
+              "value": "={{ $vars.repo || 'repo' }}"
+            },
+            {
+              "id": "since",
+              "name": "since",
+              "type": "string",
+              "value": "={{ new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() }}"
+            },
+            {
+              "id": "slackChannel",
+              "name": "slackChannel",
+              "type": "string",
+              "value": "={{ $vars.slackChannel || '#engineering' }}"
+            }
+          ]
+        }
+      },
+      "id": "set-config",
+      "name": "Set Repo Config",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -680,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $json.owner }}/{{ $json.repo }}/commits?since={{ encodeURIComponent($json.since) }}&per_page=50",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "githubApi",
+        "options": {}
+      },
+      "id": "github-commits",
+      "name": "Fetch Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -440,
+        -220
+      ],
+      "credentials": {
+        "githubApi": {
+          "id": "GITHUB_CREDENTIAL_ID",
+          "name": "GitHub account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Set Repo Config').item.json.owner }}/{{ $('Set Repo Config').item.json.repo }}/issues?state=all&since={{ encodeURIComponent($('Set Repo Config').item.json.since) }}&per_page=50",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "githubApi",
+        "options": {}
+      },
+      "id": "github-issues",
+      "name": "Fetch Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -440,
+        0
+      ],
+      "credentials": {
+        "githubApi": {
+          "id": "GITHUB_CREDENTIAL_ID",
+          "name": "GitHub account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Set Repo Config').item.json.owner }}/{{ $('Set Repo Config').item.json.repo }}/pulls?state=all&sort=updated&direction=desc&per_page=50",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "githubApi",
+        "options": {}
+      },
+      "id": "github-prs",
+      "name": "Fetch Pull Requests",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -440,
+        220
+      ],
+      "credentials": {
+        "githubApi": {
+          "id": "GITHUB_CREDENTIAL_ID",
+          "name": "GitHub account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const commits = $('Fetch Commits').all().flatMap(item => Array.isArray(item.json) ? item.json : [item.json]).slice(0, 50);\nconst issues = $('Fetch Issues').all().flatMap(item => Array.isArray(item.json) ? item.json : [item.json]).filter(item => !item.pull_request).slice(0, 50);\nconst prs = $('Fetch Pull Requests').all().flatMap(item => Array.isArray(item.json) ? item.json : [item.json]).slice(0, 50);\n\nreturn [{\n  json: {\n    owner: $('Set Repo Config').item.json.owner,\n    repo: $('Set Repo Config').item.json.repo,\n    since: $('Set Repo Config').item.json.since,\n    slackChannel: $('Set Repo Config').item.json.slackChannel,\n    commits: commits.map(c => ({ sha: c.sha?.slice(0, 7), message: c.commit?.message, author: c.commit?.author?.name, url: c.html_url })),\n    issues: issues.map(i => ({ number: i.number, title: i.title, state: i.state, url: i.html_url, updatedAt: i.updated_at })),\n    pullRequests: prs.map(p => ({ number: p.number, title: p.title, state: p.state, url: p.html_url, updatedAt: p.updated_at, draft: p.draft }))\n  }\n}];"
+      },
+      "id": "combine-activity",
+      "name": "Combine Activity",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -180,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-3-5-sonnet-latest\",\n  \"max_tokens\": 1800,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Create a weekly dev summary for {{$json.owner}}/{{$json.repo}} since {{$json.since}}. Use only the JSON activity below. Do not invent facts. Return Markdown with these sections: Executive Summary, Shipped Changes, Open Risks, PRs Needing Attention, Suggested Next Actions. Cite commit shas, issue numbers, or PR numbers when available. Activity JSON:\\n\\n\" + JSON.stringify({ commits: $json.commits, issues: $json.issues, pullRequests: $json.pullRequests }, null, 2)\n    }\n  ]\n}"
+      },
+      "id": "claude-summary",
+      "name": "Claude Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        80,
+        0
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "ANTHROPIC_CREDENTIAL_ID",
+          "name": "Anthropic API key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $json;\nconst text = response.content?.map(part => part.text || '').join('\\n') || 'No summary returned.';\nreturn [{ json: { channel: $('Combine Activity').item.json.slackChannel, text } }];"
+      },
+      "id": "extract-summary",
+      "name": "Extract Summary",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        320,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "select": "channel",
+        "channelId": "={{ $json.channel }}",
+        "text": "={{ $json.text }}",
+        "otherOptions": {}
+      },
+      "id": "send-slack",
+      "name": "Send Slack Summary",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.3,
+      "position": [
+        560,
+        0
+      ],
+      "credentials": {
+        "slackOAuth2Api": {
+          "id": "SLACK_CREDENTIAL_ID",
+          "name": "Slack account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Weekly Schedule": {
+      "main": [
+        [
+          {
+            "node": "Set Repo Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Repo Config": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Issues",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Pull Requests",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits": {
+      "main": [
+        [
+          {
+            "node": "Combine Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Issues": {
+      "main": [
+        [
+          {
+            "node": "Combine Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Pull Requests": {
+      "main": [
+        [
+          {
+            "node": "Combine Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Combine Activity": {
+      "main": [
+        [
+          {
+            "node": "Claude Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Summary": {
+      "main": [
+        [
+          {
+            "node": "Extract Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Summary": {
+      "main": [
+        [
+          {
+            "node": "Send Slack Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": false
+}


### PR DESCRIPTION
This PR adds an importable n8n workflow for issue #5.

What it includes:

- Weekly schedule trigger
- GitHub commits/issues/PR activity collection
- Activity aggregation node
- Claude summary call
- Slack delivery node
- README with import/config/test instructions
- Sample weekly summary output
- JSON validation and workflow structure tests

Verification:

```text
python3 tests/test_weekly_dev_summary_workflow.py

Ran 2 tests
OK
```

Also checked:

```text
python3 -m json.tool workflows/n8n-weekly-dev-summary/weekly-dev-summary.workflow.json
git diff --cached --check
```

No JSON or whitespace errors.

Closes #5.