### PR TITLE
Add Claude PR reviewer agent

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,36 @@
+# PR Reviewer Agent
+
+Use this agent when a user asks Claude Code to review a GitHub pull request or a PR diff.
+
+## Contract
+
+Input:
+- A GitHub PR URL, or
+- A unified diff plus optional PR title and file list.
+
+Output:
+- Structured Markdown only.
+- Include these sections in order:
+  - `## Summary`
+  - `## Identified Risks`
+  - `## Improvement Suggestions`
+  - `## Confidence: Low|Medium|High`
+
+## Review Rules
+
+- Keep the summary to 2-3 sentences.
+- Prioritize correctness, security, data-loss, migration, CI, and missing-test risks.
+- Prefer concrete risks grounded in changed files and diff lines.
+- Do not block on style-only comments unless they affect maintainability.
+- If evidence is missing, say exactly what evidence would raise confidence.
+- Never invent test results. Only mention tests that are visible in the PR, provided by the user, or produced by the CLI.
+
+## Local CLI
+
+Run the bundled deterministic reviewer when a PR URL is available:
+
+```bash
+node bin/claude-review.mjs --pr https://github.com/owner/repo/pull/123
+```
+
+Use the CLI output as the review skeleton, then add any extra code-specific findings from manual diff inspection.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,60 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Generate structured review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node bin/claude-review.mjs --pr "${{ github.event.pull_request.html_url }}" --output review.md
+          cat review.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post review comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- claude-pr-review -->";
+            const body = `${marker}\n${fs.readFileSync("review.md", "utf8")}`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/README-pr-reviewer.md
+++ b/README-pr-reviewer.md
@@ -63,10 +63,11 @@ permissions:
 
 ## Examples
 
-Sample reviews generated from two real public PRs are included in:
+Sample reviews generated from three real public PRs are included in:
 
 - `sample-outputs/claude-builders-2277.md`
 - `sample-outputs/claude-builders-2271.md`
+- `sample-outputs/claude-builders-2284.md`
 
 ## Validation
 

