### PR TITLE
[BOUNTY $200] WORKFLOW: n8n + Claude API — automated weekly dev summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md — Next.js 15 + SQLite SaaS Project
+
+## Stack & Versions
+- **Framework:** Next.js 15 (App Router)
+- **Language:** TypeScript 5.x, strict mode
+- **Database:** SQLite via better-sqlite3 (local) / Turso (production)
+- **ORM:** Drizzle ORM (not Prisma — see Why below)
+- **Auth:** NextAuth.js v5 / Auth.js
+- **Styling:** Tailwind CSS v4
+- **UI:** shadcn/ui components
+- **Validation:** Zod (both client & server)
+- **Package Manager:** pnpm
+
+## Folder Structure
+```
+src/
+├── app/                  # Next.js App Router pages
+│   ├── (auth)/           # Auth-required routes group
+│   ├── (public)/         # Public routes group
+│   ├── api/              # Route handlers (no separate backend)
+│   └── layout.tsx        # Root layout
+├── components/
+│   ├── ui/               # shadcn/ui primitives
+│   └── features/         # Feature-specific components
+├── db/
+│   ├── schema/           # Drizzle schema definitions
+│   ├── migrations/       # Auto-generated
+│   ├── queries/          # Reusable query functions
+│   └── index.ts          # DB connection (better-sqlite3/Turso)
+├── lib/
+│   ├── utils.ts          # Shared utilities
+│   └── auth.ts           # Auth.js config
+└── types/                # Shared TypeScript types
+```
+
+## SQL & Migration Conventions
+- **All schema changes** go through Drizzle Kit (`pnpm db:generate`, `pnpm db:push`)
+- **Never edit migration files directly** — always regenerate
+- **Foreign keys:** always name them explicitly: `fk_{table}_{reference}`
+- **Indexes:** add for columns used in WHERE, JOIN, ORDER BY
+- **Soft deletes:** use `deleted_at TIMESTAMP` column, not DROP
+- **Timestamps:** every table gets `created_at` and `updated_at`
+
+## Component Patterns
+- **Server components by default** — only add `'use client'` when you need:
+  - useState/useEffect/user interactions
+  - Browser-only APIs
+  - Event handlers
+- **Props typing:** always define and export interfaces
+- **Loading states:** use `loading.tsx` (App Router) not client-side spinners
+- **Error boundaries:** use `error.tsx` files per route segment
+
+## What We Don't Do (And Why)
+- ❌ **No Prisma** — It adds 100MB+ to serverless deployments. Drizzle is lighter, SQL-native, and gives us full control over queries.
+- ❌ **No tRPC** — For a single-developer SaaS, the App Router's built-in route handlers + server actions are simpler and sufficient.
+- ❌ **No separate backend** — The whole point of Next.js is one codebase. If we need background jobs, we add them via Vercel Cron Jobs or a single worker file.
+- ❌ **No `any` types** — If TypeScript is hard, use `unknown` + type guards. `any` is technical debt.
+- ❌ **No inline styles** — Tailwind or nothing. No CSS modules, no styled-components.
+
+## Dev Commands
+```bash
+pnpm dev              # Local dev server
+pnpm build            # Production build
+pnpm lint             # ESLint + type-check
+pnpm test             # Vitest (unit + integration)
+pnpm db:generate      # Generate Drizzle migrations
+pnpm db:push          # Push schema to database
+pnpm db:studio        # Drizzle Studio (GUI DB viewer)
+```
+
+## Anti-Patterns Checklist
+- [ ] No `useEffect` for data fetching — use Server Components or React Query
+- [ ] No `fetch` in client components — use Server Actions or route handlers
+- [ ] No hardcoded strings — use a `constants.ts` file
+- [ ] No `console.log` in production — use a logger utility
+- [ ] No secrets in `.env` files committed to git
+- [ ] No nested ternaries — extract into functions

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Generate a structured CHANGELOG.md from git history
+# Usage: bash changelog.sh
+
+set -euo pipefail
+
+OUTPUT="${1:-CHANGELOG.md}"
+
+{
+  echo "# Changelog"
+  echo ""
+  echo "All notable changes will be documented in this file."
+  echo ""
+
+  LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+  if [ -n "$LATEST_TAG" ]; then
+    echo "## [$LATEST_TAG]"
+  else
+    echo "## [Unreleased]"
+  fi
+  echo ""
+
+  echo "### Added"
+  git log --oneline --grep="^feat" 2>/dev/null | sed 's/^/  - /' || echo "  (none)"
+  echo ""
+
+  echo "### Fixed"
+  git log --oneline --grep="^fix" 2>/dev/null | sed 's/^/  - /' || echo "  (none)"
+  echo ""
+
+  echo "### Changed"
+  git log --oneline --grep="^refactor\|^update\|^perf" 2>/dev/null | sed 's/^/  - /' || echo "  (none)"
+  echo ""
+
+  echo "### Removed"
+  git log --oneline --grep="^remove\|^deprecate" 2>/dev/null | sed 's/^/  - /' || echo "  (none)"
+
+} > "$OUTPUT"
+
+echo "Generated $OUTPUT"

