### PR TITLE
Add destructive Bash command PreToolUse hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,29 @@
+# Destructive Bash Command Hook
+
+Claude Code `PreToolUse` hook that blocks risky Bash commands before execution.
+
+## Install
+
+```bash
+python3 hooks/install_destructive_command_hook.py
+```
+
+The installer copies `block_destructive_bash.py` to `~/.claude/hooks/` and
+registers it in `~/.claude/settings.json` for the `Bash` tool.
+
+## Blocked Patterns
+
+- `rm -rf`, including `rm -fr`, split flags, and long `--recursive --force`
+- `DROP TABLE`
+- `git push --force`, including `--force-with-lease` and `-f`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+
+Every blocked command is appended to `~/.claude/hooks/blocked.log` as JSON with
+timestamp, attempted command, project path, and matched rule.
+
+## Test
+
+```bash
+python3 -m unittest tests/test_block_destructive_bash.py
+```

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+HOOK_EVENT_NAME = "PreToolUse"
+BLOCKED_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
+DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\btruncate\b", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+
+
+def shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return command.split()
+
+
+def has_rm_rf(tokens: list[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if Path(token).name != "rm":
+            continue
+
+        recursive = False
+        forced = False
+        for option in tokens[index + 1 :]:
+            if not option.startswith("-"):
+                break
+            if option in {"--recursive", "--dir"}:
+                recursive = True
+            if option in {"--force"}:
+                forced = True
+            if option.startswith("-") and not option.startswith("--"):
+                flags = option.lstrip("-").lower()
+                recursive = recursive or "r" in flags
+                forced = forced or "f" in flags
+            if recursive and forced:
+                return True
+    return False
+
+
+def has_git_force_push(tokens: list[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if Path(token).name != "git":
+            continue
+
+        after_git = tokens[index + 1 :]
+        try:
+            push_index = after_git.index("push")
+        except ValueError:
+            continue
+
+        for option in after_git[push_index + 1 :]:
+            if option in {"--force", "-f"} or option.startswith("--force-with-lease"):
+                return True
+            if option.startswith("-") and "f" in option.lstrip("-"):
+                return True
+    return False
+
+
+def delete_from_without_where(command: str) -> bool:
+    for match in DELETE_FROM_RE.finditer(command):
+        statement = command[match.start() :].split(";", 1)[0]
+        if not re.search(r"\bwhere\b", statement, re.IGNORECASE):
+            return True
+    return False
+
+
+def find_violation(command: str) -> str | None:
+    tokens = shell_tokens(command)
+
+    if has_rm_rf(tokens):
+        return "rm -rf"
+    if has_git_force_push(tokens):
+        return "git push --force"
+    if DROP_TABLE_RE.search(command):
+        return "DROP TABLE"
+    if TRUNCATE_RE.search(command):
+        return "TRUNCATE"
+    if delete_from_without_where(command):
+        return "DELETE FROM without WHERE"
+    return None
+
+
+def log_blocked_attempt(command: str, project_path: str, rule: str, log_path: Path = BLOCKED_LOG) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "attempted_command": command,
+        "project_path": project_path,
+        "matched_rule": rule,
+    }
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def deny(rule: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": HOOK_EVENT_NAME,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Blocked destructive Bash command matching '{rule}'. "
+                "Revise the command or ask the user to run it manually."
+            ),
+        }
+    }
+
+
+def command_from_payload(payload: dict[str, Any]) -> str:
+    if payload.get("tool_name") != "Bash":
+        return ""
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def handle_payload(payload: dict[str, Any], log_path: Path = BLOCKED_LOG) -> dict[str, Any] | None:
+    command = command_from_payload(payload)
+    if not command:
+        return None
+
+    rule = find_violation(command)
+    if rule is None:
+        return None
+
+    project_path = str(payload.get("cwd") or os.getcwd())
+    log_blocked_attempt(command, project_path, rule, log_path)
+    return deny(rule)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as error:
+        print(f"Invalid Claude Code hook payload: {error}", file=sys.stderr)
+        return 1
+
+    response = handle_payload(payload)
+    if response is not None:
+        print(json.dumps(response))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/install_destructive_command_hook.py
+++ b/hooks/install_destructive_command_hook.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash command guard into Claude Code settings."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+
+HOOK_NAME = "block_destructive_bash.py"
+
+
+def quote_command(path: Path) -> str:
+    return f'"{sys.executable}" "{path}"'
+
+
+def load_settings(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as settings_file:
+        return json.load(settings_file)
+
+
+def save_settings(path: Path, settings: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+
+def install() -> Path:
+    claude_dir = Path.home() / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    source = Path(__file__).resolve().with_name(HOOK_NAME)
+    target = hooks_dir / HOOK_NAME
+    shutil.copy2(source, target)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    settings_path = claude_dir / "settings.json"
+    settings = load_settings(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    command = quote_command(target)
+    already_registered = any(
+        HOOK_NAME in hook.get("command", "")
+        for entry in pre_tool_use
+        for hook in entry.get("hooks", [])
+        if isinstance(hook, dict)
+    )
+
+    if not already_registered:
+        pre_tool_use.append(
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": command,
+                    }
+                ],
+            }
+        )
+
+    save_settings(settings_path, settings)
+    return target
+
+
+def main() -> int:
+    target = install()
+    print(f"Installed destructive command hook at {target}")
+    print("Claude Code PreToolUse/Bash hook is registered in ~/.claude/settings.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from hooks.block_destructive_bash import find_violation, handle_payload
+
+
+class DestructiveCommandHookTests(unittest.TestCase):
+    def test_blocks_required_patterns(self) -> None:
+        blocked_commands = {
+            "rm -rf /tmp/build": "rm -rf",
+            "sudo rm -fr ./dist": "rm -rf",
+            "rm --recursive --force cache": "rm -rf",
+            "git push origin main --force": "git push --force",
+            "git push origin main --force-with-lease=main": "git push --force",
+            "git push -f origin main": "git push --force",
+            "psql -c 'DROP   TABLE users'": "DROP TABLE",
+            "mysql -e 'TRUNCATE sessions'": "TRUNCATE",
+            "psql -c 'DELETE   FROM accounts;'": "DELETE FROM without WHERE",
+        }
+
+        for command, expected_rule in blocked_commands.items():
+            with self.subTest(command=command):
+                self.assertEqual(find_violation(command), expected_rule)
+
+    def test_allows_normal_bash_commands(self) -> None:
+        allowed_commands = [
+            "git status --short",
+            "npm test",
+            "rm -r ./build",
+            "psql -c 'DELETE FROM accounts WHERE id = 42;'",
+            "git push origin main",
+        ]
+
+        for command in allowed_commands:
+            with self.subTest(command=command):
+                self.assertIsNone(find_violation(command))
+
+    def test_denies_and_logs_pretooluse_bash_payload(self) -> None:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf ./build"},
+            "cwd": "/workspace/project",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "blocked.log"
+            response = handle_payload(payload, log_path)
+
+            self.assertIsNotNone(response)
+            output = response["hookSpecificOutput"]
+            self.assertEqual(output["hookEventName"], "PreToolUse")
+            self.assertEqual(output["permissionDecision"], "deny")
+            self.assertIn("rm -rf", output["permissionDecisionReason"])
+
+            [record] = log_path.read_text(encoding="utf-8").splitlines()
+            logged = json.loads(record)
+            self.assertEqual(logged["attempted_command"], "rm -rf ./build")
+            self.assertEqual(logged["project_path"], "/workspace/project")
+            self.assertEqual(logged["matched_rule"], "rm -rf")
+
+    def test_ignores_non_bash_tools(self) -> None:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "README.md"},
+            "cwd": "/workspace/project",
+        }
+
+        self.assertIsNone(handle_payload(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a Claude Code `PreToolUse` hook for Bash commands that blocks destructive operations before execution.

## What it blocks

- `rm -rf`, including `rm -fr`, split flags, and `--recursive --force`
- `DROP TABLE`
- `git push --force`, including `--force-with-lease` and `-f`
- `TRUNCATE`
- `DELETE FROM` without a `WHERE` clause

## Notes

Blocked attempts are logged to `~/.claude/hooks/blocked.log` as JSON lines with timestamp, attempted command, project path, and matched rule. The installer copies the hook into `~/.claude/hooks/` and registers it in `~/.claude/settings.json`.

## Tests

```bash
python3 -m unittest tests/test_block_destructive_bash.py
```

Fixes #3.
