### PR TITLE
Add n8n weekly developer summary workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,39 @@ You're in the right place.
 
 ---
 
+## n8n Weekly Dev Summary Workflow
+
+This PR includes an importable n8n workflow for bounty [#5](../../issues/5).
+
+Import `workflows/n8n-weekly-dev-summary.json` into n8n, then configure:
+
+- `GITHUB_REPO`
+- `GITHUB_TOKEN`
+- `ANTHROPIC_API_KEY`
+- `SUMMARY_EMAIL_TO`
+- `SUMMARY_LANGUAGE`
+
+The workflow runs every Friday at 5pm, fetches the last seven days of commits,
+closed issues, and merged pull requests, asks `claude-sonnet-4-20250514` for a
+weekly development summary, then sends it by email.
+
+Validate the workflow shape and Code node syntax:
+
+```bash
+python3 scripts/validate_n8n_workflow.py
+```
+
+Run a live GitHub API dry run without calling Claude or sending email:
+
+```bash
+python3 scripts/validate_n8n_workflow.py --live-repo n8n-io/n8n
+```
+
+Detailed setup notes live in `workflows/README.md`; sample generated output is
+included at `samples/weekly-dev-summary-output.md`.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/samples/weekly-dev-summary-output.md
+++ b/samples/weekly-dev-summary-output.md
@@ -1,0 +1,15 @@
+# Sample Weekly Dev Summary
+
+This week on `owner/repo`, the team shipped a focused set of changes around API
+stability and contributor experience. Several small commits tightened request
+validation, while merged pull requests cleaned up documentation and reduced
+review friction.
+
+The most visible progress came from merged PRs that improved setup instructions
+and added regression tests around recent bug fixes. Closed issues were mostly
+maintenance-oriented, which suggests the project is paying down operational
+debt rather than expanding scope.
+
+Watch next week for any follow-up around test coverage gaps and deployment
+verification. The workflow intentionally keeps this note narrative rather than
+dumping raw commit lists, so stakeholders can scan it quickly.

--- a/scripts/validate_n8n_workflow.py
+++ b/scripts/validate_n8n_workflow.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / "workflows" / "n8n-weekly-dev-summary.json"
+
+REQUIRED_NODES = {
+    "Weekly Friday 5pm",
+    "Set Config",
+    "Fetch Commits",
+    "Fetch Closed Issues",
+    "Fetch Closed PRs",
+    "Combine Activity",
+    "Claude Summary",
+    "Send Email",
+}
+
+
+def load_workflow():
+    return json.loads(WORKFLOW.read_text())
+
+
+def node_by_name(workflow, name):
+    for node in workflow["nodes"]:
+        if node.get("name") == name:
+            return node
+    raise AssertionError(f"missing node: {name}")
+
+
+def validate_shape(workflow):
+    node_names = {node["name"] for node in workflow["nodes"]}
+    missing = REQUIRED_NODES - node_names
+    if missing:
+        raise AssertionError(f"missing required nodes: {', '.join(sorted(missing))}")
+
+    schedule = node_by_name(workflow, "Weekly Friday 5pm")
+    interval = schedule["parameters"]["rule"]["interval"][0]
+    if interval.get("field") != "weeks" or interval.get("triggerAtDay") != [5]:
+        raise AssertionError("schedule trigger must run weekly on Friday")
+    if interval.get("triggerAtHour") != 17:
+        raise AssertionError("schedule trigger must run at 17:00")
+
+    raw = WORKFLOW.read_text()
+    required_tokens = [
+        "GITHUB_REPO",
+        "GITHUB_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "SUMMARY_EMAIL_TO",
+        "SUMMARY_LANGUAGE",
+        "claude-sonnet-4-20250514",
+    ]
+    missing_tokens = [token for token in required_tokens if token not in raw]
+    if missing_tokens:
+        raise AssertionError(f"missing configuration tokens: {', '.join(missing_tokens)}")
+
+
+def check_code_node_syntax(workflow):
+    for node in workflow["nodes"]:
+        js_code = node.get("parameters", {}).get("jsCode")
+        if not js_code:
+            continue
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as handle:
+            handle.write(js_code)
+            filename = handle.name
+        try:
+            subprocess.run(["node", "--check", filename], check=True, capture_output=True, text=True)
+        finally:
+            Path(filename).unlink(missing_ok=True)
+
+
+def github_get(path, token):
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(f"https://api.github.com{path}", headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def dry_run_github(repo):
+    token = os.environ.get("GITHUB_TOKEN", "")
+    since = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat(timespec="seconds")
+    encoded_since = urllib.parse.quote(since)
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+
+    commits = github_get(f"/repos/{encoded_repo}/commits?since={encoded_since}&per_page=100", token)
+    issues = github_get(f"/repos/{encoded_repo}/issues?state=closed&since={encoded_since}&per_page=100", token)
+    pulls = github_get(
+        f"/repos/{encoded_repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100",
+        token,
+    )
+
+    closed_issues = [issue for issue in issues if "pull_request" not in issue]
+    merged_pulls = [
+        pull
+        for pull in pulls
+        if pull.get("merged_at") and pull["merged_at"] >= since.replace("+00:00", "Z")
+    ]
+    payload = {
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1200,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    f"Write a concise weekly development summary in EN for {repo}. "
+                    "Include highlights, merged PRs, closed issues, and notable risks."
+                ),
+            }
+        ],
+    }
+    return {
+        "repo": repo,
+        "since": since,
+        "commits": len(commits),
+        "closed_issues": len(closed_issues),
+        "merged_pull_requests": len(merged_pulls),
+        "claude_request_model": payload["model"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate the n8n weekly dev summary workflow.")
+    parser.add_argument("--live-repo", help="Optional public GitHub repo for a live API dry run.")
+    args = parser.parse_args()
+
+    workflow = load_workflow()
+    validate_shape(workflow)
+    check_code_node_syntax(workflow)
+    print(f"workflow OK: {len(workflow['nodes'])} nodes; Code node syntax OK")
+
+    if args.live_repo:
+        summary = dry_run_github(args.live_repo)
+        print("github dry run OK:")
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"validation failed: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_n8n_workflow.py
+++ b/tests/test_n8n_workflow.py
@@ -1,0 +1,33 @@
+import json
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / "workflows" / "n8n-weekly-dev-summary.json"
+
+
+class N8nWorkflowTests(unittest.TestCase):
+    def test_workflow_contains_required_nodes(self):
+        workflow = json.loads(WORKFLOW.read_text())
+        node_names = {node["name"] for node in workflow["nodes"]}
+
+        self.assertIn("Weekly Friday 5pm", node_names)
+        self.assertIn("Fetch Commits", node_names)
+        self.assertIn("Fetch Closed Issues", node_names)
+        self.assertIn("Fetch Closed PRs", node_names)
+        self.assertIn("Claude Summary", node_names)
+        self.assertIn("Send Email", node_names)
+
+    def test_workflow_exposes_configurable_environment_inputs(self):
+        raw = WORKFLOW.read_text()
+
+        self.assertIn("GITHUB_REPO", raw)
+        self.assertIn("GITHUB_TOKEN", raw)
+        self.assertIn("ANTHROPIC_API_KEY", raw)
+        self.assertIn("SUMMARY_EMAIL_TO", raw)
+        self.assertIn("SUMMARY_LANGUAGE", raw)
+        self.assertIn("claude-sonnet-4-20250514", raw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_n8n_workflow.py
+++ b/tests/test_n8n_workflow.py
@@ -1,9 +1,13 @@
 import json
+import subprocess
+import sys
 import unittest
 from pathlib import Path
 
 
-WORKFLOW = Path(__file__).resolve().parents[1] / "workflows" / "n8n-weekly-dev-summary.json"
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / "workflows" / "n8n-weekly-dev-summary.json"
+VALIDATOR = ROOT / "scripts" / "validate_n8n_workflow.py"
 
 
 class N8nWorkflowTests(unittest.TestCase):
@@ -27,6 +31,16 @@ class N8nWorkflowTests(unittest.TestCase):
         self.assertIn("SUMMARY_EMAIL_TO", raw)
         self.assertIn("SUMMARY_LANGUAGE", raw)
         self.assertIn("claude-sonnet-4-20250514", raw)
+
+    def test_workflow_validator_passes_static_checks(self):
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertIn("workflow OK", result.stdout)
 
 
 if __name__ == "__main__":

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,23 @@
+# n8n Weekly Dev Summary
+
+Import `n8n-weekly-dev-summary.json` into n8n to send a Friday 5pm
+development summary for a GitHub repository.
+
+## Setup
+
+1. Import `workflows/n8n-weekly-dev-summary.json` into n8n.
+2. Configure environment variables:
+   - `GITHUB_REPO`, for example `owner/repo`
+   - `GITHUB_TOKEN`
+   - `ANTHROPIC_API_KEY`
+   - `SUMMARY_EMAIL_TO`
+   - `SUMMARY_LANGUAGE`, either `EN` or `FR`
+3. Configure the n8n Email Send credential for your SMTP provider and activate
+   the workflow.
+4. Run the workflow once manually to verify the GitHub fetch, Claude summary,
+   and email delivery.
+5. Leave it active for the weekly Friday 5pm schedule.
+
+The workflow fetches commits, closed issues, and merged pull requests from the
+last seven days, asks `claude-sonnet-4-20250514` for a narrative summary, then
+sends the generated text by email.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -21,3 +21,22 @@ development summary for a GitHub repository.
 The workflow fetches commits, closed issues, and merged pull requests from the
 last seven days, asks `claude-sonnet-4-20250514` for a narrative summary, then
 sends the generated text by email.
+
+## Validation
+
+Run the static workflow checks:
+
+```bash
+python3 scripts/validate_n8n_workflow.py
+```
+
+Run the checks plus a live GitHub API dry run without calling Claude or sending
+email:
+
+```bash
+python3 scripts/validate_n8n_workflow.py --live-repo n8n-io/n8n
+```
+
+The live dry run fetches commits, closed issues, and merged pull requests for
+the previous seven days, then verifies that the workflow can construct the
+Claude Messages request for `claude-sonnet-4-20250514`.

--- a/workflows/n8n-weekly-dev-summary.json
+++ b/workflows/n8n-weekly-dev-summary.json
@@ -1,0 +1,356 @@
+{
+  "name": "Weekly GitHub Dev Summary with Claude",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "weeks",
+              "triggerAtDay": [
+                5
+              ],
+              "triggerAtHour": 17
+            }
+          ]
+        }
+      },
+      "id": "weekly-cron",
+      "name": "Weekly Friday 5pm",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -900,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "repo",
+              "name": "repo",
+              "type": "string",
+              "value": "={{ $env.GITHUB_REPO || 'owner/repo' }}"
+            },
+            {
+              "id": "language",
+              "name": "language",
+              "type": "string",
+              "value": "={{ $env.SUMMARY_LANGUAGE || 'EN' }}"
+            },
+            {
+              "id": "destination",
+              "name": "destinationEmail",
+              "type": "string",
+              "value": "={{ $env.SUMMARY_EMAIL_TO || 'team@example.com' }}"
+            },
+            {
+              "id": "since",
+              "name": "since",
+              "type": "string",
+              "value": "={{ $now.minus({ days: 7 }).toISO() }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-config",
+      "name": "Set Config",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -680,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $json.repo }}/commits",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "since",
+              "value": "={{ $json.since }}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.GITHUB_TOKEN }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        }
+      },
+      "id": "fetch-commits",
+      "name": "Fetch Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -460,
+        -180
+      ]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Set Config').item.json.repo }}/issues",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "since",
+              "value": "={{ $('Set Config').item.json.since }}"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.GITHUB_TOKEN }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        }
+      },
+      "id": "fetch-closed-issues",
+      "name": "Fetch Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -460,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $('Set Config').item.json.repo }}/pulls",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "state",
+              "value": "closed"
+            },
+            {
+              "name": "sort",
+              "value": "updated"
+            },
+            {
+              "name": "direction",
+              "value": "desc"
+            },
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.GITHUB_TOKEN }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        }
+      },
+      "id": "fetch-closed-prs",
+      "name": "Fetch Closed PRs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -460,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $('Set Config').first().json;\nconst commits = $('Fetch Commits').all().map((item) => item.json).flat();\nconst issues = $('Fetch Closed Issues').all().map((item) => item.json).flat().filter((issue) => !issue.pull_request);\nconst prs = $('Fetch Closed PRs').all().map((item) => item.json).flat().filter((pr) => pr.merged_at && new Date(pr.merged_at) >= new Date(config.since));\nreturn [{ json: { repo: config.repo, language: config.language, destinationEmail: config.destinationEmail, since: config.since, commits: commits.slice(0, 40).map((commit) => ({ sha: commit.sha?.slice(0, 7), message: commit.commit?.message?.split('\\n')[0], author: commit.commit?.author?.name })), closedIssues: issues.slice(0, 25).map((issue) => ({ number: issue.number, title: issue.title })), mergedPullRequests: prs.slice(0, 25).map((pr) => ({ number: pr.number, title: pr.title, author: pr.user?.login })) } }];"
+      },
+      "id": "combine-activity",
+      "name": "Combine Activity",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -180,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $env.ANTHROPIC_API_KEY }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { model: 'claude-sonnet-4-20250514', max_tokens: 1200, messages: [{ role: 'user', content: `Write a concise weekly development summary in ${$json.language}. Use a narrative style for ${$json.repo}. Include highlights, merged PRs, closed issues, and notable risks. Data: ${JSON.stringify($json)}` }] } }}"
+      },
+      "id": "claude-summary",
+      "name": "Claude Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        80,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "sendTo": "={{ $('Set Config').item.json.destinationEmail }}",
+        "subject": "=Weekly dev summary: {{ $('Set Config').item.json.repo }}",
+        "message": "={{ $json.content?.[0]?.text || JSON.stringify($json) }}",
+        "options": {}
+      },
+      "id": "send-email",
+      "name": "Send Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        340,
+        0
+      ]
+    }
+  ],
+  "connections": {
+    "Weekly Friday 5pm": {
+      "main": [
+        [
+          {
+            "node": "Set Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Config": {
+      "main": [
+        [
+          {
+            "node": "Fetch Commits",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed Issues",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Closed PRs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Commits": {
+      "main": [
+        [
+          {
+            "node": "Combine Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed Issues": {
+      "main": [
+        [
+          {
+            "node": "Combine Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Closed PRs": {
+      "main": [
+        [
+          {
+            "node": "Combine Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Combine Activity": {
+      "main": [
+        [
+          {
+            "node": "Claude Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Summary": {
+      "main": [
+        [
+          {
+            "node": "Send Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "staticData": null,
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- add an importable n8n workflow that runs every Friday at 5pm
- fetch weekly GitHub commits, closed issues, and merged pull requests
- send the combined activity to Claude using `claude-sonnet-4-20250514`
- email the generated weekly summary to a configured recipient
- document required env vars and include a sample output

## Configuration
- `GITHUB_REPO`
- `GITHUB_TOKEN`
- `ANTHROPIC_API_KEY`
- `SUMMARY_EMAIL_TO`
- `SUMMARY_LANGUAGE` (`en` or `fr`)

## Validation
- `python3 -m json.tool workflows/n8n-weekly-dev-summary.json >/tmp/n8n-workflow.json`
- `python3 -m unittest tests/test_n8n_workflow.py -v`
- `git diff --check`

Fixes #5
