### PR TITLE
Add destructive bash command hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,24 @@
+# Destructive Bash Command Hook
+
+This Claude Code `PreToolUse` hook blocks dangerous Bash commands before they run.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block_destructive_bash.py ~/.claude/hooks/block_destructive_bash.py && chmod +x ~/.claude/hooks/block_destructive_bash.py
+cp hooks/settings.example.json ~/.claude/settings.json
+```
+
+If you already have `~/.claude/settings.json`, copy only the `PreToolUse` hook entry from `hooks/settings.example.json` instead of replacing the file.
+
+## What It Blocks
+
+- `rm -rf`, including `rm -fr` and combined flag variants
+- `DROP TABLE`
+- `git push --force`, `git push --force-with-lease`, and `git push -f`
+- `TRUNCATE`
+- `DELETE FROM` statements that do not include a `WHERE` clause
+
+Blocked attempts are appended to `~/.claude/hooks/blocked.log` as JSON lines with timestamp, attempted command, project path, and reason.
+
+Safe Bash commands produce no output and continue through the normal Claude Code permission flow.

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BLOCK_PATTERNS = (
+    (
+        "rm -rf",
+        re.compile(r"\brm\s+(?:-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*|-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*)\b"),
+        "Recursive force delete can permanently remove files.",
+    ),
+    (
+        "DROP TABLE",
+        re.compile(r"\bdrop\s+table\b", re.IGNORECASE),
+        "Dropping a table is destructive and should be reviewed manually.",
+    ),
+    (
+        "git push --force",
+        re.compile(r"\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?|-f)\b", re.IGNORECASE),
+        "Force-pushing can overwrite remote history.",
+    ),
+    (
+        "TRUNCATE",
+        re.compile(r"\btruncate\b", re.IGNORECASE),
+        "TRUNCATE removes data without row-by-row safeguards.",
+    ),
+)
+
+DELETE_FROM_PATTERN = re.compile(r"\bdelete\s+from\b(?P<body>.*?)(?:;|$)", re.IGNORECASE | re.DOTALL)
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        deny(f"Could not parse hook input JSON: {exc}", command="<invalid-json>", project_path=os.getcwd())
+        raise SystemExit(0)
+
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def get_command(payload: dict[str, Any]) -> str:
+    tool_input = payload.get("tool_input", {})
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command", "")
+        if isinstance(command, str):
+            return command
+    return ""
+
+
+def get_project_path(payload: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "project_dir"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def find_block_reason(command: str) -> str | None:
+    for name, pattern, reason in BLOCK_PATTERNS:
+        if pattern.search(command):
+            return f"{name}: {reason}"
+
+    for match in DELETE_FROM_PATTERN.finditer(command):
+        if not re.search(r"\bwhere\b", match.group("body"), re.IGNORECASE):
+            return "DELETE FROM without WHERE: add a WHERE clause or run the command manually."
+
+    return None
+
+
+def log_block(command: str, project_path: str, reason: str) -> None:
+    home = Path(os.environ.get("HOME") or str(Path.home()))
+    log_path = home / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
+    entry = {
+        "timestamp": timestamp,
+        "command": command,
+        "project_path": project_path,
+        "reason": reason,
+    }
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def deny(reason: str, command: str, project_path: str) -> None:
+    log_block(command, project_path, reason)
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "Blocked dangerous Bash command. "
+                        f"{reason} Attempted command: {command!r}. "
+                        "This attempt was logged to ~/.claude/hooks/blocked.log."
+                    ),
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    payload = load_payload()
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = get_command(payload)
+    reason = find_block_reason(command)
+    if not reason:
+        return 0
+
+    deny(reason, command=command, project_path=get_project_path(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/settings.example.json
+++ b/hooks/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,84 @@
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import block_destructive_bash
+
+
+class BlockDestructiveBashTest(unittest.TestCase):
+    def run_hook(self, payload, home):
+        old_stdin = sys.stdin
+        old_home = os.environ.get("HOME")
+        sys.stdin = io.StringIO(json.dumps(payload))
+        os.environ["HOME"] = str(home)
+        try:
+            with redirect_stdout(io.StringIO()) as stdout:
+                exit_code = block_destructive_bash.main()
+            return exit_code, stdout.getvalue()
+        finally:
+            sys.stdin = old_stdin
+            if old_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = old_home
+
+    def test_blocks_required_patterns(self):
+        blocked_commands = [
+            "rm -rf build",
+            "rm -fr build",
+            "psql -c 'DROP TABLE users'",
+            "git push --force origin main",
+            "git push -f origin main",
+            "sqlite3 app.db 'TRUNCATE sessions'",
+            "sqlite3 app.db 'DELETE FROM users'",
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            for command in blocked_commands:
+                exit_code, output = self.run_hook(
+                    {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": "/repo"},
+                    home,
+                )
+                self.assertEqual(exit_code, 0)
+                response = json.loads(output)
+                hook_output = response["hookSpecificOutput"]
+                self.assertEqual(hook_output["permissionDecision"], "deny")
+                self.assertIn("Blocked dangerous Bash command", hook_output["permissionDecisionReason"])
+
+            log_lines = (home / ".claude" / "hooks" / "blocked.log").read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(log_lines), len(blocked_commands))
+            self.assertEqual(json.loads(log_lines[0])["project_path"], "/repo")
+
+    def test_allows_safe_bash_commands(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            exit_code, output = self.run_hook(
+                {"tool_name": "Bash", "tool_input": {"command": "npm test && git status"}, "cwd": "/repo"},
+                Path(temp_dir),
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(output, "")
+
+    def test_allows_delete_with_where(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            exit_code, output = self.run_hook(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "sqlite3 app.db 'DELETE FROM users WHERE id = 1'"},
+                    "cwd": "/repo",
+                },
+                Path(temp_dir),
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(output, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a Claude Code `PreToolUse` Bash hook that denies destructive commands using the official hook JSON response shape
- Block `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without `WHERE`
- Log blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, project path, and reason
- Include a two-command install README, settings example, and unit tests

## Testing
- `python -m unittest -v tests.test_block_destructive_bash`
- `git diff --check`
- Manual JSON smoke test against `git push --force origin main`, verified deny output and blocked.log entry

Refs #3