### PR TITLE
Add destructive Bash command hook

### DIFF
--- a/destructive-command-hook/README.md
+++ b/destructive-command-hook/README.md
@@ -1,0 +1,36 @@
+# Destructive Bash Command Hook
+
+Claude Code `PreToolUse` hook that blocks dangerous Bash commands before they run.
+
+## Install
+
+From this repository root:
+
+```bash
+bash destructive-command-hook/install.sh
+```
+
+That single command copies the hook to `~/.claude/hooks/block_destructive_bash.py` and registers it for `PreToolUse` Bash calls in `~/.claude/settings.json`.
+
+## What It Blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force` and `git push -f`
+- `TRUNCATE`
+- `DELETE FROM ...` without a `WHERE` clause
+
+Normal Bash commands are allowed. Blocked attempts are logged to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each log entry includes timestamp, project path, matched rule, and attempted command.
+
+## Test Locally
+
+```bash
+python3 destructive-command-hook/test_hook.py
+```
+

--- a/destructive-command-hook/block_destructive_bash.py
+++ b/destructive-command-hook/block_destructive_bash.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _log_path() -> Path:
+    home = os.environ.get("HOME")
+    base = Path(home) if home else Path.home()
+    return base / ".claude" / "hooks" / "blocked.log"
+
+
+def _collapse_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def _strip_sql_comments(command: str) -> str:
+    command = re.sub(r"--.*?$", "", command, flags=re.MULTILINE)
+    command = re.sub(r"/\*.*?\*/", "", command, flags=re.DOTALL)
+    return command
+
+
+def _delete_without_where(command: str) -> bool:
+    sql = _strip_sql_comments(command)
+    statements = [part.strip() for part in sql.split(";") if part.strip()]
+    for statement in statements:
+        normalized = _collapse_whitespace(statement).lower()
+        if not re.search(r"\bdelete\s+from\b", normalized):
+            continue
+        if not re.search(r"\bwhere\b", normalized):
+            return True
+    return False
+
+
+def detect_block_reason(command: str) -> str | None:
+    checks = [
+        (r"(?i)(^|[;&|]\s*)rm\s+(-[A-Za-z]*r[A-Za-z]*f|-[-A-Za-z]*force[-A-Za-z]*recursive|-[-A-Za-z]*recursive[-A-Za-z]*force)\b", "rm -rf recursively deletes files without confirmation"),
+        (r"(?i)\bdrop\s+table\b", "DROP TABLE can destroy database schema/data"),
+        (r"(?i)\bgit\s+push\b[^\n;&|]*\s(--force|-f)(\s|$)", "force-pushing can overwrite remote history"),
+        (r"(?i)\btruncate\b", "TRUNCATE can delete table contents without row-level safeguards"),
+    ]
+    for pattern, reason in checks:
+        if re.search(pattern, command):
+            return reason
+    if _delete_without_where(command):
+        return "DELETE FROM without WHERE can delete every row in a table"
+    return None
+
+
+def _read_payload() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _command_from_payload(payload: dict) -> str:
+    if payload.get("tool_name") != "Bash":
+        return ""
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def _project_path(payload: dict) -> str:
+    cwd = payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    return str(cwd)
+
+
+def _log_block(command: str, project_path: str, reason: str) -> None:
+    try:
+        log_path = _log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).isoformat()
+        safe_command = command.replace("\n", "\\n")
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                f"{timestamp}\tproject={project_path}\trule={reason}\tcommand={safe_command}\n"
+            )
+    except OSError:
+        pass
+
+
+def _deny(reason: str, command: str) -> None:
+    message = (
+        "Blocked destructive Bash command before execution. "
+        f"Reason: {reason}. Command: {command}"
+    )
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": message,
+                }
+            }
+        )
+    )
+
+
+def _allow() -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": "Command passed destructive-command checks.",
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    payload = _read_payload()
+    command = _command_from_payload(payload)
+    if not command:
+        _allow()
+        return 0
+
+    reason = detect_block_reason(command)
+    if reason:
+        _log_block(command, _project_path(payload), reason)
+        _deny(reason, command)
+        return 0
+
+    _allow()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/destructive-command-hook/install.sh
+++ b/destructive-command-hook/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="${HOME}/.claude/hooks"
+settings_path="${HOME}/.claude/settings.json"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$hook_dir"
+cp "$script_dir/block_destructive_bash.py" "$hook_dir/block_destructive_bash.py"
+chmod +x "$hook_dir/block_destructive_bash.py"
+
+python3 - "$settings_path" "$hook_dir/block_destructive_bash.py" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+hook_path = Path(sys.argv[2])
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+if settings_path.exists() and settings_path.read_text(encoding="utf-8").strip():
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+else:
+    data = {}
+
+hooks = data.setdefault("hooks", {})
+pre_tool = hooks.setdefault("PreToolUse", [])
+command = f"python3 {hook_path}"
+
+entry = {
+    "matcher": "Bash",
+    "hooks": [{"type": "command", "command": command}],
+}
+
+for existing in pre_tool:
+    if existing.get("matcher") != "Bash":
+        continue
+    existing_hooks = existing.setdefault("hooks", [])
+    if not any(hook.get("command") == command for hook in existing_hooks):
+        existing_hooks.append({"type": "command", "command": command})
+    break
+else:
+    pre_tool.append(entry)
+
+settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+print(f"Installed hook and updated {settings_path}")
+PY
+

