### PR TITLE
Add destructive command blocker hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.py text eol=lf
+*.sh text eol=lf
+*.md text eol=lf
+*.json text eol=lf

--- a/DESTRUCTIVE_COMMAND_HOOK.md
+++ b/DESTRUCTIVE_COMMAND_HOOK.md
@@ -1,0 +1,46 @@
+# Destructive Command Blocker Hook
+
+This Claude Code `PreToolUse` hook blocks common destructive Bash commands before they run.
+
+## What It Blocks
+
+- `rm -rf` style recursive forced deletion
+- `git push --force` and `git push --force-with-lease`
+- `DROP TABLE`
+- `TRUNCATE TABLE`
+- `DELETE FROM` without a `WHERE` clause
+
+## Install
+
+1. Copy `hooks/pre_tool_use_block_destructive.py` into your project.
+2. Make it executable with `chmod +x hooks/pre_tool_use_block_destructive.py`.
+3. Add it to Claude Code hook settings:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 hooks/pre_tool_use_block_destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Blocked commands are logged to `~/.claude/hooks/blocked-destructive-commands.log`.
+
+## Manual Test
+
+```bash
+printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./dist"}}' \
+  | python3 hooks/pre_tool_use_block_destructive.py
+```
+
+The hook exits with status `2` and prints a clear blocking reason to stderr.

--- a/examples/destructive-command-hook-settings.json
+++ b/examples/destructive-command-hook-settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 hooks/pre_tool_use_block_destructive.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/pre_tool_use_block_destructive.py
+++ b/hooks/pre_tool_use_block_destructive.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive shell commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+BLOCK_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("recursive forced delete", re.compile(r"(?i)(^|[;&|]\s*)rm\s+-[a-z]*r[a-z]*f[a-z]*\b")),
+    ("force push", re.compile(r"(?i)\bgit\s+push\b[^\n;&|]*\s--force(?:-with-lease)?\b")),
+    ("drop table", re.compile(r"(?i)\bdrop\s+table\b")),
+    ("truncate table", re.compile(r"(?i)\btruncate\s+(?:table\s+)?[a-zA-Z0-9_.\"`]+")),
+    ("delete without where", re.compile(r"(?is)\bdelete\s+from\b(?![^;\n]*\bwhere\b)")),
+]
+
+
+def load_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+
+
+def command_from_payload(payload: dict) -> str:
+    tool_name = str(payload.get("tool_name", ""))
+    tool_input = payload.get("tool_input") or {}
+
+    if tool_name.lower() != "bash":
+        return ""
+
+    if isinstance(tool_input, dict):
+        return str(tool_input.get("command") or "")
+
+    return ""
+
+
+def find_block_reason(command: str) -> str | None:
+    for reason, pattern in BLOCK_RULES:
+        if pattern.search(command):
+            return reason
+    return None
+
+
+def log_block(payload: dict, command: str, reason: str) -> None:
+    log_dir = Path.home() / ".claude" / "hooks"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "blocked-destructive-commands.log"
+    project = payload.get("cwd") or payload.get("workspace") or os.getcwd()
+    timestamp = datetime.now(timezone.utc).isoformat()
+    log_file.write_text(
+        "",
+        encoding="utf-8",
+    ) if not log_file.exists() else None
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{timestamp}\treason={reason}\tproject={project}\tcommand={command!r}\n")
+
+
+def main() -> int:
+    payload = load_payload()
+    command = command_from_payload(payload)
+    if not command:
+        return 0
+
+    reason = find_block_reason(command)
+    if reason is None:
+        return 0
+
+    log_block(payload, command, reason)
+    print(
+        f"Blocked destructive Bash command ({reason}). Review the command and use a safer, explicit alternative.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #3

## Summary

Adds a Claude Code PreToolUse hook that blocks common destructive Bash commands before they run.

## What changed

- Adds a Python hook for Bash tool calls.
- Blocks rm -rf, force pushes, DROP TABLE, TRUNCATE TABLE, and DELETE FROM without WHERE.
- Logs blocked commands to ~/.claude/hooks/blocked-destructive-commands.log.
- Adds hook installation instructions and example Claude Code hook settings.

## Validation

Tested locally with safe and blocked payloads:

- safe command exits 0
- rm -rf exits 2
- DROP TABLE exits 2
- DELETE FROM with WHERE exits 0
- DELETE FROM without WHERE exits 2