### PR TITLE
Add git history changelog generator

### DIFF
--- a/tools/generate-changelog/README.md
+++ b/tools/generate-changelog/README.md
@@ -1,0 +1,33 @@
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from commits since the latest git tag.
+
+## Setup
+
+1. Copy `tools/generate-changelog` into your repository.
+2. Run `bash tools/generate-changelog/changelog.sh`.
+3. Review and commit the generated `CHANGELOG.md`.
+
+## Usage
+
+```bash
+bash tools/generate-changelog/changelog.sh
+```
+
+Optional flags:
+
+```bash
+bash tools/generate-changelog/changelog.sh --since v1.2.0 --output CHANGELOG.md
+bash tools/generate-changelog/changelog.sh --repo /path/to/repo
+```
+
+## Categorization
+
+The generator reads non-merge commits from `{latest-tag}..HEAD` and groups them into:
+
+- `Added`: `feat:`, `feature:`, `add:`, or subjects starting with `add`
+- `Fixed`: `fix:`, `bugfix:`, `hotfix:`, or subjects containing `fix` / `bug`
+- `Removed`: `remove:`, `delete:`, `drop:`, or matching subject prefixes
+- `Changed`: everything else
+
+The output follows a Keep a Changelog-style layout and includes the short commit SHA for traceability.

--- a/tools/generate-changelog/changelog.sh
+++ b/tools/generate-changelog/changelog.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/generate_changelog.py" "$@"

--- a/tools/generate-changelog/generate_changelog.py
+++ b/tools/generate-changelog/generate_changelog.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate a Keep a Changelog-style CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+
+CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+
+
+def run_git(args: list[str], cwd: Path) -> str:
+    return subprocess.check_output(["git", *args], cwd=cwd, text=True, stderr=subprocess.STDOUT).strip()
+
+
+def latest_tag(cwd: Path) -> str | None:
+    try:
+        return run_git(["describe", "--tags", "--abbrev=0"], cwd)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def commits_since(ref: str | None, cwd: Path) -> list[Commit]:
+    rev_range = f"{ref}..HEAD" if ref else "HEAD"
+    output = run_git(["log", "--no-merges", "--pretty=format:%h%x09%s", rev_range], cwd)
+    commits: list[Commit] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        sha, subject = line.split("\t", 1)
+        commits.append(Commit(sha=sha, subject=subject))
+    return commits
+
+
+def category_for(subject: str) -> str:
+    clean = subject.lower().strip()
+    if re.match(r"^(fix|bugfix|hotfix)(\(.+\))?:", clean) or "fix" in clean or "bug" in clean:
+        return "Fixed"
+    if re.match(r"^(feat|feature|add)(\(.+\))?:", clean) or clean.startswith(("add ", "added ")):
+        return "Added"
+    if re.match(r"^(remove|delete|drop)(\(.+\))?:", clean) or clean.startswith(("remove ", "delete ", "drop ")):
+        return "Removed"
+    return "Changed"
+
+
+def display_subject(subject: str) -> str:
+    cleaned = re.sub(r"^(feat|feature|fix|bugfix|hotfix|chore|refactor|docs|test|remove|delete|drop)(\(.+\))?:\s*", "", subject, flags=re.I)
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return subject.strip()
+    return cleaned[0].upper() + cleaned[1:]
+
+
+def render(commits: list[Commit], since: str | None, repo_name: str) -> str:
+    grouped: dict[str, list[Commit]] = defaultdict(list)
+    for commit in commits:
+        grouped[category_for(commit.subject)].append(commit)
+
+    lines = [
+        "# Changelog",
+        "",
+        "All notable changes are generated from git history.",
+        "",
+        f"## Unreleased - {date.today().isoformat()}",
+        "",
+        f"_Repository: {repo_name}_",
+        f"_Range: {since or 'initial commit'}..HEAD_",
+        "",
+    ]
+
+    if not commits:
+        lines.extend(["No changes since the last tag.", ""])
+        return "\n".join(lines)
+
+    for category in CATEGORIES:
+        lines.append(f"### {category}")
+        lines.append("")
+        entries = grouped.get(category, [])
+        if entries:
+            for commit in entries:
+                lines.append(f"- {display_subject(commit.subject)} ({commit.sha})")
+        else:
+            lines.append("- None")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def repo_name(cwd: Path) -> str:
+    try:
+        remote = run_git(["config", "--get", "remote.origin.url"], cwd)
+    except subprocess.CalledProcessError:
+        return cwd.name
+    return remote.rstrip("/").removesuffix(".git").split("/")[-1] or cwd.name
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from commits since the latest git tag.")
+    parser.add_argument("--repo", default=".", help="Path to the git repository. Defaults to current directory.")
+    parser.add_argument("--output", default="CHANGELOG.md", help="Output path. Defaults to CHANGELOG.md.")
+    parser.add_argument("--since", default=None, help="Override the starting tag/ref. Defaults to latest git tag.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cwd = Path(args.repo).resolve()
+    if not (cwd / ".git").exists():
+        raise SystemExit(f"{cwd} is not a git repository")
+
+    since = args.since or latest_tag(cwd)
+    changelog = render(commits_since(since, cwd), since, repo_name(cwd))
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = cwd / output
+    output.write_text(changelog, encoding="utf-8")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate-changelog/sample-output.md
+++ b/tools/generate-changelog/sample-output.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes are generated from git history.
+
+## Unreleased - 2026-05-29
+
+_Repository: cli_
+_Range: v2.92.0..HEAD_
+
+### Added
+
+- Missing //go:build integration tag to verify_integration_test.go (20e4d25)
+
+### Fixed
+
+- Flaky Password test by increasing echo mode setup timeout (6d6ea5f)
+
+### Changed
+
+- Update installation commands for GitHub CLI (ba33308)
+- Print `gh auth refresh` for 401 returns (a656271)
+- Apply patch from code review feedback. (c139b17)
+- Bump goreleaser/goreleaser-action from 7.0.0 to 7.2.1 (ed31e2f)
+
+### Removed
+
+- None


### PR DESCRIPTION
Closes #1

## Summary

- Add a `bash tools/generate-changelog/changelog.sh` entry point backed by a dependency-free Python generator.
- Detect the latest git tag, read non-merge commits from `{tag}..HEAD`, and write a Keep a Changelog-style `CHANGELOG.md`.
- Categorize commits into Added, Fixed, Changed, and Removed using common conventional commit prefixes and subject heuristics.
- Include setup/usage docs in 3 steps and a sample output from a real GitHub repository range (`cli/cli` `v2.92.0..HEAD`).

## Verification

- `python -m py_compile tools/generate-changelog/generate_changelog.py`
- Render smoke test for Added / Fixed / Changed / Removed grouping using the module directly.