### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/README-destructive-command-hook.md
+++ b/README-destructive-command-hook.md
@@ -1,0 +1,41 @@
+# Destructive Command PreToolUse Hook
+
+Blocks dangerous Bash commands before Claude Code can run them.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks && cp destructive-command-hook.py ~/.claude/hooks/destructive-command-hook.py && chmod +x ~/.claude/hooks/destructive-command-hook.py
+```
+
+Add this hook to your Claude Code settings for Bash `PreToolUse` events:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/destructive-command-hook.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## What it blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force` and `git push --force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM ...` statements without a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` with timestamp, attempted command, and project path.
+
+Normal Bash commands exit `0` and pass through untouched.

--- a/destructive-command-hook.py
+++ b/destructive-command-hook.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive bash commands.
+
+Install under ~/.claude/hooks/ and register it for Bash PreToolUse events.
+The hook reads Claude Code's JSON event from stdin and exits non-zero when the
+attempted Bash command matches a dangerous pattern.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    ("rm -rf", re.compile(r"(^|[;&|`$()\s])rm\s+(?:-[A-Za-z]*r[A-Za-z]*f|- [^\n]*|-[A-Za-z]*f[A-Za-z]*r)\b", re.I), "recursive forced delete"),
+    ("DROP TABLE", re.compile(r"\bdrop\s+table\b", re.I), "SQL table drop"),
+    ("git push --force", re.compile(r"\bgit\s+push\b[^\n;&|]*\s--force(?:\b|=|-with-lease)", re.I), "forced git push"),
+    ("TRUNCATE", re.compile(r"\btruncate\b", re.I), "SQL truncate"),
+    (
+        "DELETE FROM without WHERE",
+        re.compile(r"\bdelete\s+from\b(?:(?!\bwhere\b|;|\n).)*(?:;|$)", re.I | re.S),
+        "SQL delete without WHERE clause",
+    ),
+]
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    """Handle common Claude Code hook payload shapes."""
+    candidates = [
+        payload.get("command"),
+        payload.get("tool_input", {}).get("command") if isinstance(payload.get("tool_input"), dict) else None,
+        payload.get("input", {}).get("command") if isinstance(payload.get("input"), dict) else None,
+        payload.get("parameters", {}).get("command") if isinstance(payload.get("parameters"), dict) else None,
+    ]
+    for value in candidates:
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "workspace", "repository"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return os.getcwd()
+
+
+def log_block(command: str, project: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(f"{stamp}\t{project}\t{reason}\t{safe_command}\n")
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {"command": raw}
+
+    command = extract_command(payload)
+    if not command:
+        return 0
+
+    for name, pattern, reason in PATTERNS:
+        if pattern.search(command):
+            project = project_path(payload)
+            log_block(command, project, name)
+            print(
+                f"Blocked destructive Bash command: {reason}. Pattern: {name}. "
+                f"No command was run. Logged to {LOG_PATH}.",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_destructive_command_hook.py
+++ b/test_destructive_command_hook.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+
+HOOK = "./destructive-command-hook.py"
+
+cases = [
+    ({"tool_input": {"command": "echo ok"}, "cwd": "/tmp/project"}, 0),
+    ({"tool_input": {"command": "rm -rf build"}, "cwd": "/tmp/project"}, 2),
+    ({"tool_input": {"command": "psql -c 'DROP TABLE users'"}, "cwd": "/tmp/project"}, 2),
+    ({"tool_input": {"command": "git push origin main --force"}, "cwd": "/tmp/project"}, 2),
+    ({"tool_input": {"command": "sqlite3 db 'DELETE FROM users;'"}, "cwd": "/tmp/project"}, 2),
+    ({"tool_input": {"command": "sqlite3 db 'DELETE FROM users WHERE id=1;'"}, "cwd": "/tmp/project"}, 0),
+]
+
+for payload, expected in cases:
+    proc = subprocess.run([sys.executable, HOOK], input=json.dumps(payload), text=True)
+    assert proc.returncode == expected, (payload, proc.returncode, expected)
+
+print("all destructive-command-hook checks passed")


### PR DESCRIPTION
Implements the $100 destructive Bash PreToolUse hook bounty (#3).

What is included:
- `destructive-command-hook.py`: Claude Code PreToolUse hook for Bash payloads
- Blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without `WHERE`
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
- Clear stderr message explaining why the command was blocked
- `README-destructive-command-hook.md`: install in one command plus settings snippet
- `test_destructive_command_hook.py`: smoke tests covering blocked and allowed commands

Tested locally:
```bash
python3 test_destructive_command_hook.py
# all destructive-command-hook checks passed
```

Closes #3