### PR TITLE
Add changelog generator skill

### DIFF
--- a/samples/claude-builders-bounty-CHANGELOG.md
+++ b/samples/claude-builders-bounty-CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [Unreleased] - 2026-05-29
+
+Generated from full history. Commit count: 1.
+
+### Added
+
+- No changes.
+
+### Fixed
+
+- No changes.
+
+### Changed
+
+- Initial commit ([a80a580](https://github.com/claude-builders-bounty/claude-builders-bounty/commit/a80a580e34190a6bb8649a1b75a9fec8312bea5c))
+
+### Removed
+
+- No changes.

--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,38 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from git history since the latest tag.
+
+## Setup
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `bash changelog.sh`.
+3. Review and commit the generated `CHANGELOG.md`.
+
+## Usage
+
+```bash
+bash changelog.sh
+```
+
+To write to a custom path:
+
+```bash
+bash changelog.sh docs/CHANGELOG.md
+```
+
+The script detects the latest git tag with `git describe --tags --abbrev=0`.
+If the repository has no tags, it uses the full commit history.
+
+## Categories
+
+- `Added`: `feat`, `feature`, `add`.
+- `Fixed`: `fix`, `bug`, `hotfix`.
+- `Removed`: `remove`, `removed`, `delete`, `deleted`.
+- `Changed`: everything else, including `refactor`, `chore`, `docs`, `test`,
+  `ci`, and uncategorized commits.
+
+## Claude Code Command
+
+Use the included `SKILL.md` as the backing skill for `/generate-changelog`.
+The skill delegates generation to the same script so manual and Claude-driven
+usage produce identical output.

--- a/skills/generate-changelog/SKILL.md
+++ b/skills/generate-changelog/SKILL.md
@@ -1,0 +1,27 @@
+# Generate Changelog
+
+Use this skill when the user asks to generate or refresh a `CHANGELOG.md` from
+git history.
+
+## Workflow
+
+1. Confirm the current directory is the target git repository.
+2. Run:
+
+   ```bash
+   bash skills/generate-changelog/changelog.sh
+   ```
+
+3. Inspect the generated `CHANGELOG.md` for obvious categorization mistakes.
+4. Report the latest tag used, number of commits grouped, and output path.
+
+## Behavior
+
+The script:
+
+- Finds the latest git tag with `git describe --tags --abbrev=0`.
+- Reads commits since that tag, or all commits when no tag exists.
+- Categorizes commits into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Writes a Keep-a-Changelog-style Markdown file.
+
+Do not invent release notes that are not backed by git commits.

--- a/skills/generate-changelog/changelog.sh
+++ b/skills/generate-changelog/changelog.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must run inside a git repository" >&2
+  exit 1
+fi
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  range_label="since ${latest_tag}"
+else
+  range="HEAD"
+  range_label="full history"
+fi
+
+repo_url="$(git config --get remote.origin.url || true)"
+repo_url="${repo_url%.git}"
+if [[ "$repo_url" == git@github.com:* ]]; then
+  repo_url="https://github.com/${repo_url#git@github.com:}"
+fi
+
+today="$(date +%Y-%m-%d)"
+output_dir="$(dirname "$output_path")"
+if [[ "$output_dir" != "." ]]; then
+  mkdir -p "$output_dir"
+fi
+added=()
+fixed=()
+changed=()
+removed=()
+commit_count=0
+
+commit_url() {
+  local hash="$1"
+  if [[ "$repo_url" == https://github.com/* ]]; then
+    printf "[%s](%s/commit/%s)" "${hash:0:7}" "$repo_url" "$hash"
+  else
+    printf "%s" "${hash:0:7}"
+  fi
+}
+
+categorize_subject() {
+  local subject_lower="$1"
+  case "$subject_lower" in
+    feat:*|feature:*|add:*|added:*|*add\ *|*introduce\ *)
+      printf "Added"
+      ;;
+    fix:*|bug:*|hotfix:*|*fix\ *|*bug\ *)
+      printf "Fixed"
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|*remove\ *|*delete\ *)
+      printf "Removed"
+      ;;
+    *)
+      printf "Changed"
+      ;;
+  esac
+}
+
+while IFS=$'\x1f' read -r hash subject; do
+  [[ -z "${hash:-}" ]] && continue
+  commit_count=$((commit_count + 1))
+  subject_lower="$(printf "%s" "$subject" | tr '[:upper:]' '[:lower:]')"
+  category="$(categorize_subject "$subject_lower")"
+  entry="- ${subject} ($(commit_url "$hash"))"
+
+  case "$category" in
+    Added) added+=("$entry") ;;
+    Fixed) fixed+=("$entry") ;;
+    Removed) removed+=("$entry") ;;
+    *) changed+=("$entry") ;;
+  esac
+done < <(git log --reverse --pretty=format:'%H%x1f%s' "$range")
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  printf "\n### %s\n\n" "$title"
+  if [[ "${#items[@]}" -eq 0 ]]; then
+    printf "%s\n" "- No changes."
+    return
+  fi
+
+  local item
+  for item in "${items[@]}"; do
+    printf "%s\n" "$item"
+  done
+}
+
+{
+  printf "# Changelog\n\n"
+  printf "## [Unreleased] - %s\n\n" "$today"
+  printf "Generated from %s. Commit count: %s.\n" "$range_label" "$commit_count"
+  write_section "Added" "${added[@]}"
+  write_section "Fixed" "${fixed[@]}"
+  write_section "Changed" "${changed[@]}"
+  write_section "Removed" "${removed[@]}"
+} > "$output_path"
+
+echo "Wrote ${output_path} from ${commit_count} commits ${range_label}."


### PR DESCRIPTION
Fixes #1.

## Summary
- Adds `bash changelog.sh` support for generating a structured `CHANGELOG.md` from git history.
- Detects the latest git tag and falls back to full history when no tag exists.
- Categorizes commits into Added, Fixed, Changed, and Removed.
- Adds a Claude Code `SKILL.md`, a 3-step README, and sample output generated from this repository.

## Validation
- `bash skills/generate-changelog/changelog.sh samples/claude-builders-bounty-CHANGELOG.md`
- `bash -n skills/generate-changelog/changelog.sh`
- `git diff --check`
- ASCII check for `skills/generate-changelog` and `samples`