### PR TITLE
Add Claude PR reviewer agent

### DIFF
--- a/pr-reviewer-agent/README.md
+++ b/pr-reviewer-agent/README.md
@@ -1,0 +1,84 @@
+# Claude PR Reviewer Agent
+
+`claude-review` is a self-contained Claude Code PR reviewer agent. It accepts a public GitHub pull request URL, reads the PR diff, and prints a structured Markdown review comment with a short summary, risks, suggestions, and a confidence score.
+
+The command works without GitHub credentials for public PRs and has no third-party Python dependencies. When the Claude Code CLI is available, `--use-claude` can route the diff through Claude; otherwise the built-in deterministic reviewer still produces the required structured output.
+
+## Install
+
+From this folder:
+
+```bash
+chmod +x bin/claude-review
+```
+
+Optionally add the `bin` directory to your `PATH`:
+
+```bash
+export PATH="$PWD/bin:$PATH"
+```
+
+## Usage
+
+Review a public GitHub PR:
+
+```bash
+bin/claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+Write the Markdown review to a file:
+
+```bash
+bin/claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+Review a local diff:
+
+```bash
+bin/claude-review --diff-file ./example.diff
+```
+
+Use the Claude Code CLI when it is installed and authenticated locally:
+
+```bash
+bin/claude-review --use-claude --pr https://github.com/owner/repo/pull/123
+```
+
+The deterministic fallback is useful for CI and for reviewers who do not want to connect any account. The Claude path is optional because this bounty deliverable must be runnable from a clean checkout.
+
+## Output Format
+
+Every run emits Markdown with:
+
+- `### Summary of Changes`
+- `### Identified Risks`
+- `### Improvement Suggestions`
+- `### Confidence Score: Low|Medium|High`
+
+## Claude Code Sub-Agent Prompt
+
+The reusable sub-agent prompt lives at `claude-agents/pr-reviewer.md`. You can copy it into a Claude Code agent setup or use the CLI's `--use-claude` flag to send an equivalent prompt to the local `claude` binary.
+
+## Optional GitHub Action
+
+This folder includes `github-action/claude-review.yml` as a copy-paste workflow example. It posts the generated review as a PR comment using the default `GITHUB_TOKEN`. The CLI route above is the primary acceptance path.
+
+## Sample Outputs
+
+Two real public PR runs are included in:
+
+- `samples/github-gitignore-4857.md`
+- `samples/github-gitignore-4500.md`
+
+Regenerate them with:
+
+```bash
+bin/claude-review --pr https://github.com/github/gitignore/pull/4857 --output samples/github-gitignore-4857.md
+bin/claude-review --pr https://github.com/github/gitignore/pull/4500 --output samples/github-gitignore-4500.md
+```
+
+## Verify
+
+```bash
+PYTHONPATH=src python3 -m unittest discover tests
+```

--- a/pr-reviewer-agent/bin/claude-review
+++ b/pr-reviewer-agent/bin/claude-review
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Entrypoint for the PR reviewer agent."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from claude_review_agent import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pr-reviewer-agent/claude-agents/pr-reviewer.md
+++ b/pr-reviewer-agent/claude-agents/pr-reviewer.md
@@ -1,0 +1,36 @@
+# PR Reviewer Agent
+
+Use this Claude Code sub-agent to review pull request diffs and return a single structured Markdown comment.
+
+## Inputs
+
+- A public GitHub PR URL, or
+- A raw unified diff.
+
+## Instructions
+
+1. Read the diff carefully and infer the changed files, behavior, tests, and operational impact.
+2. Avoid claiming that tests passed unless the diff or user explicitly provides test output.
+3. Prioritize concrete risks over generic review advice.
+4. Return only Markdown in the exact structure below.
+
+## Output
+
+```markdown
+## PR Review
+
+### Summary of Changes
+Two to three sentences summarizing the changed behavior and scope.
+
+### Identified Risks
+- Risk 1
+- Risk 2
+
+### Improvement Suggestions
+- Suggestion 1
+- Suggestion 2
+
+### Confidence Score: Low|Medium|High
+```
+
+Use `High` only when the diff is small and clear, `Medium` when the diff is understandable but broad or partially indirect, and `Low` when key context is missing or the diff is truncated.

