### PR TITLE
Add changelog generator script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.md text eol=lf

--- a/CHANGELOG_GENERATOR.md
+++ b/CHANGELOG_GENERATOR.md
@@ -1,0 +1,20 @@
+# Changelog Generator
+
+Generate a structured `CHANGELOG.md` from git commits since the last tag.
+
+## Setup
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `bash changelog.sh`.
+3. Review the generated `CHANGELOG.md` and commit it.
+
+## Categories
+
+The script groups commits into:
+
+- `Added`: `feat:`, `feat!:`, `add:`, `added:`
+- `Fixed`: `fix:`, `bug:`, `bugfix:`
+- `Removed`: `remove:`, `removed:`, `delete:`, `deleted:`
+- `Changed`: everything else, including docs, chores, tests, and refactors
+
+If a repository has tags, only commits since the latest tag are included. If it has no tags, the script uses the full project history.

--- a/SAMPLE_CHANGELOG.md
+++ b/SAMPLE_CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Generated on 2026-05-30 from project history.
+
+### Added
+
+- initial README with bounty board (1aeae2a)
+
+### Fixed
+
+- No changes.
+
+### Changed
+
+- Initial commit (a80a580)
+
+### Removed
+
+- No changes.

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FILE="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [ -n "$LAST_TAG" ]; then
+  RANGE="${LAST_TAG}..HEAD"
+  SINCE_LABEL="since ${LAST_TAG}"
+else
+  RANGE="HEAD"
+  SINCE_LABEL="from project history"
+fi
+
+COMMITS="$(git log --no-merges --pretty=format:'%s|%h' "$RANGE")"
+
+declare -a ADDED=()
+declare -a FIXED=()
+declare -a CHANGED=()
+declare -a REMOVED=()
+
+clean_subject() {
+  local subject="$1"
+  subject="${subject#feat: }"
+  subject="${subject#feat!: }"
+  subject="${subject#fix: }"
+  subject="${subject#perf: }"
+  subject="${subject#refactor: }"
+  subject="${subject#chore: }"
+  subject="${subject#docs: }"
+  subject="${subject#test: }"
+  subject="${subject#remove: }"
+  subject="${subject#removed: }"
+  subject="${subject#delete: }"
+  subject="${subject#deleted: }"
+  printf '%s' "$subject"
+}
+
+while IFS='|' read -r subject sha; do
+  [ -z "${subject:-}" ] && continue
+  line="$(clean_subject "$subject") (${sha})"
+  case "$subject" in
+    feat:*|feat!:*|add:*|added:*)
+      ADDED+=("$line")
+      ;;
+    fix:*|bug:*|bugfix:*)
+      FIXED+=("$line")
+      ;;
+    remove:*|removed:*|delete:*|deleted:*)
+      REMOVED+=("$line")
+      ;;
+    *)
+      CHANGED+=("$line")
+      ;;
+  esac
+done <<< "$COMMITS"
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  {
+    echo "### ${title}"
+    echo
+    if [ "${#items[@]}" -eq 0 ]; then
+      echo "- No changes."
+    else
+      for item in "${items[@]}"; do
+        echo "- ${item}"
+      done
+    fi
+    echo
+  } >> "$OUTPUT_FILE"
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "Generated on $(date +%Y-%m-%d) ${SINCE_LABEL}."
+  echo
+} > "$OUTPUT_FILE"
+
+write_section "Added" "${ADDED[@]}"
+write_section "Fixed" "${FIXED[@]}"
+write_section "Changed" "${CHANGED[@]}"
+write_section "Removed" "${REMOVED[@]}"
+
+echo "Wrote ${OUTPUT_FILE}"


### PR DESCRIPTION
Closes #1

## Summary

Adds a reusable Bash changelog generator that builds a structured CHANGELOG.md from git history.

## What changed

- Adds changelog.sh with Added, Fixed, Changed, and Removed categories.
- Detects the latest git tag and falls back to full history when no tag exists.
- Adds three-step setup instructions.
- Adds a sample changelog generated from this repository.
- Pins LF line endings for shell/Markdown files.

## Validation

Ran locally with Git Bash:

```bash
bash changelog.sh TEST_CHANGELOG.md
```

Result: generated a categorized changelog from the repo commit history.