### PR TITLE
Add Claude PR review agent

### DIFF
--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,0 +1,39 @@
+# Claude PR Reviewer Agent
+
+`claude-review` reviews a GitHub pull request and returns a structured Markdown comment with a summary, risks, improvement suggestions, and a confidence score.
+
+## Setup
+
+1. Copy `claude-review.py` into a directory on your `PATH` as `claude-review`.
+2. Set `GITHUB_TOKEN` for private repos or higher rate limits, and set `ANTHROPIC_API_KEY` to use Claude.
+3. Run `claude-review --pr https://github.com/owner/repo/pull/123`.
+
+If `ANTHROPIC_API_KEY` is not set, the CLI uses a deterministic local reviewer. This keeps tests and examples reproducible without exposing secrets.
+
+## Usage
+
+```bash
+claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2266
+claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+claude-review --pr https://github.com/owner/repo/pull/123 --heuristic
+```
+
+The output always contains:
+
+- `## Summary`
+- `## Identified Risks`
+- `## Improvement Suggestions`
+- `## Confidence`
+
+## GitHub Action
+
+Copy `github-action.yml` to `.github/workflows/claude-review.yml` in a repository and add `ANTHROPIC_API_KEY` as a repository secret. The workflow runs on pull requests, generates `review.md`, and uploads it as an artifact. Uncomment the final `gh pr comment` step if you want automatic PR comments.
+
+## Validation
+
+```bash
+python -m unittest discover -s agents/pr-reviewer/tests -p test_*.py
+python agents/pr-reviewer/claude-review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2266 --heuristic
+```
+
+Sample outputs from two real PRs are included in `samples/`.

--- a/agents/pr-reviewer/agent-prompt.md
+++ b/agents/pr-reviewer/agent-prompt.md
@@ -1,0 +1,25 @@
+# Claude PR Reviewer Agent Prompt
+
+Use this prompt when running the reviewer through Claude Code or the Anthropic API.
+
+```text
+You are a senior code reviewer. Review the pull request diff and return only Markdown using this exact structure:
+
+## Summary
+Two or three sentences explaining what changed.
+
+## Identified Risks
+- List concrete risks found in the diff, or "- None found in the supplied diff."
+
+## Improvement Suggestions
+- List actionable improvements, or "- None."
+
+## Confidence
+High | Medium | Low
+
+Rules:
+- Focus on correctness, regressions, security, tests, and maintainability.
+- Do not praise the author or summarize unrelated repository context.
+- If evidence is missing, say what evidence is missing.
+- Confidence is High only when the diff is small enough and evidence is direct.
+```