--- a/pr-reviewer-agent/github-action/claude-review.yml
+++ b/pr-reviewer-agent/github-action/claude-review.yml
@@ -1,0 +1,35 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Generate structured PR review
+        run: |
+          python3 pr-reviewer-agent/bin/claude-review \
+            --pr "${{ github.event.pull_request.html_url }}" \
+            --output /tmp/claude-pr-review.md
+
+      - name: Post review comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const body = fs.readFileSync("/tmp/claude-pr-review.md", "utf8");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });

--- a/pr-reviewer-agent/samples/github-gitignore-4500.md
+++ b/pr-reviewer-agent/samples/github-gitignore-4500.md
@@ -1,0 +1,14 @@
+## PR Review
+
+### Summary of Changes
+This PR changes 1 file with 4 additions and 0 deletions. The touched paths include UnrealEngine.gitignore. The review below is based on the public diff and highlights structural risks for a human reviewer to confirm.
+
+### Identified Risks
+- Configuration or automation files changed; deployment behavior may differ from local behavior.
+
+### Improvement Suggestions
+- Add or reference focused tests that exercise the changed behavior before merging.
+
+### Confidence Score: High
+
+_Source: https://github.com/github/gitignore/pull/4500_

--- a/pr-reviewer-agent/samples/github-gitignore-4857.md
+++ b/pr-reviewer-agent/samples/github-gitignore-4857.md
@@ -1,0 +1,14 @@
+## PR Review
+
+### Summary of Changes
+This PR changes 1 file with 4 additions and 0 deletions. The touched paths include Node.gitignore. The review below is based on the public diff and highlights structural risks for a human reviewer to confirm.
+
+### Identified Risks
+- Configuration or automation files changed; deployment behavior may differ from local behavior.
+
+### Improvement Suggestions
+- Add or reference focused tests that exercise the changed behavior before merging.
+
+### Confidence Score: High
+
+_Source: https://github.com/github/gitignore/pull/4857_

