### PR TITLE
Add changelog generator (closes #1)

### DIFF
--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate CHANGELOG.md from git history since the last tag.
+# Usage:
+#   bash changelog.sh
+#   bash changelog.sh --output path/to/CHANGELOG.md
+
+output="CHANGELOG.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: bash changelog.sh [--output CHANGELOG.md]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "error: git is required" >&2
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: must run inside a git repository" >&2
+  exit 1
+fi
+
+last_tag=""
+if last_tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+  :
+else
+  last_tag=""
+fi
+
+range="HEAD"
+since_line="(all commits)"
+if [[ -n "$last_tag" ]]; then
+  range="${last_tag}..HEAD"
+  since_line="since tag ${last_tag}"
+fi
+
+today="$(date +%F)"
+
+added=()
+fixed=()
+changed=()
+removed=()
+
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  # Conventional commits friendly categorization.
+  if [[ "$lower" =~ ^(feat|add)(\(|:|!| ) ]]; then
+    added+=("$subject")
+  elif [[ "$lower" =~ ^fix(\(|:|!| ) ]]; then
+    fixed+=("$subject")
+  elif [[ "$lower" =~ ^(remove|delete)(\(|:|!| ) ]]; then
+    removed+=("$subject")
+  else
+    changed+=("$subject")
+  fi
+done < <(git log --no-merges --pretty=format:%s "$range")
+
+{
+  echo "# Changelog"
+  echo
+  echo "## [Unreleased] - $today"
+  echo
+  echo "_Generated from git history $since_line._"
+  echo
+
+  echo "### Added"
+  if [[ ${#added[@]} -eq 0 ]]; then
+    echo "- (none)"
+  else
+    for s in "${added[@]}"; do echo "- $s"; done
+  fi
+  echo
+
+  echo "### Fixed"
+  if [[ ${#fixed[@]} -eq 0 ]]; then
+    echo "- (none)"
+  else
+    for s in "${fixed[@]}"; do echo "- $s"; done
+  fi
+  echo
+
+  echo "### Changed"
+  if [[ ${#changed[@]} -eq 0 ]]; then
+    echo "- (none)"
+  else
+    for s in "${changed[@]}"; do echo "- $s"; done
+  fi
+  echo
+
+  echo "### Removed"
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    echo "- (none)"
+  else
+    for s in "${removed[@]}"; do echo "- $s"; done
+  fi
+  echo
+} >"$output"
+
+echo "Wrote $output ($today)."
+

--- a/changelog.sh
+++ b/changelog.sh
@@ -11,7 +11,12 @@ output="CHANGELOG.md"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output)
-      output="${2:-}"
+      if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
+        echo "error: --output requires a value" >&2
+        echo "Usage: bash changelog.sh [--output CHANGELOG.md]" >&2
+        exit 2
+      fi
+      output="$2"
       shift 2
       ;;
     -h|--help)

--- a/docs/generate-changelog/README.md
+++ b/docs/generate-changelog/README.md
@@ -1,0 +1,6 @@
+# Generate Changelog
+
+1. `cd` into any git repo
+2. Copy `changelog.sh` (or `generate_changelog.py`) into that repo
+3. Run `bash changelog.sh` (or `python generate_changelog.py`) to write `CHANGELOG.md`
+

--- a/docs/generate-changelog/sample-CHANGELOG.md
+++ b/docs/generate-changelog/sample-CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [Unreleased] - 2026-05-30
+
+_Generated from git history (all commits)._
+
+### Added
+- Add idempotent PR comment posting
+- Address PR review edge cases
+- Add PR review action example
+- Add Claude PR review agent
+- feat: initial README with bounty board
+
+### Fixed
+- (none)
+
+### Changed
+- Strengthen Claude PR reviewer submission
+- Document review action comment permission
+- Support shorthand PR references
+- Make review action idempotent
+
+### Removed
+- (none)

--- a/docs/generate-changelog/sample-CHANGELOG.md
+++ b/docs/generate-changelog/sample-CHANGELOG.md
@@ -5,20 +5,14 @@
 _Generated from git history (all commits)._
 
 ### Added
-- Add idempotent PR comment posting
-- Address PR review edge cases
-- Add PR review action example
-- Add Claude PR review agent
+- Add changelog generator script
 - feat: initial README with bounty board
 
 ### Fixed
 - (none)
 
 ### Changed
-- Strengthen Claude PR reviewer submission
-- Document review action comment permission
-- Support shorthand PR references
-- Make review action idempotent
+- (none)
 
 ### Removed
 - (none)

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Generate a structured CHANGELOG.md from git history since the last tag.
 
-Dependency-free: only requires Python 3 and git.
+Dependency-free: only requires Python 3.8+ and git.
 """
 
 from __future__ import annotations
@@ -9,12 +9,8 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import subprocess
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class Entry:
-    subject: str
+import sys
+from typing import List, Optional
 
 
 def sh(cmd: list[str]) -> str:
@@ -22,14 +18,14 @@ def sh(cmd: list[str]) -> str:
     return out.decode("utf-8", errors="replace").strip()
 
 
-def try_last_tag() -> str | None:
+def try_last_tag() -> Optional[str]:
     try:
         return sh(["git", "describe", "--tags", "--abbrev=0"]) or None
     except subprocess.CalledProcessError:
         return None
 
 
-def subjects_since(tag: str | None) -> list[str]:
+def subjects_since(tag: Optional[str]) -> List[str]:
     rev = "HEAD" if not tag else f"{tag}..HEAD"
     out = sh(["git", "log", "--no-merges", "--pretty=format:%s", rev])
     if not out:
@@ -38,17 +34,33 @@ def subjects_since(tag: str | None) -> list[str]:
 
 
 def bucket(subject: str) -> str:
-    lower = subject.lower()
-    if lower.startswith(("feat", "add")):
+    lower = subject.lower().strip()
+    # Match conventional-commit-ish prefixes using a delimiter so we don't
+    # accidentally treat "feature:" as "feat:" etc.
+    def _starts(prefixes) -> bool:
+        return any(lower.startswith(p) for p in prefixes)
+
+    if _starts(("feat(", "feat:", "feat!", "feat ", "add(", "add:", "add!", "add ")):
         return "Added"
-    if lower.startswith("fix"):
+    if _starts(("fix(", "fix:", "fix!", "fix ")):
         return "Fixed"
-    if lower.startswith(("remove", "delete")):
+    if _starts(
+        (
+            "remove(",
+            "remove:",
+            "remove!",
+            "remove ",
+            "delete(",
+            "delete:",
+            "delete!",
+            "delete ",
+        )
+    ):
         return "Removed"
     return "Changed"
 
 
-def render(subjects: list[str], tag: str | None) -> str:
+def render(subjects: List[str], tag: Optional[str]) -> str:
     today = dt.date.today().isoformat()
     since_line = "(all commits)" if not tag else f"since tag {tag}"
 
@@ -88,7 +100,11 @@ def main() -> int:
     ap.add_argument("--output", default="CHANGELOG.md")
     args = ap.parse_args()
 
-    sh(["git", "rev-parse", "--is-inside-work-tree"])
+    try:
+        sh(["git", "rev-parse", "--is-inside-work-tree"])
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        print(f"error: must run inside a git repository and have git installed ({exc})", file=sys.stderr)
+        return 2
 
     tag = try_last_tag()
     subjects = subjects_since(tag)

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git history since the last tag.
+
+Dependency-free: only requires Python 3 and git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Entry:
+    subject: str
+
+
+def sh(cmd: list[str]) -> str:
+    out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    return out.decode("utf-8", errors="replace").strip()
+
+
+def try_last_tag() -> str | None:
+    try:
+        return sh(["git", "describe", "--tags", "--abbrev=0"]) or None
+    except subprocess.CalledProcessError:
+        return None
+
+
+def subjects_since(tag: str | None) -> list[str]:
+    rev = "HEAD" if not tag else f"{tag}..HEAD"
+    out = sh(["git", "log", "--no-merges", "--pretty=format:%s", rev])
+    if not out:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def bucket(subject: str) -> str:
+    lower = subject.lower()
+    if lower.startswith(("feat", "add")):
+        return "Added"
+    if lower.startswith("fix"):
+        return "Fixed"
+    if lower.startswith(("remove", "delete")):
+        return "Removed"
+    return "Changed"
+
+
+def render(subjects: list[str], tag: str | None) -> str:
+    today = dt.date.today().isoformat()
+    since_line = "(all commits)" if not tag else f"since tag {tag}"
+
+    buckets: dict[str, list[str]] = {"Added": [], "Fixed": [], "Changed": [], "Removed": []}
+    for s in subjects:
+        buckets[bucket(s)].append(s)
+
+    def section(name: str) -> str:
+        lines = [f"### {name}"]
+        if not buckets[name]:
+            lines.append("- (none)")
+        else:
+            lines.extend([f"- {s}" for s in buckets[name]])
+        return "\n".join(lines)
+
+    parts = [
+        "# Changelog",
+        "",
+        f"## [Unreleased] - {today}",
+        "",
+        f"_Generated from git history {since_line}._",
+        "",
+        section("Added"),
+        "",
+        section("Fixed"),
+        "",
+        section("Changed"),
+        "",
+        section("Removed"),
+        "",
+    ]
+    return "\n".join(parts)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", default="CHANGELOG.md")
+    args = ap.parse_args()
+
+    sh(["git", "rev-parse", "--is-inside-work-tree"])
+
+    tag = try_last_tag()
+    subjects = subjects_since(tag)
+    text = render(subjects, tag)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(text)
+
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Closes #1.\n\nAdds a dependency-free changelog generator (bash + python) that:\n- detects the last git tag and generates an Unreleased section from commits since that tag\n- categorizes commits into Added/Fixed/Changed/Removed\n- writes a formatted CHANGELOG.md\n\nIncluded sample output generated from this repo in docs/generate-changelog/sample-CHANGELOG.md and a 3-step README.