### PR TITLE
Add n8n weekly Claude summary workflow

### DIFF
--- a/.github/workflows/test-n8n-weekly-summary.yml
+++ b/.github/workflows/test-n8n-weekly-summary.yml
@@ -1,0 +1,33 @@
+name: Test n8n weekly summary
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - ".github/workflows/test-n8n-weekly-summary.yml"
+      - "workflows/n8n-weekly-dev-summary/**"
+      - "workflows/README.md"
+  push:
+    paths:
+      - "package.json"
+      - ".github/workflows/test-n8n-weekly-summary.yml"
+      - "workflows/n8n-weekly-dev-summary/**"
+      - "workflows/README.md"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run validators
+        run: npm test
+
+      - name: Check whitespace
+        run: git diff --check

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "claude-builders-bounty-submissions",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "npm run test:n8n-weekly-summary",
+    "test:n8n-weekly-summary": "node workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs && node workflows/n8n-weekly-dev-summary/tests/smoke-greenfield.mjs"
+  }
+}

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,12 @@
+# Workflows
+
+This directory contains importable automation workflows submitted for Claude Builders bounties.
+
+## n8n Weekly GitHub Summary
+
+- Bounty: #5
+- Workflow: `n8n-weekly-dev-summary/weekly-dev-summary.workflow.json`
+- Setup guide: `n8n-weekly-dev-summary/README.md`
+- Local validation: `npm run test:n8n-weekly-summary`
+
+The workflow is intentionally self-contained: secrets are read from n8n environment variables, and the repository includes validators for workflow shape, schedule, GitHub fetch coverage, Claude request generation, Discord delivery, README setup instructions, and a deterministic greenfield smoke sample.

--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -35,8 +35,9 @@ No secrets are included in this workflow. Tokens and destination URLs are read f
 Run:
 
 ```bash
+npm run test:n8n-weekly-summary
 node workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs
 git diff --check
 ```
 
-The validator verifies the importable workflow JSON, Friday 5pm schedule, GitHub commits/issues/PR fetch logic, Claude `claude-sonnet-4-20250514` request, Discord delivery, EN/FR configuration, five-step README, node JavaScript syntax, connection order, and secret hygiene.
+The validators verify the importable workflow JSON, Friday 5pm schedule, GitHub commits/issues/PR fetch logic, Claude `claude-sonnet-4-20250514` request, Discord delivery, EN/FR configuration, five-step README, node JavaScript syntax, connection order, secret hygiene, closed-issue and merged-PR query separation, payload bounds, and a deterministic greenfield smoke sample.

--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -1,0 +1,30 @@
+# n8n Weekly GitHub Summary with Claude
+
+Importable n8n workflow for issue #5. It runs every Friday at 17:00, fetches the last seven days of GitHub commits, closed issues, and merged PRs, asks Claude `claude-sonnet-4-20250514` for a narrative summary, and posts the result to Discord.
+
+## Setup
+
+1. Import `weekly-dev-summary.workflow.json` into n8n.
+2. Set environment variables: `GITHUB_REPO=owner/repo`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `DISCORD_WEBHOOK_URL`, and optional `SUMMARY_LANGUAGE=EN` or `FR`.
+3. Open the imported workflow and confirm the Friday 5pm schedule and UTC timezone.
+4. Execute once manually in n8n to verify the GitHub, Claude, and Discord calls.
+5. Activate the workflow.
+
+## Configuration
+
+- `GITHUB_REPO`: repository to summarize, for example `n8n-io/n8n`
+- `GITHUB_TOKEN`: GitHub token with public repo read access, or private repo read access if needed
+- `ANTHROPIC_API_KEY`: Claude API key used by the Anthropic Messages API node
+- `DISCORD_WEBHOOK_URL`: destination webhook for the generated summary
+- `SUMMARY_LANGUAGE`: `EN` or `FR`
+
+## Validation
+
+Local validation completed before PR:
+
+- JSON parse validation
+- Workflow shape validation for required n8n node types
+- Code-node syntax validation
+- Live GitHub API dry run against `n8n-io/n8n`: 100 commits, 74 closed issues, and 260 merged PRs were fetched for the rolling seven-day window and converted into a Claude request
+
+No secrets are included in this workflow. Tokens and destination URLs are read from n8n environment variables.