--- a/agents/pr-reviewer/claude-review.py
+++ b/agents/pr-reviewer/claude-review.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Claude-oriented PR review agent.
+
+Fetches a GitHub pull request diff and returns a structured Markdown review.
+When ANTHROPIC_API_KEY is present it asks Claude; otherwise it falls back to a
+deterministic local reviewer so the workflow remains testable without secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+ANTHROPIC_VERSION = "2023-06-01"
+MAX_DIFF_CHARS = 65000
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def api_url(self) -> str:
+        return f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls/{self.number}"
+
+    @property
+    def html_url(self) -> str:
+        return f"https://github.com/{self.owner}/{self.repo}/pull/{self.number}"
+
+
+def parse_pr_url(url: str) -> PullRequestRef:
+    match = re.match(
+        r"^https://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)(?:[/?#].*)?$",
+        url.strip(),
+    )
+    if not match:
+        raise ValueError("PR must look like https://github.com/owner/repo/pull/123")
+    return PullRequestRef(match.group(1), match.group(2), int(match.group(3)))
+
+
+def request_json(url: str, token: str | None = None) -> dict[str, Any]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "claude-review-agent",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def request_text(url: str, token: str | None = None, accept: str = "text/plain") -> str:
+    headers = {"Accept": accept, "User-Agent": "claude-review-agent"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def fetch_pr(pr: PullRequestRef, token: str | None) -> tuple[dict[str, Any], str]:
+    metadata = request_json(pr.api_url, token)
+    diff = request_text(metadata["diff_url"], token, "application/vnd.github.v3.diff")
+    return metadata, diff
+
+
+def changed_files(diff: str) -> list[str]:
+    return re.findall(r"^\+\+\+ b/(.+)$", diff, flags=re.MULTILINE)
+
+
+def diff_stats(diff: str) -> tuple[int, int]:
+    additions = 0
+    deletions = 0
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            additions += 1
+        elif line.startswith("-"):
+            deletions += 1
+    return additions, deletions
+
+
+def build_prompt(metadata: dict[str, Any], diff: str) -> str:
+    pr_title = metadata.get("title", "Untitled PR")
+    pr_url = metadata.get("html_url", "unknown URL")
+    files = changed_files(diff)
+    additions, deletions = diff_stats(diff)
+    truncated = diff[:MAX_DIFF_CHARS]
+    if len(diff) > MAX_DIFF_CHARS:
+        truncated += "\n\n[Diff truncated for review context]\n"
+
+    return textwrap.dedent(
+        f"""
+        You are a senior code reviewer. Review the pull request below and return
+        only Markdown using this exact structure:
+
+        ## Summary
+        Two or three sentences explaining what changed.
+
+        ## Identified Risks
+        - Risk bullets, or "- None found in the supplied diff."
+
+        ## Improvement Suggestions
+        - Concrete suggestion bullets, or "- None."
+
+        ## Confidence
+        High | Medium | Low
+
+        PR: {pr_url}
+        Title: {pr_title}
+        Files: {", ".join(files) if files else "unknown"}
+        Diff stats: +{additions} -{deletions}
+
+        Diff:
+        ```diff
+        {truncated}
+        ```
+        """
+    ).strip()
+
+
+def claude_review(prompt: str, model: str, api_key: str) -> str:
+    payload = {
+        "model": model,
+        "max_tokens": 1200,
+        "temperature": 0.2,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "User-Agent": "claude-review-agent",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as response:
+        result = json.loads(response.read().decode("utf-8"))
+    blocks = result.get("content", [])
+    return "\n".join(block.get("text", "") for block in blocks if block.get("type") == "text").strip()
+
+
+def heuristic_review(metadata: dict[str, Any], diff: str) -> str:
+    title = metadata.get("title", "this pull request")
+    url = metadata.get("html_url", "")
+    files = changed_files(diff)
+    additions, deletions = diff_stats(diff)
+    file_list = ", ".join(files[:6]) if files else "the supplied files"
+    if len(files) > 6:
+        file_list += f", and {len(files) - 6} more"
+
+    risks: list[str] = []
+    suggestions: list[str] = []
+    lowered = diff.lower()
+
+    if not files:
+        risks.append("No file list could be extracted from the supplied diff.")
+    if additions + deletions > 500:
+        risks.append("The diff is relatively large, so review should pay extra attention to hidden coupling and missed edge cases.")
+    if any(path.endswith((".sh", ".py", ".js", ".ts")) for path in files) and not re.search(r"test|spec", "\n".join(files), re.I):
+        risks.append("The changed executable code does not appear to include nearby automated test coverage.")
+        suggestions.append("Add focused tests or fixture-based smoke checks that exercise the main success and failure paths.")
+    if re.search(r"delete\s+from(?![\s\S]{0,120}\bwhere\b)", lowered):
+        risks.append("A SQL DELETE statement appears without a nearby WHERE clause.")
+    if re.search(r"rm\s+-[^\n]*[rf]", lowered):
+        risks.append("Shell deletion logic appears in the diff and should be reviewed for path safety.")
+    if "api_key" in lowered or "token" in lowered or "secret" in lowered:
+        risks.append("The diff references credentials or secret-like configuration; verify no secrets are hard-coded.")
+        suggestions.append("Document required environment variables and ensure examples use placeholders only.")
+    if any(path.lower().endswith(("readme.md", "validation.md", "sample.md")) for path in files):
+        suggestions.append("Keep the sample output and README in sync with the CLI flags so users can copy commands directly.")
+    if not suggestions:
+        suggestions.append("Consider adding a short validation note with the exact command used to verify the change.")
+
+    if not risks:
+        risks.append("None found in the supplied diff.")
+
+    confidence = "High"
+    if len(diff) > MAX_DIFF_CHARS or additions + deletions > 500:
+        confidence = "Medium"
+    if not diff.strip():
+        confidence = "Low"
+
+    risk_block = "\n".join(f"- {risk}" for risk in risks)
+    suggestion_block = "\n".join(f"- {suggestion}" for suggestion in suggestions)
+    return (
+        "## Summary\n"
+        f'This PR, "{title}", changes {file_list}. The supplied diff shows {additions} '
+        f"added lines and {deletions} removed lines, with the main review focus on "
+        "whether the implementation, documentation, and validation evidence line up.\n\n"
+        "## Identified Risks\n"
+        f"{risk_block}\n\n"
+        "## Improvement Suggestions\n"
+        f"{suggestion_block}\n\n"
+        "## Confidence\n"
+        f"{confidence}\n\n"
+        f"<!-- Reviewed PR: {url} -->"
+    )
+
+
+def validate_sections(markdown: str) -> None:
+    required = ["## Summary", "## Identified Risks", "## Improvement Suggestions", "## Confidence"]
+    missing = [section for section in required if section not in markdown]
+    if missing:
+        raise ValueError(f"review output missing required sections: {', '.join(missing)}")
+    if not re.search(r"## Confidence\s*\n\s*(High|Medium|Low)\b", markdown):
+        raise ValueError("confidence must be exactly Low, Medium, or High")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Review a GitHub pull request with Claude-style structured Markdown.")
+    parser.add_argument("--pr", required=True, help="GitHub PR URL, e.g. https://github.com/owner/repo/pull/123")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Anthropic model to use. Default: {DEFAULT_MODEL}")
+    parser.add_argument("--offline-diff", help="Read a local diff file instead of fetching from GitHub.")
+    parser.add_argument("--output", help="Write Markdown review to this file instead of stdout only.")
+    parser.add_argument("--heuristic", action="store_true", help="Force local deterministic review even when ANTHROPIC_API_KEY exists.")
+    args = parser.parse_args(argv)
+
+    try:
+        pr = parse_pr_url(args.pr)
+        token = os.environ.get("GITHUB_TOKEN")
+        if args.offline_diff:
+            metadata = {"title": f"{pr.owner}/{pr.repo} PR #{pr.number}", "html_url": pr.html_url}
+            with open(args.offline_diff, "r", encoding="utf-8") as handle:
+                diff = handle.read()
+        else:
+            metadata, diff = fetch_pr(pr, token)
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if api_key and not args.heuristic:
+            review = claude_review(build_prompt(metadata, diff), args.model, api_key)
+        else:
+            review = heuristic_review(metadata, diff)
+        validate_sections(review)
+
+        if args.output:
+            with open(args.output, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(review + "\n")
+        print(review)
+        return 0
+    except (OSError, ValueError, urllib.error.URLError, KeyError) as exc:
+        print(f"claude-review: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-reviewer/github-action.yml
+++ b/agents/pr-reviewer/github-action.yml
@@ -1,0 +1,37 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate structured PR review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          python agents/pr-reviewer/claude-review.py --pr "$PR_URL" --output review.md
+
+      - name: Upload review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review
+          path: review.md
+
+      # Optional auto-comment mode:
+      # - name: Comment review on PR
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     PR_NUMBER: ${{ github.event.pull_request.number }}
+      #   run: gh pr comment "$PR_NUMBER" --body-file review.md

--- a/agents/pr-reviewer/samples/pr-2265-review.md
+++ b/agents/pr-reviewer/samples/pr-2265-review.md
@@ -1,0 +1,15 @@
+## Summary
+This PR, "Add Next.js SQLite CLAUDE template", changes templates/nextjs-sqlite-saas/CLAUDE.md, templates/nextjs-sqlite-saas/VALIDATION.md. The supplied diff shows 544 added lines and 0 removed lines, with the main review focus on whether the implementation, documentation, and validation evidence line up.
+
+## Identified Risks
+- The diff is relatively large, so review should pay extra attention to hidden coupling and missed edge cases.
+- The diff references credentials or secret-like configuration; verify no secrets are hard-coded.
+
+## Improvement Suggestions
+- Document required environment variables and ensure examples use placeholders only.
+- Keep the sample output and README in sync with the CLI flags so users can copy commands directly.
+
+## Confidence
+Medium
+
+<!-- Reviewed PR: https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2265 -->

--- a/agents/pr-reviewer/samples/pr-2266-review.md
+++ b/agents/pr-reviewer/samples/pr-2266-review.md
@@ -1,0 +1,15 @@
+## Summary
+This PR, "Add destructive command guard hook", changes hooks/destructive-command-guard/README.md, hooks/destructive-command-guard/install_settings.py, hooks/destructive-command-guard/pre_tool_use.py, hooks/destructive-command-guard/settings.example.json, hooks/destructive-command-guard/tests/test_pre_tool_use.py. The supplied diff shows 450 added lines and 0 removed lines, with the main review focus on whether the implementation, documentation, and validation evidence line up.
+
+## Identified Risks
+- Shell deletion logic appears in the diff and should be reviewed for path safety.
+- The diff references credentials or secret-like configuration; verify no secrets are hard-coded.
+
+## Improvement Suggestions
+- Document required environment variables and ensure examples use placeholders only.
+- Keep the sample output and README in sync with the CLI flags so users can copy commands directly.
+
+## Confidence
+High
+
+<!-- Reviewed PR: https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2266 -->

--- a/agents/pr-reviewer/tests/test_claude_review.py
+++ b/agents/pr-reviewer/tests/test_claude_review.py
@@ -1,0 +1,56 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "claude-review.py"
+SPEC = importlib.util.spec_from_file_location("claude_review", MODULE_PATH)
+claude_review = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["claude_review"] = claude_review
+SPEC.loader.exec_module(claude_review)
+
+
+class ClaudeReviewTests(unittest.TestCase):
+    def test_parse_pr_url(self):
+        ref = claude_review.parse_pr_url("https://github.com/example/project/pull/123")
+        self.assertEqual(ref.owner, "example")
+        self.assertEqual(ref.repo, "project")
+        self.assertEqual(ref.number, 123)
+
+    def test_rejects_invalid_pr_url(self):
+        with self.assertRaises(ValueError):
+            claude_review.parse_pr_url("https://github.com/example/project/issues/123")
+
+    def test_changed_files_and_stats(self):
+        diff = """diff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1 +1,2 @@
+-old
++new
++extra
+"""
+        self.assertEqual(claude_review.changed_files(diff), ["a.py"])
+        self.assertEqual(claude_review.diff_stats(diff), (2, 1))
+
+    def test_heuristic_output_has_required_sections(self):
+        metadata = {"title": "Add script", "html_url": "https://github.com/o/r/pull/1"}
+        diff = """diff --git a/tool.py b/tool.py
+--- a/tool.py
++++ b/tool.py
+@@ -0,0 +1,2 @@
++print("hello")
++token = "placeholder"
+"""
+        output = claude_review.heuristic_review(metadata, diff)
+        claude_review.validate_sections(output)
+        self.assertIn("## Summary", output)
+        self.assertIn("## Identified Risks", output)
+        self.assertIn("## Improvement Suggestions", output)
+        self.assertRegex(output, r"## Confidence\n(High|Medium|Low)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #4.

## Summary
- Adds a `claude-review --pr <url>` Python CLI that fetches a GitHub PR diff and returns structured Markdown review output.
- Uses Claude via `ANTHROPIC_API_KEY` when available, with a deterministic heuristic fallback for tests and demos without secrets.
- Includes an optional GitHub Action workflow, agent prompt, README, unit tests, and two sample outputs from real public PRs.

## Sample outputs
- `agents/pr-reviewer/samples/pr-2265-review.md`
- `agents/pr-reviewer/samples/pr-2266-review.md`

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s agents/pr-reviewer/tests -p test_*.py`
- `git diff --cached --check`
- ASCII check for `agents/pr-reviewer`