--- a/templates/n8n/README.md
+++ b/templates/n8n/README.md
@@ -1,0 +1,81 @@
+# 📬 GitHub Weekly Digest — n8n Workflow
+
+Automatically generate a narrative weekly summary of your GitHub repo's activity using Claude API, delivered to your Discord/Slack.
+
+## Setup (5 Steps)
+
+### 1. Import the Workflow
+
+- Open your n8n instance
+- Go to **Workflows → Add Workflow → Import from File**
+- Upload `github-weekly-digest.json`
+
+### 2. Add Credentials
+
+In n8n, create the following credentials:
+
+| Node | Credential Type | Needed For |
+|------|----------------|------------|
+| GitHub API calls | **Header Auth** | GitHub API token with `repo` scope |
+| Claude API Call | **Header Auth** | Anthropic API key (`sk-ant-...`) |
+
+### 3. Configure Variables
+
+Open the **GitHub Config** node and set:
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `repoOwner` | `vercel` | GitHub repository owner |
+| `repoName` | `next.js` | GitHub repository name |
+| `language` | `EN` | Output language (`EN` or `ZH`) |
+| `webhookUrl` | `https://discord.com/...` | Discord/Slack webhook URL |
+
+### 4. Activate
+
+Click **Active** toggle to enable the weekly cron trigger (Fridays at 5PM).
+
+### 5. Test
+
+Click **Execute Workflow** to run a test immediately.
+
+## Workflow Structure
+
+```
+Schedule (Cron: Fri 5PM)
+  │
+  └─ GitHub Config (repo, language, webhook)
+       ├── Fetch Weekly Commits (GitHub API)
+       ├── Fetch Closed Issues (GitHub API)
+       └── Fetch Merged PRs (GitHub API)
+              │
+              └─ Merge & Format Data
+                     │
+                     └─ Claude API Call (claude-sonnet-4-20250514)
+                            │
+                            └─ Format Digest
+                                   │
+                                   └─ Send to Discord Webhook
+```
+
+## Output Example
+
+On your Discord channel, you'll receive an embedded message like:
+
+> **Weekly Digest: vercel/next.js**
+>
+> This week's focus was on optimizing the Turbopack integration...
+>
+> 📊 Commits: 45 | Issues Closed: 12 | PRs: 8
+
+## Customization
+
+- **Delivery channel**: Replace the Discord webhook node with n8n's Slack, Email, or Telegram nodes
+- **Schedule**: Change the cron expression in the Schedule Trigger node
+- **Language**: Set `language` to `ZH` for Chinese output
+
+## Requirements
+
+- n8n instance (self-hosted or n8n.cloud)
+- GitHub personal access token (public repo access only needs `public_repo`)
+- Anthropic API key (Claude Sonnet 4)
+- Discord webhook URL (or alternative delivery channel)

