### PR TITLE
feat: add git history changelog generator skill

### DIFF
--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased - 2026-05-28
+
+Generated from commits for entire history.
+
+### Added
+- feat: initial README with bounty board (1aeae2a)
+
+### Fixed
+- No notable fixes.
+
+### Changed
+- No notable changes.
+
+### Removed
+- No notable removals.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,21 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from git history.
+
+## Command
+
+```bash
+bash changelog.sh
+```
+
+## What it does
+
+- Finds commits since the last git tag, or all history if no tag exists.
+- Groups commit subjects into `Added`, `Fixed`, `Changed`, `Removed`.
+- Writes a Keep-a-Changelog-style `CHANGELOG.md`.
+
+## Setup: 3 steps
+
+1. Copy `changelog.sh` into any git repo.
+2. Run `bash changelog.sh`.
+3. Review/commit the generated `CHANGELOG.md`.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT=${1:-CHANGELOG.md}
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [ -n "$LAST_TAG" ]; then
+  RANGE="$LAST_TAG..HEAD"
+  SINCE="since $LAST_TAG"
+else
+  RANGE="HEAD"
+  SINCE="for entire history"
+fi
+
+map_commits() {
+  local pattern=$1
+  git log "$RANGE" --no-merges --pretty=format:'%s (%h)' 2>/dev/null \
+    | awk -v pat="$pattern" 'BEGIN{IGNORECASE=1} $0 ~ pat {print "- " $0}'
+}
+
+ADDED=$(map_commits '^(feat|add|create|implement)(\(.+\))?:|add|new|implement')
+FIXED=$(map_commits '^(fix|bugfix|hotfix)(\(.+\))?:|fix|bug|error|crash')
+CHANGED=$(map_commits '^(change|refactor|perf|docs|style|test|chore)(\(.+\))?:|change|update|refactor|improve')
+REMOVED=$(map_commits '^(remove|delete|drop)(\(.+\))?:|remove|delete|drop|deprecat')
+
+uncategorized=$(git log "$RANGE" --no-merges --pretty=format:'%s (%h)' 2>/dev/null \
+  | awk 'BEGIN{IGNORECASE=1} $0 !~ /^(feat|add|create|implement|fix|bugfix|hotfix|change|refactor|perf|docs|style|test|chore|remove|delete|drop)(\(.+\))?:|add|new|implement|fix|bug|error|crash|change|update|refactor|improve|remove|delete|drop|deprecat/ {print "- " $0}')
+[ -z "$CHANGED" ] && CHANGED=$uncategorized
+
+date_utc=$(date -u +%Y-%m-%d)
+{
+  echo "# Changelog"
+  echo
+  echo "## Unreleased - $date_utc"
+  echo
+  echo "Generated from commits $SINCE."
+  echo
+  echo "### Added";   [ -n "$ADDED" ] && echo "$ADDED" || echo "- No notable additions."
+  echo
+  echo "### Fixed";   [ -n "$FIXED" ] && echo "$FIXED" || echo "- No notable fixes."
+  echo
+  echo "### Changed"; [ -n "$CHANGED" ] && echo "$CHANGED" || echo "- No notable changes."
+  echo
+  echo "### Removed"; [ -n "$REMOVED" ] && echo "$REMOVED" || echo "- No notable removals."
+} > "$OUT"
+
+echo "Wrote $OUT ($SINCE)"


### PR DESCRIPTION
Closes #1

## Summary
- Adds `changelog.sh` to generate a structured `CHANGELOG.md` from git history since the last tag.
- Adds `SKILL.md` with 3-step setup instructions.
- Includes `SAMPLE_CHANGELOG.md` generated from this repository as a real test output.

## Test
- `bash changelog.sh SAMPLE_CHANGELOG.md`