--- a/README-pr-reviewer.md
+++ b/README-pr-reviewer.md
@@ -1,0 +1,77 @@
+# Claude PR Reviewer Agent
+
+`claude-review` is a dependency-free Claude Code PR review agent. It fetches a GitHub pull request, analyzes the changed files and patch text, and prints a structured Markdown review comment.
+
+## Install
+
+```bash
+npm install
+npm link
+```
+
+Then run:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+You can also run without linking:
+
+```bash
+node bin/claude-review.mjs --pr https://github.com/owner/repo/pull/123
+```
+
+For very large PRs, cap the first pass and then review the omitted files manually:
+
+```bash
+node bin/claude-review.mjs --pr https://github.com/owner/repo/pull/123 --max-files 50
+```
+
+## Authentication
+
+Public PRs work without a token until GitHub rate limits anonymous requests. For private repos or higher limits, set one of:
+
+```bash
+export GITHUB_TOKEN=ghp_xxx
+export GH_TOKEN=ghp_xxx
+```
+
+No Claude API key is required for deterministic local review generation. The `.claude/agents/pr-reviewer.md` file describes how Claude Code should use the CLI output as a review skeleton before adding manual diff findings.
+
+## Output
+
+The Markdown output always includes:
+
+- `## Summary`
+- `## Identified Risks`
+- `## Improvement Suggestions`
+- `## Confidence: Low|Medium|High`
+
+The confidence score is based on diff size, affected file types, test-file signals, workflow or migration changes, dependency changes, and security-sensitive patterns.
+
+## GitHub Action
+
+The workflow in `.github/workflows/claude-review.yml` runs on pull request events, writes the review to the job summary, and posts it as a PR comment.
+
+Required permission:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+## Examples
+
+Sample reviews generated from two real public PRs are included in:
+
+- `sample-outputs/claude-builders-2277.md`
+- `sample-outputs/claude-builders-2271.md`
+
+## Validation
+
+```bash
+npm run check
+node bin/claude-review.mjs --fixture test/fixtures/sample-pr.json
+node bin/claude-review.mjs --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2277
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ You're in the right place.
 
 ---
 
+## Submitted Tooling
+
+- [Claude PR Reviewer Agent](./README-pr-reviewer.md): a dependency-free `claude-review --pr <url>` CLI, Claude Code sub-agent instructions, GitHub Action workflow, tests, and real PR sample outputs for bounty #4.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/bin/claude-review.mjs
+++ b/bin/claude-review.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { request } from "node:https";
+import { dirname } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const USER_AGENT = "claude-pr-reviewer-agent/1.0";
+
+function usage() {
+  return `Usage:
+  claude-review --pr https://github.com/owner/repo/pull/123
+  claude-review --fixture test/fixtures/pr.json
+
+Options:
+  --pr <url>          GitHub pull request URL to review.
+  --fixture <path>    Local JSON fixture with pr and files fields.
+  --output <path>     Write review to a file instead of stdout.
+  --format <name>     markdown or json. Default: markdown.
+  --max-files <n>     Limit analyzed files for very large PRs.
+  --help              Show this help text.`;
+}
+
+function parseArgs(argv) {
+  const args = { format: "markdown" };
+  const valueFlags = new Set(["--pr", "--fixture", "--output", "--format", "--max-files"]);
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+      continue;
+    }
+
+    if (valueFlags.has(arg)) {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      const key = arg.slice(2);
+      args[key] = key === "max-files" ? Number.parseInt(value, 10) : value;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!args.help && !args.pr && !args.fixture) {
+    throw new Error("Provide --pr or --fixture");
+  }
+
+  if (args.pr && args.fixture) {
+    throw new Error("Use either --pr or --fixture, not both");
+  }
+
+  if (!["markdown", "json"].includes(args.format)) {
+    throw new Error("--format must be markdown or json");
+  }
+
+  if (args["max-files"] !== undefined && (!Number.isInteger(args["max-files"]) || args["max-files"] < 1)) {
+    throw new Error("--max-files must be a positive integer");
+  }
+
+  return args;
+}
+
+function parsePullRequestUrl(url) {
+  const match = String(url).match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/);
+  if (!match) {
+    throw new Error(`Not a GitHub pull request URL: ${url}`);
+  }
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: Number(match[3]),
+    url: `https://github.com/${match[1]}/${match[2]}/pull/${match[3]}`,
+  };
+}
+
+function githubGet(path, token) {
+  return new Promise((resolve, reject) => {
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": USER_AGENT,
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const req = request(
+      {
+        hostname: "api.github.com",
+        path,
+        method: "GET",
+        headers,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`GitHub API ${res.statusCode}: ${body.slice(0, 300)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (error) {
+            reject(new Error(`Invalid GitHub JSON response: ${error.message}`));
+          }
+        });
+      }
+    );
+
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function fetchPullRequest(prUrl, token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
+  const ref = parsePullRequestUrl(prUrl);
+  const pr = await githubGet(`/repos/${ref.owner}/${ref.repo}/pulls/${ref.number}`, token);
+  const files = [];
+
+  for (let page = 1; page <= 10; page += 1) {
+    const pageFiles = await githubGet(
+      `/repos/${ref.owner}/${ref.repo}/pulls/${ref.number}/files?per_page=100&page=${page}`,
+      token
+    );
+    files.push(...pageFiles);
+    if (pageFiles.length < 100) break;
+  }
+
+  return { ref, pr, files };
+}
+
+async function loadFixture(path) {
+  const raw = await readFile(path, "utf8");
+  const parsed = JSON.parse(raw);
+  if (!parsed.pr || !Array.isArray(parsed.files)) {
+    throw new Error("Fixture must contain { pr, files }");
+  }
+  return {
+    ref: parsed.ref || {
+      owner: "fixture",
+      repo: "fixture",
+      number: parsed.pr.number || 0,
+      url: parsed.pr.html_url || "fixture://pull-request",
+    },
+    pr: parsed.pr,
+    files: parsed.files,
+  };
+}
+
+function isTestFile(fileName) {
+  return /(^|\/)(__tests__|tests?|specs?)\//.test(fileName)
+    || /\.(test|spec)\.[cm]?[jt]sx?$/.test(fileName)
+    || /(^|\/)test_.*\.py$/.test(fileName)
+    || /(^|\/)test[-_].*\.(sh|bash|zsh|ps1)$/.test(fileName);
+}
+
+function isCodeFile(fileName) {
+  return /\.(js|jsx|ts|tsx|mjs|cjs|py|go|rs|java|rb|php|cs|sql|sh|bash|zsh|ps1)$/.test(fileName);
+}
+
+function isDocsFile(fileName) {
+  return /\.(md|mdx|txt|rst)$/.test(fileName) || /(^|\/)docs?\//.test(fileName);
+}
+
+function isWorkflowFile(fileName) {
+  return /^\.github\/workflows\/.+\.ya?ml$/.test(fileName) || /(^|\/)action\.ya?ml$/.test(fileName);
+}
+
+function isMigrationFile(fileName) {
+  return /(^|\/)(migrations?|db|database)\//.test(fileName) || /migration/i.test(fileName);
+}
+
+function isDependencyFile(fileName) {
+  return /(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|requirements\.txt|poetry\.lock|Cargo\.lock|go\.sum)$/.test(fileName)
+    || /(^|\/)(package\.json|pyproject\.toml|Cargo\.toml|go\.mod)$/.test(fileName);
+}
+
+function patchContains(files, pattern) {
+  return files.some((file) => pattern.test(`${file.patch || ""}\n${file.filename || ""}`));
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function describeFileMix(files) {
+  const labels = [];
+  if (files.some((file) => isCodeFile(file.filename))) labels.push("application code");
+  if (files.some((file) => isTestFile(file.filename))) labels.push("tests");
+  if (files.some((file) => isDocsFile(file.filename))) labels.push("documentation");
+  if (files.some((file) => isWorkflowFile(file.filename))) labels.push("automation");
+  if (files.some((file) => isMigrationFile(file.filename))) labels.push("database migrations");
+  return labels.length ? labels.join(", ") : "repository files";
+}
+
+export function analyzePullRequest({ ref, pr, files }) {
+  const truncatedFiles = Number(pr.truncatedFiles || 0);
+  const additions = files.reduce((sum, file) => sum + (file.additions || 0), 0);
+  const deletions = files.reduce((sum, file) => sum + (file.deletions || 0), 0);
+  const changedFiles = files.length;
+  const codeFiles = files.filter((file) => isCodeFile(file.filename));
+  const testFiles = files.filter((file) => isTestFile(file.filename));
+  const workflowFiles = files.filter((file) => isWorkflowFile(file.filename));
+  const migrationFiles = files.filter((file) => isMigrationFile(file.filename));
+  const dependencyFiles = files.filter((file) => isDependencyFile(file.filename));
+  const risks = [];
+  const suggestions = [];
+
+  if (codeFiles.length > 0 && testFiles.length === 0) {
+    risks.push("Code changed without matching test files in the diff.");
+    suggestions.push("Add focused tests or explain why existing coverage already exercises the changed behavior.");
+  }
+
+  if (changedFiles > 20 || additions + deletions > 800) {
+    risks.push(`Large review surface: ${changedFiles} analyzed files and ${additions + deletions} changed lines.`);
+    suggestions.push("Split the change or add a reviewer guide that maps files to behavior changes.");
+  }
+
+  if (truncatedFiles > 0) {
+    risks.push(`${truncatedFiles} changed file${truncatedFiles === 1 ? " was" : "s were"} omitted by the configured file limit.`);
+    suggestions.push("Run again without --max-files before merge or review the omitted files manually.");
+  }
+
+  if (migrationFiles.length > 0) {
+    risks.push("Database or migration files changed, so rollout and rollback behavior need explicit review.");
+    suggestions.push("Document migration order, data backfill expectations, and rollback safety before merge.");
+  }
+
+  if (workflowFiles.length > 0) {
+    risks.push("Automation or workflow files changed, which can affect CI permissions or secret exposure.");
+    suggestions.push("Verify workflow permissions are least-privilege and secrets are not echoed in logs.");
+  }
+
+  if (dependencyFiles.length > 0) {
+    risks.push("Dependency or lock files changed, which may introduce supply-chain or runtime drift.");
+    suggestions.push("Call out why each dependency change is required and confirm lockfile consistency.");
+  }
+
+  if (patchContains(files, /\b(eval|exec|child_process|subprocess|shell_exec)\b/)) {
+    risks.push("The diff references dynamic execution or shell execution primitives.");
+    suggestions.push("Constrain inputs, document trust boundaries, and add tests for command injection paths.");
+  }
+
+  if (patchContains(files, /\b(TODO|FIXME|XXX)\b/)) {
+    risks.push("The diff contains TODO/FIXME markers that may represent unfinished work.");
+    suggestions.push("Resolve the marker or convert it into a tracked follow-up with clear non-blocking rationale.");
+  }
+
+  if (patchContains(files, /\b(secret|token|password|private[_-]?key|api[_-]?key)\b/i)) {
+    risks.push("The diff mentions credential-like terms and should be checked for accidental secret handling.");
+    suggestions.push("Confirm examples use placeholders only and that no secret value is committed.");
+  }
+
+  if (risks.length === 0) {
+    risks.push("No high-risk pattern was detected from the diff metadata and patch text.");
+  }
+
+  const defaultSuggestion = "Keep the PR description aligned with the final diff and include manual verification evidence.";
+  if (suggestions.length === 0) {
+    suggestions.push(defaultSuggestion);
+  } else if (!suggestions.includes(defaultSuggestion)) {
+    suggestions.push(defaultSuggestion);
+  }
+
+  const uniqueRisks = unique(risks);
+  const uniqueSuggestions = unique(suggestions);
+  const riskScore = uniqueRisks.filter((risk) => !risk.startsWith("No high-risk")).length;
+  const confidence = riskScore >= 4 || changedFiles > 30
+    ? "Low"
+    : riskScore >= 2 || testFiles.length === 0
+      ? "Medium"
+      : "High";
+
+  const title = pr.title || `PR #${ref.number}`;
+  const summary = [
+    `${title} changes ${changedFiles} file${changedFiles === 1 ? "" : "s"} with ${additions} additions and ${deletions} deletions across ${describeFileMix(files)}.`,
+    testFiles.length > 0
+      ? `The diff includes ${testFiles.length} test-related file${testFiles.length === 1 ? "" : "s"}, which improves review confidence.`
+      : "No test file was detected in the changed file list, so behavior coverage should be verified explicitly.",
+  ];
+  if (truncatedFiles > 0) {
+    summary.push(`${truncatedFiles} additional changed file${truncatedFiles === 1 ? " was" : "s were"} not analyzed because --max-files was set.`);
+  }
+
+  return {
+    pullRequest: {
+      url: ref.url || pr.html_url,
+      owner: ref.owner,
+      repo: ref.repo,
+      number: ref.number || pr.number,
+      title,
+      author: pr.user?.login || pr.author || "unknown",
+    },
+    stats: {
+      changedFiles,
+      additions,
+      deletions,
+      codeFiles: codeFiles.length,
+      testFiles: testFiles.length,
+      workflowFiles: workflowFiles.length,
+      migrationFiles: migrationFiles.length,
+      dependencyFiles: dependencyFiles.length,
+    },
+    summary,
+    risks: uniqueRisks,
+    suggestions: uniqueSuggestions,
+    confidence,
+  };
+}
+
+export function formatMarkdown(review) {
+  const lines = [];
+  lines.push("# Claude PR Review");
+  lines.push("");
+  lines.push(`**PR:** ${review.pullRequest.url}`);
+  lines.push(`**Author:** @${review.pullRequest.author}`);
+  lines.push(`**Files:** ${review.stats.changedFiles} changed, +${review.stats.additions} / -${review.stats.deletions}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  for (const sentence of review.summary) {
+    lines.push(sentence);
+  }
+  lines.push("");
+  lines.push("## Identified Risks");
+  lines.push("");
+  for (const risk of review.risks) {
+    lines.push(`- ${risk}`);
+  }
+  lines.push("");
+  lines.push("## Improvement Suggestions");
+  lines.push("");
+  for (const suggestion of review.suggestions) {
+    lines.push(`- ${suggestion}`);
+  }
+  lines.push("");
+  lines.push(`## Confidence: ${review.confidence}`);
+  lines.push("");
+  lines.push("Confidence is based on diff size, affected file types, test coverage signals, and security-sensitive patterns.");
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      process.stdout.write(`${usage()}\n`);
+      return;
+    }
+
+    const input = args.fixture
+      ? await loadFixture(args.fixture)
+      : await fetchPullRequest(args.pr);
+
+    if (args["max-files"] && input.files.length > args["max-files"]) {
+      input.pr = { ...input.pr, truncatedFiles: input.files.length - args["max-files"] };
+      input.files = input.files.slice(0, args["max-files"]);
+    }
+
+    const review = analyzePullRequest(input);
+    const output = args.format === "json"
+      ? `${JSON.stringify(review, null, 2)}\n`
+      : formatMarkdown(review);
+
+    if (args.output) {
+      await mkdir(dirname(args.output), { recursive: true });
+      await writeFile(args.output, output, "utf8");
+    } else {
+      process.stdout.write(output);
+    }
+  } catch (error) {
+    process.stderr.write(`claude-review: ${error.message}\n\n${usage()}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+
+export { parseArgs, parsePullRequestUrl };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-pr-reviewer-agent",
+  "version": "1.0.0",
+  "description": "Dependency-free Claude Code PR review agent for structured Markdown reviews.",
+  "type": "module",
+  "bin": {
+    "claude-review": "./bin/claude-review.mjs"
+  },
+  "scripts": {
+    "test": "node --test",
+    "check": "node --check bin/claude-review.mjs && node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/sample-outputs/claude-builders-2271.md
+++ b/sample-outputs/claude-builders-2271.md
@@ -1,0 +1,22 @@
+# Claude PR Review
+
+**PR:** https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2271
+**Author:** @taherdhanera
+**Files:** 5 changed, +215 / -0
+
+## Summary
+
+Add destructive Bash command blocker hook changes 5 files with 215 additions and 0 deletions across application code, tests, documentation.
+The diff includes 1 test-related file, which improves review confidence.
+
+## Identified Risks
+
+- No high-risk pattern was detected from the diff metadata and patch text.
+
+## Improvement Suggestions
+
+- Keep the PR description aligned with the final diff and include manual verification evidence.
+
+## Confidence: High
+
+Confidence is based on diff size, affected file types, test coverage signals, and security-sensitive patterns.

--- a/sample-outputs/claude-builders-2277.md
+++ b/sample-outputs/claude-builders-2277.md
@@ -1,0 +1,23 @@
+# Claude PR Review
+
+**PR:** https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2277
+**Author:** @taherdhanera
+**Files:** 9 changed, +240 / -0
+
+## Summary
+
+Add git changelog generator skill changes 9 files with 240 additions and 0 deletions across application code, tests, documentation.
+The diff includes 1 test-related file, which improves review confidence.
+
+## Identified Risks
+
+- The diff references dynamic execution or shell execution primitives.
+
+## Improvement Suggestions
+
+- Constrain inputs, document trust boundaries, and add tests for command injection paths.
+- Keep the PR description aligned with the final diff and include manual verification evidence.
+
+## Confidence: High
+
+Confidence is based on diff size, affected file types, test coverage signals, and security-sensitive patterns.

--- a/sample-outputs/claude-builders-2284.md
+++ b/sample-outputs/claude-builders-2284.md
@@ -1,0 +1,23 @@
+# Claude PR Review
+
+**PR:** https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2284
+**Author:** @taherdhanera
+**Files:** 2 changed, +506 / -0
+
+## Summary
+
+Add Next.js SQLite CLAUDE template changes 2 files with 506 additions and 0 deletions across application code, documentation.
+No test file was detected in the changed file list, so behavior coverage should be verified explicitly.
+
+## Identified Risks
+
+- Code changed without matching test files in the diff.
+
+## Improvement Suggestions
+
+- Add focused tests or explain why existing coverage already exercises the changed behavior.
+- Keep the PR description aligned with the final diff and include manual verification evidence.
+
+## Confidence: Medium
+
+Confidence is based on diff size, affected file types, test coverage signals, and security-sensitive patterns.

--- a/test/claude-review.test.mjs
+++ b/test/claude-review.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 
 import {
   analyzePullRequest,
@@ -117,4 +118,24 @@ test("formats structured markdown review", () => {
   assert.match(markdown, /## Identified Risks/);
   assert.match(markdown, /## Improvement Suggestions/);
   assert.match(markdown, /## Confidence: Medium/);
+});
+
+test("bundled real PR samples include required review sections", async () => {
+  const samplePaths = [
+    "sample-outputs/claude-builders-2271.md",
+    "sample-outputs/claude-builders-2277.md",
+    "sample-outputs/claude-builders-2284.md",
+  ];
+
+  assert.equal(samplePaths.length, 3);
+
+  for (const samplePath of samplePaths) {
+    const markdown = await readFile(samplePath, "utf8");
+
+    assert.match(markdown, /^# Claude PR Review/);
+    assert.match(markdown, /## Summary/);
+    assert.match(markdown, /## Identified Risks/);
+    assert.match(markdown, /## Improvement Suggestions/);
+    assert.match(markdown, /## Confidence: (Low|Medium|High)/);
+  }
 });

--- a/test/claude-review.test.mjs
+++ b/test/claude-review.test.mjs
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  analyzePullRequest,
+  formatMarkdown,
+  parseArgs,
+  parsePullRequestUrl,
+} from "../bin/claude-review.mjs";
+
+const fixture = {
+  ref: {
+    owner: "example",
+    repo: "app",
+    number: 42,
+    url: "https://github.com/example/app/pull/42",
+  },
+  pr: {
+    number: 42,
+    title: "Add billing webhook",
+    user: { login: "octocat" },
+  },
+  files: [
+    {
+      filename: "app/api/billing/route.ts",
+      additions: 80,
+      deletions: 12,
+      patch: "+const token = process.env.STRIPE_WEBHOOK_SECRET;\n+export async function POST() {}",
+    },
+    {
+      filename: "tests/billing-webhook.test.ts",
+      additions: 45,
+      deletions: 0,
+      patch: "+test('handles webhook', () => {})",
+    },
+    {
+      filename: ".github/workflows/review.yml",
+      additions: 22,
+      deletions: 0,
+      patch: "+permissions:\n+  pull-requests: write",
+    },
+  ],
+};
+
+test("parses GitHub PR URLs", () => {
+  assert.deepEqual(
+    parsePullRequestUrl("https://github.com/acme/project/pull/123"),
+    {
+      owner: "acme",
+      repo: "project",
+      number: 123,
+      url: "https://github.com/acme/project/pull/123",
+    }
+  );
+});
+
+test("parses max-files option", () => {
+  assert.deepEqual(
+    parseArgs(["--pr", "https://github.com/acme/project/pull/123", "--max-files", "10"]),
+    {
+      pr: "https://github.com/acme/project/pull/123",
+      format: "markdown",
+      "max-files": 10,
+    }
+  );
+});
+
+test("analyzes diff metadata into required review sections", () => {
+  const review = analyzePullRequest(fixture);
+
+  assert.equal(review.pullRequest.title, "Add billing webhook");
+  assert.equal(review.stats.changedFiles, 3);
+  assert.equal(review.stats.testFiles, 1);
+  assert.equal(review.confidence, "Medium");
+  assert.match(review.risks.join("\n"), /workflow files changed/i);
+  assert.match(review.risks.join("\n"), /credential-like terms/i);
+});
+
+test("detects shell code and shell test files", () => {
+  const review = analyzePullRequest({
+    ref: {
+      owner: "example",
+      repo: "hooks",
+      number: 7,
+      url: "https://github.com/example/hooks/pull/7",
+    },
+    pr: {
+      number: 7,
+      title: "Add command hook",
+      user: { login: "hook-author" },
+    },
+    files: [
+      {
+        filename: "hooks/block_destructive_bash.sh",
+        additions: 30,
+        deletions: 0,
+        patch: "+case \"$1\" in rm*) exit 2;; esac",
+      },
+      {
+        filename: "hooks/test_block_destructive_bash.sh",
+        additions: 20,
+        deletions: 0,
+        patch: "+bash hooks/block_destructive_bash.sh",
+      },
+    ],
+  });
+
+  assert.equal(review.stats.codeFiles, 2);
+  assert.equal(review.stats.testFiles, 1);
+});
+
+test("formats structured markdown review", () => {
+  const markdown = formatMarkdown(analyzePullRequest(fixture));
+
+  assert.match(markdown, /^# Claude PR Review/);
+  assert.match(markdown, /## Summary/);
+  assert.match(markdown, /## Identified Risks/);
+  assert.match(markdown, /## Improvement Suggestions/);
+  assert.match(markdown, /## Confidence: Medium/);
+});

--- a/test/fixtures/sample-pr.json
+++ b/test/fixtures/sample-pr.json
@@ -1,0 +1,29 @@
+{
+  "ref": {
+    "owner": "example",
+    "repo": "saas",
+    "number": 12,
+    "url": "https://github.com/example/saas/pull/12"
+  },
+  "pr": {
+    "number": 12,
+    "title": "Add account settings page",
+    "user": {
+      "login": "review-target"
+    }
+  },
+  "files": [
+    {
+      "filename": "app/settings/page.tsx",
+      "additions": 68,
+      "deletions": 0,
+      "patch": "+export default function SettingsPage() { return <main>Settings</main>; }"
+    },
+    {
+      "filename": "app/settings/actions.ts",
+      "additions": 42,
+      "deletions": 3,
+      "patch": "+export async function updateSettings() { /* TODO validate input */ }"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #4

## Claim
/claim #4

## Current status
Active Taher-owned submission for the Claude PR reviewer agent bounty. This PR is open, non-draft, and targets issue #4.

## Summary
- Adds a dependency-free Node CLI: `claude-review --pr <url>`, plus fixture, JSON, output-file, and max-file options.
- Adds Claude Code sub-agent instructions in `.claude/agents/pr-reviewer.md` and an idempotent GitHub Actions workflow that posts/updates structured PR review comments.
- Adds README setup/usage docs, tests, and sample outputs generated from three real public PRs.

## Real PR sample outputs
- `sample-outputs/claude-builders-2277.md` generated from https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2277
- `sample-outputs/claude-builders-2271.md` generated from https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2271
- `sample-outputs/claude-builders-2284.md` generated from https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2284

## Validation
- `npm run check` -> 6/6 tests passing
- `node bin/claude-review.mjs --fixture test/fixtures/sample-pr.json` -> passed
- `node bin/claude-review.mjs --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2277 --output sample-outputs/claude-builders-2277.md` -> passed
- `node bin/claude-review.mjs --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2271 --output sample-outputs/claude-builders-2271.md` -> passed
- `node bin/claude-review.mjs --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2284 --output sample-outputs/claude-builders-2284.md` -> passed
- `git diff --check` -> passed

## Latest refresh
- `4b364eb` adds a third real PR sample output and a regression test that bundled samples contain the required structured sections.
- The branch remains contributor-side complete unless maintainers request revisions.