### PR TITLE
Add PreToolUse hook to block destructive Bash commands

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,38 @@
+# Destructive Bash Command Hook
+
+This Claude Code `PreToolUse` hook blocks destructive Bash commands before execution and logs every blocked attempt to `~/.claude/hooks/blocked.log`.
+
+## Install
+
+Run these two commands from the repository root:
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block_destructive_bash.py ~/.claude/hooks/block_destructive_bash.py && chmod +x ~/.claude/hooks/block_destructive_bash.py
+python3 hooks/install_destructive_command_hook.py
+```
+
+## What It Blocks
+
+- `rm -rf` and equivalent flag orderings such as `rm -fr`
+- `DROP TABLE`
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+
+Safe commands continue through Claude Code's normal permission flow without hook output.
+
+## Hook Output
+
+When blocked, the hook returns a Claude Code `PreToolUse` decision:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Blocked destructive Bash command (...)"
+  }
+}
+```
+
+Each blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON Lines with timestamp, attempted command, project path, and matched rule.

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+LOG_PATH = Path(os.environ.get("BLOCK_DESTRUCTIVE_BASH_LOG_PATH", Path.home() / ".claude" / "hooks" / "blocked.log"))
+
+
+PATTERNS = [
+    (
+        "rm -rf",
+        re.compile(r"(^|[\s;&|()])rm\s+-(?=[A-Za-z]*r)(?=[A-Za-z]*f)[A-Za-z]+\b", re.IGNORECASE),
+        "recursive force removal can delete large parts of the filesystem",
+    ),
+    (
+        "DROP TABLE",
+        re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE),
+        "DROP TABLE permanently removes database tables",
+    ),
+    (
+        "TRUNCATE",
+        re.compile(r"\bTRUNCATE\b", re.IGNORECASE),
+        "TRUNCATE can erase all rows from a table",
+    ),
+    (
+        "git push --force",
+        re.compile(r"\bgit\s+push\b(?:(?![;&|]).)*(?:--force(?:-with-lease)?|-f\b)", re.IGNORECASE | re.DOTALL),
+        "force-pushing can overwrite shared Git history",
+    ),
+]
+
+
+def _delete_without_where(command: str) -> bool:
+    for statement in re.split(r"[;\n]", command):
+        if re.search(r"\bDELETE\s+FROM\b", statement, re.IGNORECASE) and not re.search(
+            r"\bWHERE\b", statement, re.IGNORECASE
+        ):
+            return True
+    return False
+
+
+def classify(command: str) -> tuple[bool, str, str]:
+    for name, pattern, reason in PATTERNS:
+        if pattern.search(command):
+            return True, name, reason
+
+    if _delete_without_where(command):
+        return True, "DELETE FROM without WHERE", "DELETE FROM without a WHERE clause can erase an entire table"
+
+    return False, "", ""
+
+
+def _extract_command(payload: dict[str, Any]) -> str:
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return ""
+    command = tool_input.get("command", "")
+    return command if isinstance(command, str) else ""
+
+
+def _project_path(payload: dict[str, Any]) -> str:
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        return cwd
+    return os.getcwd()
+
+
+def log_blocked(command: str, project_path: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps({"timestamp": timestamp, "command": command, "project_path": project_path, "reason": reason}) + "\n")
+
+
+def deny(reason: str, command: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Blocked destructive Bash command ({reason}): {command}",
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = _extract_command(payload)
+    if not command:
+        return 0
+
+    blocked, name, reason = classify(command)
+    if not blocked:
+        return 0
+
+    log_blocked(command, _project_path(payload), name)
+    deny(reason, command)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/install_destructive_command_hook.py
+++ b/hooks/install_destructive_command_hook.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash command hook in ~/.claude/settings.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+CLAUDE_DIR = Path.home() / ".claude"
+SETTINGS_PATH = CLAUDE_DIR / "settings.json"
+HOOK_PATH = CLAUDE_DIR / "hooks" / "block_destructive_bash.py"
+
+
+HOOK_ENTRY = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": str(HOOK_PATH),
+        }
+    ],
+}
+
+
+def load_settings() -> dict:
+    if not SETTINGS_PATH.exists():
+        return {}
+    with SETTINGS_PATH.open("r", encoding="utf-8") as settings_file:
+        return json.load(settings_file)
+
+
+def main() -> int:
+    CLAUDE_DIR.mkdir(parents=True, exist_ok=True)
+    settings = load_settings()
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    if HOOK_ENTRY not in pre_tool_use:
+        pre_tool_use.append(HOOK_ENTRY)
+
+    with SETTINGS_PATH.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+    print(f"Installed PreToolUse hook in {SETTINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,78 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, main
+
+
+HOOK = Path(__file__).resolve().parents[1] / "hooks" / "block_destructive_bash.py"
+
+
+def run_hook(command: str, log_path: Path) -> subprocess.CompletedProcess:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/tmp/example-project",
+        "hook_event_name": "PreToolUse",
+    }
+    env = os.environ.copy()
+    env["BLOCK_DESTRUCTIVE_BASH_LOG_PATH"] = str(log_path)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+class BlockDestructiveBashTests(TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = TemporaryDirectory()
+        self.log_path = Path(self.temp_dir.name) / "blocked.log"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def assert_denied(self, command: str) -> None:
+        result = run_hook(command, self.log_path)
+        self.assertEqual(result.returncode, 0)
+        self.assertTrue(result.stdout)
+        output = json.loads(result.stdout)
+        decision = output["hookSpecificOutput"]
+        self.assertEqual(decision["hookEventName"], "PreToolUse")
+        self.assertEqual(decision["permissionDecision"], "deny")
+        self.assertTrue(self.log_path.exists())
+
+    def assert_allowed(self, command: str) -> None:
+        result = run_hook(command, self.log_path)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_blocks_rm_rf_variants(self):
+        self.assert_denied("rm -rf build")
+        self.assert_denied("rm -fr /tmp/demo")
+
+    def test_blocks_sql_destructive_commands(self):
+        self.assert_denied("psql -c 'DROP TABLE users'")
+        self.assert_denied("psql -c 'TRUNCATE audit_log'")
+        self.assert_denied("psql -c 'DELETE FROM users'")
+
+    def test_allows_delete_with_where_clause(self):
+        self.assert_allowed("psql -c 'DELETE FROM users WHERE id = 1'")
+
+    def test_blocks_git_force_push(self):
+        self.assert_denied("git push --force origin main")
+        self.assert_denied("git push -f origin main")
+
+    def test_allows_normal_commands(self):
+        self.assert_allowed("npm test")
+        self.assert_allowed("git push origin main")
+        self.assert_allowed("rm build/output.txt")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3

## Summary

- Add a Claude Code `PreToolUse` hook for Bash tool calls.
- Block destructive commands: `rm -rf`, `DROP TABLE`, `TRUNCATE`, `git push --force` / `-f`, and `DELETE FROM` without `WHERE`.
- Log blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, project path, and matched rule.
- Include a two-command install flow plus stdlib unit tests.

## Verification

- `python -m unittest tests.test_block_destructive_bash -v`
- `python -m py_compile hooks/block_destructive_bash.py hooks/install_destructive_command_hook.py tests/test_block_destructive_bash.py`