### PR TITLE
Add destructive command guard hook

### DIFF
--- a/hooks/destructive-command-guard/README.md
+++ b/hooks/destructive-command-guard/README.md
@@ -1,0 +1,64 @@
+# Destructive Command Guard
+
+Claude Code `PreToolUse` hook that blocks dangerous Bash commands before they
+run and logs every blocked attempt.
+
+## Install
+
+Run from the repository root:
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/destructive-command-guard/pre_tool_use.py ~/.claude/hooks/destructive-command-guard.py && chmod +x ~/.claude/hooks/destructive-command-guard.py
+python hooks/destructive-command-guard/install_settings.py
+```
+
+The installer adds this hook to `~/.claude/settings.json` under
+`hooks.PreToolUse` with the `Bash` matcher.
+
+## What It Blocks
+
+- `rm -rf` variants, including `rm -fr`, `rm -r -f`, and `sudo rm -rf`.
+- `DROP TABLE` in SQL passed to a shell command.
+- `TRUNCATE` in SQL passed to a shell command.
+- `git push --force`, `git push -f`, and `git push --force-with-lease`.
+- `DELETE FROM ...` SQL statements that do not include a `WHERE` clause before
+  the statement terminator.
+
+Safe commands such as `npm test`, `git push`, `rm file.txt`, and
+`DELETE FROM table WHERE id = 1` are allowed.
+
+## Log File
+
+Blocked attempts are appended to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each line is JSON with:
+
+- `timestamp`
+- `attempted_command`
+- `project_path`
+- `rule`
+- `reason`
+
+## Manual Test
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"/tmp/demo","tool_input":{"command":"rm -rf build"}}' | python ~/.claude/hooks/destructive-command-guard.py
+```
+
+Expected result: JSON output with `permissionDecision` set to `deny`.
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"/tmp/demo","tool_input":{"command":"npm test"}}' | python ~/.claude/hooks/destructive-command-guard.py
+```
+
+Expected result: no output and exit code `0`.
+
+## Run Tests
+
+```bash
+python -m unittest discover -s hooks/destructive-command-guard/tests -p "test_*.py"
+```

--- a/hooks/destructive-command-guard/install_settings.py
+++ b/hooks/destructive-command-guard/install_settings.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Install the destructive command guard in ~/.claude/settings.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+HOOK_COMMAND = "~/.claude/hooks/destructive-command-guard.py"
+
+
+def load_settings(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> None:
+    claude_dir = Path.home() / ".claude"
+    settings_path = claude_dir / "settings.json"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    settings = load_settings(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    entry = {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": HOOK_COMMAND,
+            }
+        ],
+    }
+
+    already_installed = any(
+        item.get("matcher") == "Bash"
+        and any(hook.get("command") == HOOK_COMMAND for hook in item.get("hooks", []))
+        for item in pre_tool_use
+    )
+
+    if not already_installed:
+        pre_tool_use.append(entry)
+
+    with settings_path.open("w", encoding="utf-8") as handle:
+        json.dump(settings, handle, indent=2)
+        handle.write("\n")
+
+    print(f"Installed destructive command guard in {settings_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/destructive-command-guard/pre_tool_use.py
+++ b/hooks/destructive-command-guard/pre_tool_use.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+SQL_DROP_TABLE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+SQL_TRUNCATE = re.compile(r"\btruncate\b", re.IGNORECASE)
+SQL_DELETE_FROM = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class BlockDecision:
+    rule: str
+    reason: str
+
+
+def tokenize(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        return list(lexer)
+    except ValueError:
+        return command.split()
+
+
+def split_subcommands(tokens: Iterable[str]) -> list[list[str]]:
+    subcommands: list[list[str]] = []
+    current: list[str] = []
+    separators = {";", "&&", "||", "|", "\n", "(", ")"}
+
+    for token in tokens:
+        if token in separators or set(token) <= {";", "&", "|", "(", ")"}:
+            if current:
+                subcommands.append(current)
+                current = []
+            continue
+        current.append(token)
+
+    if current:
+        subcommands.append(current)
+
+    return subcommands
+
+
+def strip_wrappers(tokens: list[str]) -> list[str]:
+    stripped = list(tokens)
+
+    while stripped and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", stripped[0]):
+        stripped.pop(0)
+
+    while stripped and stripped[0] in {"sudo", "command"}:
+        stripped.pop(0)
+
+    if stripped and stripped[0] == "env":
+        stripped.pop(0)
+        while stripped and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", stripped[0]):
+            stripped.pop(0)
+
+    return stripped
+
+
+def command_name(token: str) -> str:
+    return token.replace("\\", "/").rsplit("/", 1)[-1]
+
+
+def has_rm_recursive_force(tokens: list[str]) -> bool:
+    stripped = strip_wrappers(tokens)
+    if not stripped or command_name(stripped[0]) != "rm":
+        return False
+
+    recursive = False
+    force = False
+    for token in stripped[1:]:
+        if not token.startswith("-") or token == "--":
+            continue
+        option_chars = token.lstrip("-")
+        recursive = recursive or "r" in option_chars or "R" in option_chars
+        force = force or "f" in option_chars
+
+    return recursive and force
+
+
+def has_force_push(tokens: list[str]) -> bool:
+    stripped = strip_wrappers(tokens)
+    if not stripped or command_name(stripped[0]) != "git":
+        return False
+
+    has_push = any(token == "push" for token in stripped[1:])
+    has_force = any(
+        token in {"-f", "--force", "--force-with-lease"} or token.startswith("--force=")
+        for token in stripped[1:]
+    )
+    return has_push and has_force
+
+
+def delete_without_where(command: str) -> bool:
+    for match in SQL_DELETE_FROM.finditer(command):
+        statement_tail = command[match.end() :]
+        statement = statement_tail.split(";", 1)[0]
+        if not re.search(r"\bwhere\b", statement, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def detect_block(command: str) -> BlockDecision | None:
+    tokens = tokenize(command)
+    for subcommand in split_subcommands(tokens):
+        if has_rm_recursive_force(subcommand):
+            return BlockDecision(
+                "rm-rf",
+                "Blocked recursive forced deletion. Remove files more narrowly or ask for explicit human confirmation.",
+            )
+        if has_force_push(subcommand):
+            return BlockDecision(
+                "git-force-push",
+                "Blocked force push because it can rewrite shared history.",
+            )
+
+    if SQL_DROP_TABLE.search(command):
+        return BlockDecision(
+            "drop-table",
+            "Blocked DROP TABLE because it can destroy schema and data.",
+        )
+
+    if SQL_TRUNCATE.search(command):
+        return BlockDecision(
+            "truncate",
+            "Blocked TRUNCATE because it can remove all rows from a table.",
+        )
+
+    if delete_without_where(command):
+        return BlockDecision(
+            "delete-without-where",
+            "Blocked DELETE FROM without a WHERE clause.",
+        )
+
+    return None
+
+
+def project_path(payload: dict) -> str:
+    return (
+        payload.get("cwd")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+
+
+def log_block(command: str, decision: BlockDecision, cwd: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": cwd,
+        "rule": decision.rule,
+        "reason": decision.reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def deny_output(decision: BlockDecision) -> dict:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": decision.reason,
+        },
+        "systemMessage": decision.reason,
+    }
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    decision = detect_block(command)
+    if decision is None:
+        return 0
+
+    cwd = project_path(payload)
+    log_block(command, decision, cwd)
+    print(json.dumps(deny_output(decision)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-guard/settings.example.json
+++ b/hooks/destructive-command-guard/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/destructive-command-guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/destructive-command-guard/tests/test_pre_tool_use.py
+++ b/hooks/destructive-command-guard/tests/test_pre_tool_use.py
@@ -1,0 +1,105 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "pre_tool_use.py"
+SPEC = importlib.util.spec_from_file_location("pre_tool_use", MODULE_PATH)
+pre_tool_use = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["pre_tool_use"] = pre_tool_use
+SPEC.loader.exec_module(pre_tool_use)
+
+
+class DestructiveCommandGuardTests(unittest.TestCase):
+    def test_blocks_rm_recursive_force_variants(self):
+        dangerous = [
+            "rm -rf build",
+            "rm -fr build",
+            "rm -r -f build",
+            "sudo rm -Rf /tmp/demo",
+            "env FOO=bar rm -f -r ./cache",
+        ]
+
+        for command in dangerous:
+            with self.subTest(command=command):
+                decision = pre_tool_use.detect_block(command)
+                self.assertIsNotNone(decision)
+                self.assertEqual(decision.rule, "rm-rf")
+
+    def test_blocks_force_push_variants(self):
+        dangerous = [
+            "git push --force origin main",
+            "git push -f",
+            "git push --force-with-lease origin main",
+            "FOO=bar git push --force=origin main",
+        ]
+
+        for command in dangerous:
+            with self.subTest(command=command):
+                decision = pre_tool_use.detect_block(command)
+                self.assertIsNotNone(decision)
+                self.assertEqual(decision.rule, "git-force-push")
+
+    def test_blocks_sql_destructive_patterns(self):
+        cases = {
+            "psql -c 'DROP TABLE users'": "drop-table",
+            "sqlite3 app.db 'TRUNCATE sessions'": "truncate",
+            "psql -c 'DELETE FROM users;'": "delete-without-where",
+            "mysql -e \"delete from accounts\"": "delete-without-where",
+        }
+
+        for command, rule in cases.items():
+            with self.subTest(command=command):
+                decision = pre_tool_use.detect_block(command)
+                self.assertIsNotNone(decision)
+                self.assertEqual(decision.rule, rule)
+
+    def test_allows_normal_commands(self):
+        safe = [
+            "npm test",
+            "git push origin main",
+            "rm build.log",
+            "psql -c 'DELETE FROM users WHERE id = 1;'",
+            "sqlite3 app.db 'select * from users'",
+        ]
+
+        for command in safe:
+            with self.subTest(command=command):
+                self.assertIsNone(pre_tool_use.detect_block(command))
+
+    def test_logs_blocked_attempt_as_json_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "blocked.log"
+            decision = pre_tool_use.BlockDecision("rm-rf", "Blocked test")
+
+            with patch.object(pre_tool_use, "LOG_PATH", log_path):
+                pre_tool_use.log_block("rm -rf build", decision, "/repo")
+
+            entry = json.loads(log_path.read_text(encoding="utf-8"))
+            self.assertIn("timestamp", entry)
+            self.assertEqual(entry["attempted_command"], "rm -rf build")
+            self.assertEqual(entry["project_path"], "/repo")
+            self.assertEqual(entry["rule"], "rm-rf")
+
+    def test_denies_with_claude_code_pre_tool_use_json(self):
+        decision = pre_tool_use.BlockDecision("truncate", "Blocked TRUNCATE")
+        output = pre_tool_use.deny_output(decision)
+
+        self.assertEqual(
+            output["hookSpecificOutput"]["hookEventName"],
+            "PreToolUse",
+        )
+        self.assertEqual(
+            output["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+        self.assertIn("Blocked TRUNCATE", json.dumps(output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3.

## Summary
- Adds a Claude Code `PreToolUse` Bash hook that blocks destructive commands before execution.
- Blocks `rm -rf` variants, force pushes, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` statements without a `WHERE` clause.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, rule, and reason.
- Includes a two-command install README, settings example, and unit tests.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s hooks/destructive-command-guard/tests -p test_*.py`
- `git diff --check`
- ASCII check for all files under `hooks/destructive-command-guard`
- Manual stdin smoke test for blocked `rm -rf build` and allowed `npm test`