### PR TITLE
Add generate changelog script

### DIFF
--- a/generate-changelog/README.md
+++ b/generate-changelog/README.md
@@ -1,0 +1,16 @@
+# Generate Changelog
+
+Create a structured `CHANGELOG.md` from commits since the latest git tag.
+
+## Setup
+
+1. Copy `changelog.sh` into the root of any git repository.
+2. Run `bash changelog.sh` or `bash changelog.sh v1.2.3` to override the base tag.
+3. Commit the generated `CHANGELOG.md`.
+
+## What It Does
+
+- Finds commits since the latest reachable tag, or all commits when no tag exists.
+- Categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a Keep a Changelog-style Markdown file with commit hashes for traceability.
+

--- a/generate-changelog/SAMPLE_OUTPUT.md
+++ b/generate-changelog/SAMPLE_OUTPUT.md
@@ -1,0 +1,37 @@
+# Sample Output
+
+Tested on `ritesh-1918/HELPDESK.AI` after fetching its `gssoc` branch and tags:
+
+```bash
+bash generate-changelog/changelog.sh v1.0.1-mobile
+```
+
+Excerpt:
+
+```markdown
+# Changelog
+
+## [Unreleased] - 2026-05-28
+
+_Generated from git history since v1.0.1-mobile._
+
+### Added
+
+- feat: implement real-time AI processing stream and fix ticket creation 405 error (9e50e3f)
+- feat: add backend readiness healthcheck (c88ced5)
+- feat: override weak ML predictions with LLM categorization for multilingual support (954b1aa)
+
+### Fixed
+
+- fix: resolve github action deployment error and missing favicon (7c42140)
+- fix: use jsonable_encoder to prevent json.dumps crash on numpy types in SSE stream (c29bbeb)
+- fix: handle classifier_v3 fallback gracefully to prevent confidence keyerror (9390c3e)
+
+### Changed
+
+- chore: add lint-staged config to run ESLint on staged frontend files (a1e8a77)
+
+### Removed
+
+- No entries.
+```

--- a/generate-changelog/changelog.sh
+++ b/generate-changelog/changelog.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+base_ref="${1:-}"
+if [[ -z "$base_ref" ]]; then
+  base_ref="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+fi
+
+if [[ -n "$base_ref" ]]; then
+  range="${base_ref}..HEAD"
+  since_label="since ${base_ref}"
+else
+  range="HEAD"
+  since_label="from initial commit"
+fi
+
+version="${CHANGELOG_VERSION:-Unreleased}"
+date_utc="$(date -u +%Y-%m-%d)"
+tmp_file="$(mktemp)"
+
+git log --no-merges --reverse --format='%h%x09%s' "$range" > "$tmp_file"
+
+declare -a added fixed changed removed uncategorized
+added=()
+fixed=()
+changed=()
+removed=()
+uncategorized=()
+
+append_item() {
+  local bucket="$1"
+  local hash="$2"
+  local subject="$3"
+  local item="- ${subject} (${hash})"
+
+  case "$bucket" in
+    added) added+=("$item") ;;
+    fixed) fixed+=("$item") ;;
+    changed) changed+=("$item") ;;
+    removed) removed+=("$item") ;;
+    *) uncategorized+=("$item") ;;
+  esac
+}
+
+while IFS=$'\t' read -r hash subject; do
+  [[ -z "${hash:-}" || -z "${subject:-}" ]] && continue
+
+  normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  case "$normalized" in
+    feat:*|feat\(*|feature:*|add:*|added:*|implement:*|create:*)
+      append_item added "$hash" "$subject"
+      ;;
+    fix:*|fix\(*|bug:*|bugfix:*|hotfix:*|repair:*|resolve:*)
+      append_item fixed "$hash" "$subject"
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|deprecate:*)
+      append_item removed "$hash" "$subject"
+      ;;
+    refactor:*|change:*|changed:*|update:*|updated:*|improve:*|docs:*|test:*|chore:*|ci:*)
+      append_item changed "$hash" "$subject"
+      ;;
+    *)
+      uncategorized+=("- ${subject} (${hash})")
+      ;;
+  esac
+done < "$tmp_file"
+
+rm -f "$tmp_file"
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  printf '### %s\n\n' "$title"
+  if [[ "${#items[@]}" -eq 0 ]]; then
+    printf -- '- No entries.\n\n'
+  else
+    printf '%s\n' "${items[@]}"
+    printf '\n'
+  fi
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## [%s] - %s\n\n' "$version" "$date_utc"
+  printf '_Generated from git history %s._\n\n' "$since_label"
+  write_section "Added" "${added[@]+"${added[@]}"}"
+  write_section "Fixed" "${fixed[@]+"${fixed[@]}"}"
+  write_section "Changed" "${changed[@]+"${changed[@]}"}" "${uncategorized[@]+"${uncategorized[@]}"}"
+  write_section "Removed" "${removed[@]+"${removed[@]}"}"
+} > CHANGELOG.md
+
+echo "Generated CHANGELOG.md (${since_label})"


### PR DESCRIPTION
Closes #1.

## Summary

Adds `generate-changelog/changelog.sh`, a dependency-free Bash script that:

- finds commits since the latest reachable git tag, or accepts an explicit base tag argument,
- categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`,
- writes a formatted `CHANGELOG.md`,
- preserves commit hashes for traceability.

Also includes a 3-step README and a sample output file.

## Verification

Tested in this repository:

```bash
bash generate-changelog/changelog.sh
```

Result:

```text
Generated CHANGELOG.md (from initial commit)
```

Also tested on `ritesh-1918/HELPDESK.AI` using an explicit tag:

```bash
bash generate-changelog/changelog.sh v1.0.1-mobile
```

The generated changelog included categorized `feat:`, `fix:`, and `chore:` commits.