--- a/destructive-command-hook/test_hook.py
+++ b/destructive-command-hook/test_hook.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Smoke tests for block_destructive_bash.py without requiring Claude Code."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HOOK = Path(__file__).with_name("block_destructive_bash.py")
+
+
+def run_hook(command: str, home: str) -> dict:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": "/tmp/example-project",
+        "tool_input": {"command": command},
+    }
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+        env={**os.environ, "HOME": home},
+    )
+    return json.loads(result.stdout)
+
+
+def decision(output: dict) -> str:
+    return output["hookSpecificOutput"]["permissionDecision"]
+
+
+def main() -> int:
+    blocked = [
+        "rm -rf node_modules",
+        "DROP TABLE users;",
+        "git push --force origin main",
+        "git push -f",
+        "TRUNCATE TABLE sessions;",
+        "DELETE FROM users;",
+    ]
+    allowed = [
+        "ls -la",
+        "rm -r build",
+        "git push origin main",
+        "DELETE FROM users WHERE id = ?;",
+        "npm run build",
+    ]
+
+    with tempfile.TemporaryDirectory() as home:
+        for command in blocked:
+            assert decision(run_hook(command, home)) == "deny", command
+        for command in allowed:
+            assert decision(run_hook(command, home)) == "allow", command
+
+    print("All destructive-command hook tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #3.

## Summary

Adds `destructive-command-hook`, a Claude Code `PreToolUse` hook that blocks dangerous Bash commands before execution.

It blocks:

- `rm -rf`,
- `DROP TABLE`,
- `git push --force` / `git push -f`,
- `TRUNCATE`,
- `DELETE FROM ...` without `WHERE`.

It allows normal commands and logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, project path, rule, and command.

## Files

- `destructive-command-hook/block_destructive_bash.py`: hook implementation.
- `destructive-command-hook/install.sh`: one-command installer that copies the hook and registers it in `~/.claude/settings.json`.
- `destructive-command-hook/test_hook.py`: local smoke tests using simulated Claude Code hook payloads.
- `destructive-command-hook/README.md`: install and test instructions.

## Verification

```bash
python3 destructive-command-hook/test_hook.py
```

Result:

```text
All destructive-command hook tests passed.
```

Also tested installer against a temporary `HOME`; it created `.claude/settings.json` with a `PreToolUse` Bash hook entry.