--- a/pr-reviewer-agent/src/claude_review_agent.py
+++ b/pr-reviewer-agent/src/claude_review_agent.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Review a GitHub pull request diff and emit a structured Markdown comment."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+GITHUB_PR_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)/?$"
+)
+FILE_RE = re.compile(r"^diff --git a/(.*?) b/(.*)$")
+HUNK_RE = re.compile(r"^@@")
+GENERATED_HINTS = (
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "poetry.lock",
+    "go.sum",
+)
+TEST_HINTS = ("/test", "test_", "_test.", ".spec.", ".test.", "__tests__", "tests/")
+SECURITY_HINTS = (
+    "auth",
+    "permission",
+    "token",
+    "secret",
+    "password",
+    "csrf",
+    "xss",
+    "sql",
+    "session",
+    "cookie",
+)
+CONFIG_HINTS = (".github/", "dockerfile", "compose", ".env", "config", "settings", ".gitignore")
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    owner: str
+    repo: str
+    number: str
+    url: str
+
+
+@dataclass
+class FileChange:
+    old_path: str
+    new_path: str
+    additions: int = 0
+    deletions: int = 0
+    hunks: int = 0
+    is_deleted: bool = False
+    is_new: bool = False
+
+    @property
+    def path(self) -> str:
+        return self.new_path if self.new_path != "/dev/null" else self.old_path
+
+
+@dataclass
+class DiffStats:
+    files: list[FileChange]
+    additions: int
+    deletions: int
+    truncated: bool = False
+
+
+def parse_pr_url(url: str) -> PullRequest:
+    match = GITHUB_PR_RE.match(url.strip())
+    if not match:
+        raise ValueError("Expected a GitHub PR URL like https://github.com/owner/repo/pull/123")
+    parts = match.groupdict()
+    return PullRequest(parts["owner"], parts["repo"], parts["number"], url.rstrip("/"))
+
+
+def diff_url_for(pr: PullRequest) -> str:
+    return f"https://github.com/{pr.owner}/{pr.repo}/pull/{pr.number}.diff"
+
+
+def fetch_url(url: str, timeout: int = 30) -> str:
+    request = Request(url, headers={"User-Agent": "claude-review-agent/1.0"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except HTTPError as exc:
+        raise RuntimeError(f"GitHub returned HTTP {exc.code} for {url}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Could not fetch {url}: {exc.reason}") from exc
+
+
+def parse_diff(diff: str, max_chars: int | None = None) -> DiffStats:
+    truncated = False
+    if max_chars is not None and len(diff) > max_chars:
+        diff = diff[:max_chars]
+        truncated = True
+
+    files: list[FileChange] = []
+    current: FileChange | None = None
+
+    for line in diff.splitlines():
+        file_match = FILE_RE.match(line)
+        if file_match:
+            current = FileChange(file_match.group(1), file_match.group(2))
+            files.append(current)
+            continue
+        if current is None:
+            continue
+        if line.startswith("new file mode"):
+            current.is_new = True
+        elif line.startswith("deleted file mode"):
+            current.is_deleted = True
+        elif line.startswith("--- /dev/null"):
+            current.is_new = True
+        elif line.startswith("+++ /dev/null"):
+            current.is_deleted = True
+        elif HUNK_RE.match(line):
+            current.hunks += 1
+        elif line.startswith("+") and not line.startswith("+++"):
+            current.additions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            current.deletions += 1
+
+    return DiffStats(
+        files=files,
+        additions=sum(item.additions for item in files),
+        deletions=sum(item.deletions for item in files),
+        truncated=truncated,
+    )
+
+
+def load_diff(pr_url: str | None, diff_file: str | None, max_chars: int | None) -> tuple[str, str]:
+    if diff_file:
+        source = Path(diff_file)
+        return source.read_text(encoding="utf-8"), f"local diff file {source}"
+    if not pr_url:
+        raise ValueError("Provide --pr or --diff-file")
+    pr = parse_pr_url(pr_url)
+    url = diff_url_for(pr)
+    return fetch_url(url), pr.url
+
+
+def summarize_files(files: list[FileChange], limit: int = 8) -> str:
+    if not files:
+        return "No changed files were detected in the supplied diff."
+    visible = files[:limit]
+    names = ", ".join(change.path for change in visible)
+    remaining = len(files) - len(visible)
+    if remaining > 0:
+        names += f", and {remaining} more"
+    return names
+
+
+def has_any(path: str, hints: Iterable[str]) -> bool:
+    lower = path.lower()
+    return any(hint in lower for hint in hints)
+
+
+def build_risks(stats: DiffStats) -> list[str]:
+    risks: list[str] = []
+    paths = [change.path for change in stats.files]
+    code_files = [
+        path
+        for path in paths
+        if not path.endswith((".md", ".txt", ".rst", ".gitignore")) and not has_any(path, GENERATED_HINTS)
+    ]
+    test_files = [path for path in paths if has_any(path, TEST_HINTS)]
+
+    if stats.truncated:
+        risks.append("The diff was truncated for analysis, so later files or hunks may be missing from this review.")
+    if len(stats.files) >= 20 or stats.additions + stats.deletions >= 800:
+        risks.append("The PR has broad change volume, increasing the chance of missed regressions during manual review.")
+    if code_files and not test_files:
+        risks.append("Code files changed without an obvious accompanying test file in the diff.")
+    if any(has_any(path, SECURITY_HINTS) for path in paths):
+        risks.append("Authentication, authorization, credential, or query-related paths changed and deserve security-focused review.")
+    if any(has_any(path, CONFIG_HINTS) for path in paths):
+        risks.append("Configuration or automation files changed; deployment behavior may differ from local behavior.")
+    if any(has_any(path, GENERATED_HINTS) for path in paths):
+        risks.append("Dependency lockfiles changed; dependency resolution and supply-chain impact should be checked.")
+    if any(change.is_deleted for change in stats.files):
+        risks.append("At least one file was deleted, so downstream imports or documentation links may break.")
+    if not risks:
+        risks.append("No major structural risks were detected from the diff shape; review should still validate behavior and tests.")
+    return risks
+
+
+def build_suggestions(stats: DiffStats) -> list[str]:
+    suggestions: list[str] = []
+    paths = [change.path for change in stats.files]
+
+    if any(not has_any(path, TEST_HINTS) for path in paths) and not any(has_any(path, TEST_HINTS) for path in paths):
+        suggestions.append("Add or reference focused tests that exercise the changed behavior before merging.")
+    if stats.additions + stats.deletions >= 300:
+        suggestions.append("Split unrelated changes or add a short reviewer guide in the PR description to reduce review load.")
+    if any(has_any(path, SECURITY_HINTS) for path in paths):
+        suggestions.append("Include negative-path checks for unauthorized users, malformed input, and secret handling.")
+    if any(has_any(path, GENERATED_HINTS) for path in paths):
+        suggestions.append("Confirm dependency changes are intentional and generated by the expected package manager version.")
+    if any(path.endswith((".md", ".rst")) for path in paths):
+        suggestions.append("Preview the rendered documentation to catch broken links, headings, or formatting regressions.")
+    if not suggestions:
+        suggestions.append("Keep the PR description aligned with the final behavior and include the commands used to verify it.")
+    return suggestions
+
+
+def confidence(stats: DiffStats) -> str:
+    if stats.truncated or len(stats.files) == 0:
+        return "Low"
+    if len(stats.files) > 15 or stats.additions + stats.deletions > 600:
+        return "Medium"
+    return "High"
+
+
+def render_local_review(source: str, diff: str, max_chars: int | None) -> str:
+    stats = parse_diff(diff, max_chars=max_chars)
+    file_count = len(stats.files)
+    change_word = "file" if file_count == 1 else "files"
+    addition_word = "addition" if stats.additions == 1 else "additions"
+    deletion_word = "deletion" if stats.deletions == 1 else "deletions"
+    summary = (
+        f"This PR changes {file_count} {change_word} with {stats.additions} {addition_word} "
+        f"and {stats.deletions} {deletion_word}. The touched paths include {summarize_files(stats.files)}. "
+        "The review below is based on the public diff and highlights structural risks for a human reviewer to confirm."
+    )
+
+    lines = [
+        "## PR Review",
+        "",
+        "### Summary of Changes",
+        summary,
+        "",
+        "### Identified Risks",
+    ]
+    lines.extend(f"- {risk}" for risk in build_risks(stats))
+    lines.extend(["", "### Improvement Suggestions"])
+    lines.extend(f"- {suggestion}" for suggestion in build_suggestions(stats))
+    lines.extend(["", f"### Confidence Score: {confidence(stats)}", "", f"_Source: {source}_"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def claude_prompt(source: str, diff: str, max_chars: int | None) -> str:
+    if max_chars is not None and len(diff) > max_chars:
+        diff = diff[:max_chars] + "\n\n[Diff truncated by claude-review before sending to Claude.]\n"
+    return f"""You are a Claude Code pull request reviewer sub-agent.
+
+Review the PR diff from {source}. Return only Markdown with these sections:
+
+## PR Review
+### Summary of Changes
+2-3 sentences.
+### Identified Risks
+Bulleted list.
+### Improvement Suggestions
+Bulleted list.
+### Confidence Score: Low|Medium|High
+
+Diff:
+```diff
+{diff}
+```
+"""
+
+
+def run_claude_review(source: str, diff: str, max_chars: int | None, timeout: int) -> str | None:
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        return None
+    prompt = claude_prompt(source, diff, max_chars)
+    completed = subprocess.run(
+        [claude_bin, "-p", prompt],
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return None
+    return completed.stdout.strip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="claude-review",
+        description="Review a GitHub PR diff and print a structured Markdown review comment.",
+    )
+    parser.add_argument("--pr", help="Public GitHub PR URL, for example https://github.com/owner/repo/pull/123")
+    parser.add_argument("--diff-file", help="Read a local .diff file instead of fetching GitHub")
+    parser.add_argument("--output", "-o", help="Write Markdown review to this file")
+    parser.add_argument("--max-diff-chars", type=int, default=60000, help="Maximum diff characters to analyze")
+    parser.add_argument(
+        "--use-claude",
+        action="store_true",
+        help="Use the local Claude Code CLI when available; otherwise falls back to deterministic local review",
+    )
+    parser.add_argument("--claude-timeout", type=int, default=120, help="Timeout in seconds for Claude CLI")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        diff, source = load_diff(args.pr, args.diff_file, args.max_diff_chars)
+        review = None
+        if args.use_claude or os.getenv("CLAUDE_REVIEW_USE_CLAUDE") == "1":
+            review = run_claude_review(source, diff, args.max_diff_chars, args.claude_timeout)
+        if review is None:
+            review = render_local_review(source, diff, args.max_diff_chars)
+        if args.output:
+            Path(args.output).write_text(review, encoding="utf-8")
+        else:
+            sys.stdout.write(review)
+        return 0
+    except Exception as exc:
+        parser.exit(2, f"claude-review: {exc}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pr-reviewer-agent/tests/test_claude_review_agent.py
+++ b/pr-reviewer-agent/tests/test_claude_review_agent.py
@@ -1,0 +1,56 @@
+import unittest
+
+from claude_review_agent import parse_diff, parse_pr_url, render_local_review
+
+
+SAMPLE_DIFF = """diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1,3 +1,5 @@
+ def login(user):
+-    return True
++    if not user:
++        return False
++    return user.is_active
+diff --git a/README.md b/README.md
+index 3333333..4444444 100644
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
+ # Demo
++Usage notes
+"""
+
+
+class PullRequestParsingTest(unittest.TestCase):
+    def test_parse_pr_url(self):
+        pr = parse_pr_url("https://github.com/example/project/pull/42")
+        self.assertEqual(pr.owner, "example")
+        self.assertEqual(pr.repo, "project")
+        self.assertEqual(pr.number, "42")
+
+    def test_parse_pr_url_rejects_non_pr(self):
+        with self.assertRaises(ValueError):
+            parse_pr_url("https://github.com/example/project/issues/42")
+
+
+class DiffReviewTest(unittest.TestCase):
+    def test_parse_diff_counts_files_and_changes(self):
+        stats = parse_diff(SAMPLE_DIFF)
+        self.assertEqual(len(stats.files), 2)
+        self.assertEqual(stats.additions, 4)
+        self.assertEqual(stats.deletions, 1)
+        self.assertEqual(stats.files[0].path, "app.py")
+
+    def test_render_review_has_required_sections(self):
+        review = render_local_review("sample", SAMPLE_DIFF, max_chars=None)
+        self.assertIn("### Summary of Changes", review)
+        self.assertIn("### Identified Risks", review)
+        self.assertIn("### Improvement Suggestions", review)
+        self.assertRegex(review, r"### Confidence Score: (Low|Medium|High)")
+        self.assertIn("Code files changed", review)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4.

## Summary

Adds `pr-reviewer-agent`, a self-contained PR review agent that accepts a public GitHub pull request URL or local diff and emits a structured Markdown review comment.

It includes:

- `bin/claude-review`: executable CLI wrapper,
- `src/claude_review_agent.py`: dependency-free implementation,
- `claude-agents/pr-reviewer.md`: reusable Claude Code sub-agent prompt,
- `github-action/claude-review.yml`: optional workflow example for posting review comments,
- `samples/`: two sample outputs from public GitHub PRs,
- `tests/`: unit tests for parsing and structured review output.

The CLI works without personal credentials for public PRs. If a local `claude` binary is available, `--use-claude` can route the review prompt through Claude Code; otherwise a deterministic fallback still produces the required Markdown structure.

## Verification

```bash
cd pr-reviewer-agent
PYTHONPATH=src python3 -m unittest discover tests
```

Result:

```text
Ran 4 tests in 0.001s
OK
```