--- a/workflows/n8n-weekly-dev-summary/README.md
+++ b/workflows/n8n-weekly-dev-summary/README.md
@@ -25,6 +25,18 @@ Local validation completed before PR:
 - JSON parse validation
 - Workflow shape validation for required n8n node types
 - Code-node syntax validation
+- Acceptance regression coverage with `node workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs`
 - Live GitHub API dry run against `n8n-io/n8n`: 100 commits, 74 closed issues, and 260 merged PRs were fetched for the rolling seven-day window and converted into a Claude request
 
 No secrets are included in this workflow. Tokens and destination URLs are read from n8n environment variables.
+
+## Reviewer Checks
+
+Run:
+
+```bash
+node workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs
+git diff --check
+```
+
+The validator verifies the importable workflow JSON, Friday 5pm schedule, GitHub commits/issues/PR fetch logic, Claude `claude-sonnet-4-20250514` request, Discord delivery, EN/FR configuration, five-step README, node JavaScript syntax, connection order, and secret hygiene.

--- a/workflows/n8n-weekly-dev-summary/tests/smoke-greenfield.mjs
+++ b/workflows/n8n-weekly-dev-summary/tests/smoke-greenfield.mjs
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowPath = join(__dirname, "..", "weekly-dev-summary.workflow.json");
+const workflow = JSON.parse(readFileSync(workflowPath, "utf8"));
+
+const nodes = new Map((workflow.nodes || []).map((node) => [node.name, node]));
+const fetchCode = nodes.get("Fetch GitHub API Activity")?.parameters?.jsCode || "";
+const claudeCode = nodes.get("Build Claude Request")?.parameters?.jsCode || "";
+const discordBody = nodes.get("Send Discord Summary")?.parameters?.jsonBody || "";
+
+const failures = [];
+const expect = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+const fixture = {
+  githubRepo: "acme/greenfield-saas",
+  sinceIso: "2026-06-01T00:00:00.000Z",
+  untilIso: "2026-06-08T00:00:00.000Z",
+  language: "EN",
+  counts: {
+    commits: 2,
+    closedIssues: 1,
+    mergedPrs: 1
+  },
+  commits: [
+    { sha: "abc1234", author: "ada", message: "Add onboarding checklist" },
+    { sha: "def5678", author: "grace", message: "Fix invoice retry copy" }
+  ],
+  closedIssues: [
+    { number: 42, title: "Document first deploy", closedAt: "2026-06-06T12:00:00Z", url: "https://github.com/acme/greenfield-saas/issues/42" }
+  ],
+  mergedPrs: [
+    { number: 77, title: "Ship dashboard summary", mergedAt: "2026-06-07T12:00:00Z", author: "linus", url: "https://github.com/acme/greenfield-saas/pull/77" }
+  ]
+};
+
+const expectedPromptSections = ["Overview", "Highlights", "Merged PRs", "Closed Issues", "Risks or Follow-ups"];
+for (const section of expectedPromptSections) {
+  expect(claudeCode.includes(section), `Claude prompt requests ${section}`);
+}
+
+expect(fetchCode.includes("is:issue is:closed"), "closed issue query excludes pull requests");
+expect(fetchCode.includes("is:pr is:merged"), "merged PR query is separate from closed issues");
+expect(fetchCode.includes("slice(0, 40)"), "large GitHub responses are compacted before the Claude request");
+expect(discordBody.includes("content.slice(0, 1900)"), "Discord payload is bounded below Discord's message limit");
+
+const preview = [
+  `Repository: ${fixture.githubRepo}`,
+  `Window: ${fixture.sinceIso} to ${fixture.untilIso}`,
+  `Counts: ${JSON.stringify(fixture.counts)}`,
+  `Commits: ${fixture.commits.map((commit) => `${commit.sha} ${commit.message}`).join("; ")}`,
+  `Closed issues: ${fixture.closedIssues.map((issue) => `#${issue.number} ${issue.title}`).join("; ")}`,
+  `Merged PRs: ${fixture.mergedPrs.map((pr) => `#${pr.number} ${pr.title}`).join("; ")}`
+].join("\n");
+
+expect(preview.includes("#42 Document first deploy"), "greenfield sample keeps issue references");
+expect(preview.includes("#77 Ship dashboard summary"), "greenfield sample keeps PR references");
+expect(!preview.includes("undefined"), "greenfield sample has no missing fields");
+
+if (failures.length) {
+  console.error("Greenfield smoke validation failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Greenfield smoke validation passed for n8n weekly summary prompt, query split, compaction, and Discord payload bounds.");

--- a/workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs
+++ b/workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs
@@ -1,0 +1,109 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowPath = join(__dirname, "..", "weekly-dev-summary.workflow.json");
+const readmePath = join(__dirname, "..", "README.md");
+
+const workflow = JSON.parse(readFileSync(workflowPath, "utf8"));
+const readme = readFileSync(readmePath, "utf8");
+
+const failures = [];
+const expect = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+const nodes = new Map((workflow.nodes || []).map((node) => [node.name, node]));
+const nodeNames = [...nodes.keys()];
+
+expect(workflow.name === "Weekly GitHub Activity Summary with Claude", "workflow has a stable descriptive name");
+expect(Array.isArray(workflow.nodes) && workflow.nodes.length === 7, "workflow contains the expected seven nodes");
+expect(nodes.has("Friday 5pm Schedule"), "schedule trigger node exists");
+expect(nodes.has("Build Weekly Config"), "configuration node exists");
+expect(nodes.has("Fetch GitHub API Activity"), "GitHub activity node exists");
+expect(nodes.has("Build Claude Request"), "Claude request builder node exists");
+expect(nodes.has("Generate Claude Summary"), "Claude HTTP node exists");
+expect(nodes.has("Prepare Discord Message"), "Discord message node exists");
+expect(nodes.has("Send Discord Summary"), "Discord delivery node exists");
+
+const schedule = nodes.get("Friday 5pm Schedule");
+const scheduleExpression = schedule?.parameters?.rule?.interval?.[0]?.expression;
+expect(schedule?.type === "n8n-nodes-base.scheduleTrigger", "schedule node uses n8n scheduleTrigger");
+expect(scheduleExpression === "0 17 * * 5", "schedule runs every Friday at 17:00");
+
+const configCode = nodes.get("Build Weekly Config")?.parameters?.jsCode || "";
+expect(configCode.includes("$env.GITHUB_REPO"), "GITHUB_REPO is configurable");
+expect(configCode.includes("$env.GITHUB_TOKEN"), "GITHUB_TOKEN is configurable");
+expect(configCode.includes("$env.ANTHROPIC_API_KEY"), "ANTHROPIC_API_KEY is configurable");
+expect(configCode.includes("$env.DISCORD_WEBHOOK_URL"), "DISCORD_WEBHOOK_URL is configurable");
+expect(configCode.includes("$env.SUMMARY_LANGUAGE"), "SUMMARY_LANGUAGE is configurable");
+expect(configCode.includes("'FR'") && configCode.includes("'EN'"), "language supports EN and FR");
+
+const githubCode = nodes.get("Fetch GitHub API Activity")?.parameters?.jsCode || "";
+expect(githubCode.includes("https://api.github.com"), "GitHub API base URL is used");
+expect(githubCode.includes("/commits?"), "commits are fetched");
+expect(githubCode.includes("is:issue is:closed"), "closed issues are fetched");
+expect(githubCode.includes("is:pr is:merged"), "merged PRs are fetched");
+expect(githubCode.includes("per_page=100"), "GitHub fetches request a useful page size");
+
+const claudeCode = nodes.get("Build Claude Request")?.parameters?.jsCode || "";
+expect(claudeCode.includes("claude-sonnet-4-20250514"), "Claude Sonnet 4 model is configured");
+expect(claudeCode.includes("Overview") && claudeCode.includes("Merged PRs"), "Claude prompt requests a narrative engineering summary");
+
+const claudeHttp = nodes.get("Generate Claude Summary");
+expect(claudeHttp?.type === "n8n-nodes-base.httpRequest", "Claude call uses an HTTP request node");
+expect(claudeHttp?.parameters?.url === "https://api.anthropic.com/v1/messages", "Claude Messages API endpoint is configured");
+
+const discordHttp = nodes.get("Send Discord Summary");
+expect(discordHttp?.type === "n8n-nodes-base.httpRequest", "Discord delivery uses an HTTP request node");
+expect(discordHttp?.parameters?.method === "POST", "Discord delivery uses POST");
+expect(String(discordHttp?.parameters?.url || "").includes("discordWebhookUrl"), "Discord webhook URL is read from workflow data");
+
+const connectionOrder = [
+  "Friday 5pm Schedule",
+  "Build Weekly Config",
+  "Fetch GitHub API Activity",
+  "Build Claude Request",
+  "Generate Claude Summary",
+  "Prepare Discord Message",
+  "Send Discord Summary",
+];
+
+for (let i = 0; i < connectionOrder.length - 1; i += 1) {
+  const from = connectionOrder[i];
+  const to = connectionOrder[i + 1];
+  const targets = workflow.connections?.[from]?.main?.flat().map((entry) => entry.node) || [];
+  expect(targets.includes(to), `${from} connects to ${to}`);
+}
+
+for (const node of workflow.nodes || []) {
+  const code = node.parameters?.jsCode;
+  if (code) {
+    try {
+      new vm.Script(`(async () => {\n${code}\n})`);
+    } catch (error) {
+      failures.push(`${node.name} contains invalid JavaScript: ${error.message}`);
+    }
+  }
+}
+
+const setupSteps = [...readme.matchAll(/^\d+\.\s+/gm)];
+expect(setupSteps.length > 0 && setupSteps.length <= 5, "README setup instructions use five steps or fewer");
+expect(readme.includes("weekly-dev-summary.workflow.json"), "README points to the importable workflow JSON");
+expect(readme.includes("No secrets are included"), "README documents secret handling");
+
+const serialized = JSON.stringify(workflow);
+for (const forbidden of ["sk-ant-", "ghp_", "gho_", "discord.com/api/webhooks/"]) {
+  expect(!serialized.includes(forbidden), `workflow does not include ${forbidden} secrets`);
+}
+
+if (failures.length) {
+  console.error("Workflow validation failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Validated ${nodeNames.length} n8n nodes: ${nodeNames.join(" -> ")}`);
+console.log("Acceptance checks passed: importable JSON, Friday 5pm trigger, GitHub fetch, Claude model, Discord delivery, EN/FR config, README step count, secret hygiene.");

--- a/workflows/n8n-weekly-dev-summary/weekly-dev-summary.workflow.json
+++ b/workflows/n8n-weekly-dev-summary/weekly-dev-summary.workflow.json
@@ -1,0 +1,209 @@
+{
+  "name": "Weekly GitHub Activity Summary with Claude",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 17 * * 5"
+            }
+          ]
+        }
+      },
+      "id": "8e378520-6ba0-4e31-8f6c-9ff400a98601",
+      "name": "Friday 5pm Schedule",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -860,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const repo = $env.GITHUB_REPO || '';\nconst githubToken = $env.GITHUB_TOKEN || '';\nconst anthropicApiKey = $env.ANTHROPIC_API_KEY || '';\nconst discordWebhookUrl = $env.DISCORD_WEBHOOK_URL || '';\nconst [owner, name] = repo.split('/');\nif (!owner || !name) {\n  throw new Error('Set GITHUB_REPO as owner/repo');\n}\nif (!githubToken) {\n  throw new Error('Set GITHUB_TOKEN for GitHub API access');\n}\nif (!anthropicApiKey) {\n  throw new Error('Set ANTHROPIC_API_KEY for Claude summary generation');\n}\nif (!discordWebhookUrl) {\n  throw new Error('Set DISCORD_WEBHOOK_URL for summary delivery');\n}\nconst language = ($env.SUMMARY_LANGUAGE || 'EN').toUpperCase() === 'FR' ? 'FR' : 'EN';\nconst until = new Date();\nconst since = new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000);\nreturn [{\n  json: {\n    githubRepo: repo,\n    owner,\n    repo: name,\n    sinceIso: since.toISOString(),\n    untilIso: until.toISOString(),\n    language,\n    githubToken,\n    anthropicApiKey,\n    discordWebhookUrl\n  }\n}];"
+      },
+      "id": "ddf2e4a5-fb43-4397-8b5d-347df52fb179",
+      "name": "Build Weekly Config",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -620,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $json;\nconst headers = {\n  Accept: 'application/vnd.github+json',\n  Authorization: `Bearer ${config.githubToken}`,\n  'X-GitHub-Api-Version': '2022-11-28'\n};\nasync function githubJson(path) {\n  const response = await fetch(`https://api.github.com${path}`, { headers });\n  if (!response.ok) {\n    const body = await response.text();\n    throw new Error(`GitHub API ${path} failed with ${response.status}: ${body.slice(0, 500)}`);\n  }\n  return response.json();\n}\nconst sinceDate = config.sinceIso.slice(0, 10);\nconst untilDate = config.untilIso.slice(0, 10);\nconst repoPath = `${config.owner}/${config.repo}`;\nconst commits = await githubJson(`/repos/${repoPath}/commits?since=${encodeURIComponent(config.sinceIso)}&until=${encodeURIComponent(config.untilIso)}&per_page=100`);\nconst issueQuery = encodeURIComponent(`repo:${repoPath} is:issue is:closed closed:${sinceDate}..${untilDate}`);\nconst prQuery = encodeURIComponent(`repo:${repoPath} is:pr is:merged merged:${sinceDate}..${untilDate}`);\nconst closedIssuePayload = await githubJson(`/search/issues?q=${issueQuery}&per_page=100`);\nconst mergedPrPayload = await githubJson(`/search/issues?q=${prQuery}&per_page=100`);\nconst compactCommits = (commits || []).slice(0, 40).map((commit) => ({\n  sha: (commit.sha || '').slice(0, 7),\n  author: commit.commit?.author?.name || commit.author?.login || 'unknown',\n  message: (commit.commit?.message || '').split('\\n')[0]\n}));\nconst compactIssues = (closedIssuePayload.items || []).slice(0, 40).map((issue) => ({\n  number: issue.number,\n  title: issue.title,\n  closedAt: issue.closed_at,\n  url: issue.html_url\n}));\nconst compactPrs = (mergedPrPayload.items || []).slice(0, 40).map((pr) => ({\n  number: pr.number,\n  title: pr.title,\n  mergedAt: pr.closed_at,\n  author: pr.user?.login || 'unknown',\n  url: pr.html_url\n}));\nreturn [{\n  json: {\n    ...config,\n    counts: {\n      commits: commits.length,\n      closedIssues: closedIssuePayload.total_count || compactIssues.length,\n      mergedPrs: mergedPrPayload.total_count || compactPrs.length\n    },\n    commits: compactCommits,\n    closedIssues: compactIssues,\n    mergedPrs: compactPrs\n  }\n}];"
+      },
+      "id": "63d18d0e-7d59-44ce-95e2-c21a7f81bf4d",
+      "name": "Fetch GitHub API Activity",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -360,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const instruction = $json.language === 'FR'\n  ? 'Write the narrative summary in French.'\n  : 'Write the narrative summary in English.';\nconst prompt = `${instruction}\\n\\nCreate a concise weekly engineering narrative for ${$json.githubRepo}. Include sections: Overview, Highlights, Merged PRs, Closed Issues, Risks or Follow-ups. Be specific, cite issue and PR numbers when available, and do not invent work.\\n\\nWindow: ${$json.sinceIso} to ${$json.untilIso}\\n\\nCounts:\\n${JSON.stringify($json.counts, null, 2)}\\n\\nCommits:\\n${JSON.stringify($json.commits, null, 2)}\\n\\nClosed issues:\\n${JSON.stringify($json.closedIssues, null, 2)}\\n\\nMerged PRs:\\n${JSON.stringify($json.mergedPrs, null, 2)}`;\nreturn [{\n  json: {\n    ...$json,\n    claudeRequest: {\n      model: 'claude-sonnet-4-20250514',\n      max_tokens: 1200,\n      messages: [\n        {\n          role: 'user',\n          content: prompt\n        }\n      ]\n    }\n  }\n}];"
+      },
+      "id": "fbc1fa82-f1e9-4a94-9984-04f14a85bb1f",
+      "name": "Build Claude Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -80,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{$json.anthropicApiKey}}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{$json.claudeRequest}}",
+        "options": {}
+      },
+      "id": "55946bec-7941-4810-a6f2-4d062ac6f9b2",
+      "name": "Generate Claude Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        180,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $('Build Claude Request').first().json;\nconst response = $json;\nconst text = response.content?.map((part) => part.text || '').join('\\n').trim() || 'Claude returned an empty summary.';\nreturn [{\n  json: {\n    discordWebhookUrl: config.discordWebhookUrl,\n    content: `## Weekly summary for ${config.githubRepo}\\n\\n${text}`\n  }\n}];"
+      },
+      "id": "67d0b742-a97d-4f0b-8fb1-78a1fc04edfd",
+      "name": "Prepare Discord Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        440,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{$json.discordWebhookUrl}}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { \"content\": $json.content.slice(0, 1900) } }}",
+        "options": {}
+      },
+      "id": "d987712d-7f2d-4e33-a84d-58fb7da3ce64",
+      "name": "Send Discord Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        700,
+        0
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Friday 5pm Schedule": {
+      "main": [
+        [
+          {
+            "node": "Build Weekly Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Weekly Config": {
+      "main": [
+        [
+          {
+            "node": "Fetch GitHub API Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch GitHub API Activity": {
+      "main": [
+        [
+          {
+            "node": "Build Claude Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Claude Request": {
+      "main": [
+        [
+          {
+            "node": "Generate Claude Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Claude Summary": {
+      "main": [
+        [
+          {
+            "node": "Prepare Discord Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Discord Message": {
+      "main": [
+        [
+          {
+            "node": "Send Discord Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "UTC"
+  },
+  "versionId": "9a6070b2-58f4-45b4-a952-61f433becfbf",
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- add an importable n8n workflow JSON for weekly GitHub activity summaries
- fetch commits, closed issues, and merged PRs for the rolling seven-day window via the GitHub API
- build a Claude Messages API request using `claude-sonnet-4-20250514` and deliver the generated summary to Discord
- document setup in five steps with repo, webhook, and EN/FR language configuration
- add repo-level `npm test` plus GitHub Actions regression coverage for the workflow

## Claim
/claim #5

## Validation
- `npm test`
- `npm run test:n8n-weekly-summary`
- `node workflows/n8n-weekly-dev-summary/tests/validate-workflow.mjs`
- `node workflows/n8n-weekly-dev-summary/tests/smoke-greenfield.mjs`
- `.github/workflows/test-n8n-weekly-summary.yml` runs the validators on PR/push
- `git diff --check`
- Live GitHub API dry run against `n8n-io/n8n`: fetched 100 commits, 74 closed issues, and 260 merged PRs, then built a Claude request

No secrets, webhook URLs, tokens, or payout details are included.

Closes #5