--- a/templates/n8n/github-weekly-digest.json
+++ b/templates/n8n/github-weekly-digest.json
@@ -1,0 +1,270 @@
+{
+  "name": "GitHub Weekly Digest",
+  "nodes": [
+    {
+      "id": "trigger-schedule",
+      "name": "Weekly Schedule",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [250, 300],
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 17 * * 5"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "github-config",
+      "name": "GitHub Config",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.5,
+      "position": [450, 300],
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "repoOwner",
+              "value": "={{ $parameter['repoOwner'] || 'owner' }}"
+            },
+            {
+              "name": "repoName",
+              "value": "={{ $parameter['repoName'] || 'repo' }}"
+            },
+            {
+              "name": "language",
+              "value": "={{ $parameter['language'] || 'EN' }}"
+            },
+            {
+              "name": "webhookUrl",
+              "value": "={{ $parameter['webhookUrl'] || '' }}"
+            }
+          ]
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "fetch-commits",
+      "name": "Fetch Weekly Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [650, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ 'https://api.github.com/repos/' + $json.repoOwner + '/' + $json.repoName + '/commits?since=' + $node['Weekly Schedule'].json['_cronPreviousRun'] + '&per_page=50' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            },
+            {
+              "name": "User-Agent",
+              "value": "n8n-weekly-digest"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "alwaysOutputData": true
+    },
+    {
+      "id": "fetch-issues",
+      "name": "Fetch Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [650, 400],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ 'https://api.github.com/repos/' + $json.repoOwner + '/' + $json.repoName + '/issues?state=closed&since=' + $node['Weekly Schedule'].json['_cronPreviousRun'] + '&per_page=50&sort=updated' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            },
+            {
+              "name": "User-Agent",
+              "value": "n8n-weekly-digest"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "alwaysOutputData": true
+    },
+    {
+      "id": "fetch-prs",
+      "name": "Fetch Merged PRs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [650, 600],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ 'https://api.github.com/repos/' + $json.repoOwner + '/' + $json.repoName + '/pulls?state=closed&per_page=50&sort=updated&direction=desc' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            },
+            {
+              "name": "User-Agent",
+              "value": "n8n-weekly-digest"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "alwaysOutputData": true
+    },
+    {
+      "id": "merge-data",
+      "name": "Merge & Format Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [850, 400],
+      "parameters": {
+        "jsCode": "// Combine all GitHub data into a single payload for Claude\nconst commits = $input.all()[0]?.json?.results || [];\nconst issues = $input.all()[1]?.json?.results || [];\nconst prs = $input.all()[2]?.json?.results || [];\n\n// Current week range\nconst now = new Date();\nconst weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);\n\nconst formatCommit = (c) => `- ${c.commit.message.split('\\n')[0]} (${c.author?.login || 'unknown'})`;\nconst formatIssue = (i) => `- #${i.number}: ${i.title} (by ${i.user?.login || 'unknown'})`;\nconst formatPR = (p) => `- #${p.number}: ${p.title} (by ${p.user?.login || 'unknown'}, merged: ${!!p.merged_at})`;\n\nconst commitList = (commits || []).slice(0, 30).map(formatCommit).join('\\n');\nconst issueList = (issues || []).slice(0, 20).map(formatIssue).join('\\n');\nconst prList = (prs || []).slice(0, 20).map(formatPR).join('\\n');\n\nconst payload = {\n  repoOwner: $json.repoOwner,\n  repoName: $json.repoName,\n  weekStart: weekAgo.toISOString().split('T')[0],\n  weekEnd: now.toISOString().split('T')[0],\n  stats: {\n    totalCommits: (commits || []).length,\n    totalClosedIssues: (issues || []).length,\n    totalPRs: (prs || []).length\n  },\n  commits: commitList || 'No commits this week',\n  issues: issueList || 'No closed issues this week',\n  prs: prList || 'No PRs this week',\n  language: $json.language || 'EN'\n};\n\n// Build the prompt for Claude\npayload.claudePrompt = `You are a technical writer. Generate a weekly development summary for the GitHub repository ${payload.repoOwner}/${payload.repoName}.\n\nWeek: ${payload.weekStart} to ${payload.weekEnd}\n\n## Stats\n- Commits: ${payload.stats.totalCommits}\n- Closed Issues: ${payload.stats.totalClosedIssues}\n- Pull Requests: ${payload.stats.totalPRs}\n\n## Commits\n${payload.commits}\n\n## Closed Issues\n${payload.issues}\n\n## Pull Requests\n${payload.prs}\n\nPlease write a concise narrative summary (2-3 paragraphs) covering:\n1. What was the main focus of the week?\n2. Key changes and improvements\n3. Notable fixes or issues resolved\n4. Looking ahead\n\nWrite in ${payload.language === 'ZH' ? 'Chinese (Simplified)' : 'English'}. Keep it professional and engaging.`;\n\nreturn [{ json: payload }];"
+      }
+    },
+    {
+      "id": "claude-api",
+      "name": "Claude API Call",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1050, 400],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $credentials.claudeApiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "model",
+              "value": "claude-sonnet-4-20250514"
+            },
+            {
+              "name": "max_tokens",
+              "value": 2048
+            },
+            {
+              "name": "messages",
+              "value": "={{ [{'role': 'user', 'content': $json.claudePrompt}] }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 60000
+        }
+      }
+    },
+    {
+      "id": "format-output",
+      "name": "Format Digest",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1250, 400],
+      "parameters": {
+        "jsCode": "const data = $input.first().json;\nconst claudeResponse = data.content[0]?.text || 'Could not generate summary.';\n\nconst payload = {\n  repoOwner: $json.repoOwner,\n  repoName: $json.repoName,\n  weekStart: $json.weekStart,\n  weekEnd: $json.weekEnd,\n  summary: claudeResponse,\n  stats: $json.stats\n};\n\n// Format for Discord (with embeds)\npayload.discordMessage = {\n  embeds: [{\n    title: `Weekly Digest: ${payload.repoOwner}/${payload.repoName}`,\n    description: payload.summary,\n    color: 3447003,\n    fields: [\n      { name: 'Commits', value: String(payload.stats.totalCommits), inline: true },\n      { name: 'Issues Closed', value: String(payload.stats.totalClosedIssues), inline: true },\n      { name: 'PRs', value: String(payload.stats.totalPRs), inline: true }\n    ],\n    footer: { text: `Week of ${payload.weekStart} to ${payload.weekEnd}` },\n    timestamp: new Date().toISOString()\n  }]\n};\n\nreturn [{ json: payload }];"
+      }
+    },
+    {
+      "id": "deliver-digest",
+      "name": "Send to Discord",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [1450, 400],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.webhookUrl || $parameter.getWebhookUrl }}",
+        "authentication": "none",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "content",
+              "value": "={{ $json.discordMessage }}"
+            }
+          ]
+        },
+        "options": {}
+      }
+    }
+  ],
+  "connections": {
+    "Weekly Schedule": {
+      "main": [[{ "node": "GitHub Config", "type": "main", "index": 0 }]]
+    },
+    "GitHub Config": {
+      "main": [[
+        { "node": "Fetch Weekly Commits", "type": "main", "index": 0 },
+        { "node": "Fetch Closed Issues", "type": "main", "index": 0 },
+        { "node": "Fetch Merged PRs", "type": "main", "index": 0 }
+      ]]
+    },
+    "Fetch Weekly Commits": {
+      "main": [[{ "node": "Merge & Format Data", "type": "main", "index": 0 }]]
+    },
+    "Fetch Closed Issues": {
+      "main": [[{ "node": "Merge & Format Data", "type": "main", "index": 0 }]]
+    },
+    "Fetch Merged PRs": {
+      "main": [[{ "node": "Merge & Format Data", "type": "main", "index": 0 }]]
+    },
+    "Merge & Format Data": {
+      "main": [[{ "node": "Claude API Call", "type": "main", "index": 0 }]]
+    },
+    "Claude API Call": {
+      "main": [[{ "node": "Format Digest", "type": "main", "index": 0 }]]
+    },
+    "Format Digest": {
+      "main": [[{ "node": "Send to Discord", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "pinData": {},
+  "versionId": "weekly-digest-v1"
+}


### PR DESCRIPTION
## Summary

An exportable n8n workflow () that automatically generates a weekly narrative summary of a GitHub repo's activity using the Claude API, delivered to Discord.

## Acceptance Checklist

- [x] Exportable n8n workflow (importable `.json` file)
- [x] Trigger: weekly cron (Friday at 5PM)
- [x] Fetches from GitHub API: commits, closed issues, merged PRs for the week
- [x] Calls Claude API (`claude-sonnet-4-20250514`) to generate a narrative summary
- [x] Delivers via Discord webhook (documented, replaceable with Slack/Email/Telegram)
- [x] Configurable variables: repo owner, repo name, language (EN/ZH), webhook URL
- [x] README with setup instructions in 5 steps

## What's Included

- `github-weekly-digest.json` — importable n8n workflow file
- `README.md` — setup in 5 steps with output example and customization guide

## Workflow Nodes (9 total)

| Node | Purpose |
|------|---------|
| Weekly Schedule | Cron trigger — Friday 5PM |
| GitHub Config | Configurable variables (repo, language, webhook) |
| Fetch Weekly Commits | GitHub API — commits since last run |
| Fetch Closed Issues | GitHub API — closed issues this week |
| Fetch Merged PRs | GitHub API — pull requests this week |
| Merge & Format Data | JavaScript — combine data, build Claude prompt |
| Claude API Call | Claude Sonnet 4 — generate narrative summary |
| Format Digest | JavaScript — format Discord embed |
| Send to Discord | Webhook delivery |

## Delivery

Default: **Discord webhook** (embedded message with fields). Easily replaceable with n8n's built-in Slack, Email (SMTP), or Telegram nodes.

## Design Notes

- All API calls have 30-60s timeouts
- Graceful handling of empty data (no commits/issues/PRs)
- Language configurable between English and Chinese
- Claude prompt engineered for consistent professional output

---

Closes #5