### PR TITLE
Add PR review agent

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,52 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request diff and produce a structured Markdown comment with summary, risks, suggestions, and confidence.
+tools:
+  - Bash
+  - Read
+  - Grep
+---
+
+# PR Reviewer
+
+Use this sub-agent when a user asks Claude Code to review a pull request or prepare a PR review comment.
+
+## Inputs
+
+- A GitHub PR URL, such as `https://github.com/owner/repo/pull/123`
+- Or a local unified diff file path
+
+## Workflow
+
+1. Fetch or read the PR diff.
+2. Parse changed files, additions, deletions, hunks, and added lines.
+3. Classify the change as documentation-only, code, configuration, mixed, or unparsed.
+4. Identify structural risks, including code without tests, config changes, security-sensitive paths, binary changes, large diffs, heavy deletions, and risky added patterns.
+5. Suggest practical next checks for the touched area.
+6. Return a single Markdown review comment.
+
+## Local Command
+
+Use the repository CLI helper when available:
+
+```bash
+python pr_reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123
+```
+
+For local fixtures:
+
+```bash
+python pr_reviewer/claude_review.py --diff-file samples/octocat-hello-world-6.diff
+```
+
+## Output Contract
+
+The review comment must include these sections:
+
+- `## PR Review`
+- `### Summary`
+- `### Identified Risks`
+- `### Improvement Suggestions`
+- `### Confidence`
+
+Confidence must be one of `Low`, `Medium`, or `High`.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -24,6 +24,7 @@ Use this sub-agent when a user asks Claude Code to review a pull request or prep
 4. Identify structural risks, including code without tests, config changes, security-sensitive paths, binary changes, large diffs, heavy deletions, and risky added patterns.
 5. Suggest practical next checks for the touched area.
 6. Return a single Markdown review comment.
+7. When the user asks to post the review, use `--post-comment` with a GitHub token.
 
 ## Local Command
 
@@ -31,6 +32,12 @@ Use the repository CLI helper when available:
 
 ```bash
 python pr_reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123
+```
+
+To post the generated review on the pull request:
+
+```bash
+GITHUB_TOKEN=... python pr_reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123 --post-comment
 ```
 
 For local fixtures:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,27 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Post structured PR review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          python pr_reviewer/claude_review.py --pr "$PR_URL" --post-comment

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ You're in the right place.
 
 ---
 
+## Review a Pull Request
+
+1. Run `claude-review --pr https://github.com/owner/repo/pull/123`.
+2. Review the generated Markdown comment.
+3. Post the comment manually from your GitHub account when appropriate.
+
+On Windows, run `.\claude-review.cmd --pr https://github.com/owner/repo/pull/123`.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/claude-review
+++ b/claude-review
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Repository-level shim for the PR review CLI."""
+
+from pr_reviewer.claude_review import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-review.cmd
+++ b/claude-review.cmd
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0pr_reviewer\claude_review.py" %*

--- a/claude-review.ps1
+++ b/claude-review.ps1
@@ -1,0 +1,1 @@
+python "$PSScriptRoot\pr_reviewer\claude_review.py" @args

--- a/pr_reviewer/README.md
+++ b/pr_reviewer/README.md
@@ -1,0 +1,57 @@
+# Claude Review Agent
+
+CLI agent that reviews a GitHub pull request diff and returns a structured Markdown review comment.
+
+## Setup
+
+No third-party dependencies are required.
+
+```bash
+python pr_reviewer/claude_review.py --help
+```
+
+Optionally place the repository root on your `PATH` so the `claude-review` shim is available.
+
+## Usage
+
+Review a public GitHub pull request:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+On Windows from the repository root:
+
+```cmd
+.\claude-review.cmd --pr https://github.com/owner/repo/pull/123
+```
+
+Review a local diff file:
+
+```bash
+python pr_reviewer/claude_review.py --diff-file samples/octocat-hello-world-6.diff
+```
+
+Write the Markdown review to a file:
+
+```bash
+claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+## Output Format
+
+The generated Markdown contains:
+
+- Summary of changes
+- Identified risks
+- Improvement suggestions
+- Confidence score: Low, Medium, or High
+
+## Verification
+
+```bash
+python -m py_compile pr_reviewer/claude_review.py pr_reviewer/test_claude_review.py
+python pr_reviewer/test_claude_review.py
+```
+
+Sample outputs are included under `samples/`.

--- a/pr_reviewer/README.md
+++ b/pr_reviewer/README.md
@@ -42,6 +42,16 @@ Write the Markdown review to a file:
 claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
 ```
 
+Post the review as a PR comment:
+
+```bash
+GITHUB_TOKEN=ghp_... claude-review --pr https://github.com/owner/repo/pull/123 --post-comment
+```
+
+The included GitHub Action at `.github/workflows/claude-pr-review.yml` runs the
+same command on pull requests and posts the structured Markdown comment with the
+repository `GITHUB_TOKEN`.
+
 ## Output Format
 
 The generated Markdown contains:
@@ -50,6 +60,7 @@ The generated Markdown contains:
 - Identified risks
 - Improvement suggestions
 - Confidence score: Low, Medium, or High
+- Optional GitHub PR comment URL when `--post-comment` is used
 
 ## Verification
 

--- a/pr_reviewer/README.md
+++ b/pr_reviewer/README.md
@@ -2,6 +2,10 @@
 
 CLI agent that reviews a GitHub pull request diff and returns a structured Markdown review comment.
 
+This package also includes a Claude Code sub-agent definition at
+`.claude/agents/pr-reviewer.md` so the workflow can be invoked as a reusable
+agent in repositories that load local Claude agents.
+
 ## Setup
 
 No third-party dependencies are required.
@@ -55,3 +59,10 @@ python pr_reviewer/test_claude_review.py
 ```
 
 Sample outputs are included under `samples/`.
+
+## Claude Code Sub-Agent
+
+Copy or keep `.claude/agents/pr-reviewer.md` in a repository to expose a
+`pr-reviewer` sub-agent. The sub-agent delegates the repeatable diff parsing and
+Markdown rendering to `pr_reviewer/claude_review.py`, then returns a comment
+with the required summary, risks, suggestions, and confidence sections.

--- a/pr_reviewer/SUBMISSION_NOTES.md
+++ b/pr_reviewer/SUBMISSION_NOTES.md
@@ -1,0 +1,42 @@
+# Submission Notes
+
+Issue: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/4
+
+## Summary
+
+This package adds a dependency-free CLI agent that reviews a pull request diff and returns a structured Markdown review comment.
+
+It supports:
+
+- `claude-review --pr https://github.com/owner/repo/pull/123`
+- `.\claude-review.cmd --pr https://github.com/owner/repo/pull/123` on Windows
+- `python pr_reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123`
+- `python pr_reviewer/claude_review.py --diff-file samples/octocat-hello-world-6.diff`
+- `--output review.md` for saving the review comment
+
+## Verification
+
+```powershell
+python -m py_compile .\pr_reviewer\claude_review.py .\pr_reviewer\test_claude_review.py
+python .\pr_reviewer\test_claude_review.py
+```
+
+## Sample Outputs
+
+The included samples were generated from real public GitHub PRs:
+
+- https://github.com/octocat/Hello-World/pull/1
+- https://github.com/octocat/Hello-World/pull/6
+
+## Files
+
+- `claude-review`
+- `claude-review.cmd`
+- `claude-review.ps1`
+- `pr_reviewer/claude_review.py`
+- `pr_reviewer/test_claude_review.py`
+- `pr_reviewer/README.md`
+- `samples/octocat-hello-world-1.diff`
+- `samples/octocat-hello-world-1.md`
+- `samples/octocat-hello-world-6.diff`
+- `samples/octocat-hello-world-6.md`

--- a/pr_reviewer/SUBMISSION_NOTES.md
+++ b/pr_reviewer/SUBMISSION_NOTES.md
@@ -14,6 +14,8 @@ It supports:
 - `python pr_reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123`
 - `python pr_reviewer/claude_review.py --diff-file samples/octocat-hello-world-6.diff`
 - `--output review.md` for saving the review comment
+- `--post-comment` for posting the review directly to the pull request
+- `.github/workflows/claude-pr-review.yml` for automated review comments on PR events
 
 ## Verification
 
@@ -35,6 +37,7 @@ The included samples were generated from real public GitHub PRs:
 - `claude-review.cmd`
 - `claude-review.ps1`
 - `.claude/agents/pr-reviewer.md`
+- `.github/workflows/claude-pr-review.yml`
 - `pr_reviewer/claude_review.py`
 - `pr_reviewer/test_claude_review.py`
 - `pr_reviewer/README.md`

--- a/pr_reviewer/SUBMISSION_NOTES.md
+++ b/pr_reviewer/SUBMISSION_NOTES.md
@@ -8,6 +8,7 @@ This package adds a dependency-free CLI agent that reviews a pull request diff a
 
 It supports:
 
+- A Claude Code sub-agent definition at `.claude/agents/pr-reviewer.md`
 - `claude-review --pr https://github.com/owner/repo/pull/123`
 - `.\claude-review.cmd --pr https://github.com/owner/repo/pull/123` on Windows
 - `python pr_reviewer/claude_review.py --pr https://github.com/owner/repo/pull/123`
@@ -33,6 +34,7 @@ The included samples were generated from real public GitHub PRs:
 - `claude-review`
 - `claude-review.cmd`
 - `claude-review.ps1`
+- `.claude/agents/pr-reviewer.md`
 - `pr_reviewer/claude_review.py`
 - `pr_reviewer/test_claude_review.py`
 - `pr_reviewer/README.md`

--- a/pr_reviewer/__init__.py
+++ b/pr_reviewer/__init__.py
@@ -1,0 +1,1 @@
+"""PR review agent package."""

--- a/pr_reviewer/claude_review.py
+++ b/pr_reviewer/claude_review.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Review a GitHub pull request diff and emit a structured Markdown comment."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+DOC_EXTENSIONS = {
+    ".adoc",
+    ".md",
+    ".mdx",
+    ".rst",
+    ".txt",
+}
+DOC_BASENAMES = {
+    "changelog",
+    "license",
+    "readme",
+}
+CODE_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".go",
+    ".java",
+    ".js",
+    ".jsx",
+    ".kt",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".sql",
+    ".swift",
+    ".ts",
+    ".tsx",
+}
+TEST_MARKERS = ("test", "tests", "spec", "__tests__")
+DEPENDENCY_FILES = {
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "requirements.txt",
+    "poetry.lock",
+    "pyproject.toml",
+    "cargo.toml",
+    "cargo.lock",
+    "go.mod",
+    "go.sum",
+}
+SECURITY_WORDS = (
+    "auth",
+    "admin",
+    "permission",
+    "policy",
+    "secret",
+    "token",
+    "password",
+    "payment",
+    "stripe",
+    "sql",
+)
+RISKY_ADDITION_PATTERNS = (
+    "eval(",
+    "exec(",
+    "dangerouslysetinnerhtml",
+    "innerhtml",
+    "delete from",
+    "drop table",
+)
+
+
+@dataclass
+class FileChange:
+    old_path: str = ""
+    new_path: str = ""
+    additions: int = 0
+    deletions: int = 0
+    hunks: int = 0
+    binary: bool = False
+    added_lines: list[str] = field(default_factory=list)
+
+    @property
+    def path(self) -> str:
+        return self.new_path or self.old_path or "unknown"
+
+    @property
+    def suffix(self) -> str:
+        return Path(self.path).suffix.lower()
+
+    @property
+    def basename(self) -> str:
+        return Path(self.path).name.lower()
+
+
+@dataclass
+class DiffStats:
+    files: list[FileChange]
+
+    @property
+    def additions(self) -> int:
+        return sum(file.additions for file in self.files)
+
+    @property
+    def deletions(self) -> int:
+        return sum(file.deletions for file in self.files)
+
+    @property
+    def changed_lines(self) -> int:
+        return self.additions + self.deletions
+
+
+def clean_diff_path(raw_path: str) -> str:
+    path = raw_path.strip()
+    if path in {"/dev/null", "dev/null"}:
+        return ""
+    if path.startswith("a/") or path.startswith("b/"):
+        return path[2:]
+    return path
+
+
+def parse_diff(diff_text: str) -> DiffStats:
+    files: list[FileChange] = []
+    current: FileChange | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            old_path = clean_diff_path(parts[2]) if len(parts) > 2 else ""
+            new_path = clean_diff_path(parts[3]) if len(parts) > 3 else old_path
+            current = FileChange(old_path=old_path, new_path=new_path)
+            files.append(current)
+            continue
+
+        if current is None and (line.startswith("--- ") or line.startswith("+++ ")):
+            current = FileChange()
+            files.append(current)
+
+        if current is None:
+            continue
+
+        if line.startswith("--- "):
+            current.old_path = clean_diff_path(line[4:])
+        elif line.startswith("+++ "):
+            current.new_path = clean_diff_path(line[4:])
+        elif line.startswith("@@"):
+            current.hunks += 1
+        elif line.startswith("Binary files "):
+            current.binary = True
+        elif line.startswith("+") and not line.startswith("+++ "):
+            current.additions += 1
+            current.added_lines.append(line[1:].strip())
+        elif line.startswith("-") and not line.startswith("--- "):
+            current.deletions += 1
+
+    return DiffStats(files=files)
+
+
+def is_doc_file(file: FileChange) -> bool:
+    path = file.path.lower()
+    return (
+        file.suffix in DOC_EXTENSIONS
+        or file.basename in DOC_BASENAMES
+        or "docs/" in path
+        or path.startswith("docs/")
+    )
+
+
+def is_test_file(file: FileChange) -> bool:
+    lowered = file.path.lower()
+    return any(marker in lowered for marker in TEST_MARKERS)
+
+
+def is_code_file(file: FileChange) -> bool:
+    return file.suffix in CODE_EXTENSIONS and not is_test_file(file)
+
+
+def is_config_or_dependency_file(file: FileChange) -> bool:
+    path = file.path.lower()
+    return (
+        file.basename in DEPENDENCY_FILES
+        or path.startswith(".github/workflows/")
+        or path.endswith(".yml")
+        or path.endswith(".yaml")
+        or path.endswith(".toml")
+        or path.endswith(".ini")
+    )
+
+
+def is_security_sensitive(file: FileChange) -> bool:
+    lowered = file.path.lower()
+    return any(word in lowered for word in SECURITY_WORDS)
+
+
+def classify_diff(stats: DiffStats) -> str:
+    if not stats.files:
+        return "unparsed"
+    if all(is_doc_file(file) for file in stats.files):
+        return "documentation-only"
+    if any(is_code_file(file) for file in stats.files):
+        return "code"
+    if any(is_config_or_dependency_file(file) for file in stats.files):
+        return "configuration"
+    return "mixed"
+
+
+def list_changed_files(stats: DiffStats, limit: int = 4) -> str:
+    if not stats.files:
+        return "none"
+
+    ranked = sorted(
+        stats.files,
+        key=lambda file: (file.additions + file.deletions, file.path),
+        reverse=True,
+    )
+    names = [
+        f"{file.path} (+{file.additions}/-{file.deletions})"
+        for file in ranked[:limit]
+    ]
+    if len(ranked) > limit:
+        names.append(f"{len(ranked) - limit} more")
+    return ", ".join(names)
+
+
+def summarize(stats: DiffStats, source: str | None) -> list[str]:
+    kind = classify_diff(stats)
+    source_note = f" for `{source}`" if source else ""
+    return [
+        (
+            f"This PR{source_note} changes {len(stats.files)} file(s) with "
+            f"{stats.additions} additions and {stats.deletions} deletions."
+        ),
+        (
+            f"The diff appears to be {kind}; the largest changed paths are "
+            f"{list_changed_files(stats)}."
+        ),
+    ]
+
+
+def identify_risks(stats: DiffStats) -> list[str]:
+    if not stats.files:
+        return ["No files were parsed from the diff, so the review may be incomplete."]
+
+    risks: list[str] = []
+    has_code = any(is_code_file(file) for file in stats.files)
+    has_tests = any(is_test_file(file) for file in stats.files)
+    has_docs_only = all(is_doc_file(file) for file in stats.files)
+    has_config = any(is_config_or_dependency_file(file) for file in stats.files)
+    has_security = any(is_security_sensitive(file) for file in stats.files)
+    has_binary = any(file.binary for file in stats.files)
+    added_text = "\n".join(line.lower() for file in stats.files for line in file.added_lines)
+
+    if has_docs_only:
+        risks.append("Low functional risk because the diff only changes documentation or text files.")
+    if has_code and not has_tests:
+        risks.append("Application code changed without a matching test update in the diff.")
+    if has_config:
+        risks.append("Configuration, dependency, or workflow files changed, so CI behavior may shift.")
+    if has_security:
+        risks.append("Security-sensitive paths or names changed and need authorization-focused review.")
+    if has_binary:
+        risks.append("Binary file changes cannot be meaningfully reviewed from a text diff.")
+    if stats.changed_lines > 500:
+        risks.append("The diff is large enough that hidden coupling or missed edge cases are more likely.")
+    if stats.deletions > max(20, stats.additions * 2):
+        risks.append("The PR removes substantially more code than it adds; check for behavior loss.")
+    if any(pattern in added_text for pattern in RISKY_ADDITION_PATTERNS):
+        risks.append("Added code contains patterns that deserve manual security review.")
+
+    if not risks:
+        risks.append("No obvious structural risks were detected from the diff alone.")
+    return risks
+
+
+def suggest_improvements(stats: DiffStats) -> list[str]:
+    has_code = any(is_code_file(file) for file in stats.files)
+    has_tests = any(is_test_file(file) for file in stats.files)
+    has_docs_only = bool(stats.files) and all(is_doc_file(file) for file in stats.files)
+    has_config = any(is_config_or_dependency_file(file) for file in stats.files)
+    has_security = any(is_security_sensitive(file) for file in stats.files)
+
+    suggestions: list[str] = []
+    if has_code and not has_tests:
+        suggestions.append("Add or update targeted tests for the changed behavior before merging.")
+    if has_code:
+        suggestions.append("Run the smallest relevant unit or integration test command for the touched area.")
+    if has_docs_only:
+        suggestions.append("Preview the rendered documentation and verify headings, links, and examples.")
+    if has_config:
+        suggestions.append("Run CI or a dry-run for the changed workflow/configuration path.")
+    if has_security:
+        suggestions.append("Add a regression check for denied access and invalid input cases.")
+
+    suggestions.append("Have a maintainer compare this generated review with project-specific context.")
+    return suggestions
+
+
+def confidence(stats: DiffStats) -> str:
+    kind = classify_diff(stats)
+    if not stats.files or any(file.binary for file in stats.files):
+        return "Low"
+    if stats.changed_lines > 500:
+        return "Low"
+    if kind == "documentation-only" and stats.changed_lines <= 100:
+        return "High"
+    return "Medium"
+
+
+def render_markdown(stats: DiffStats, source: str | None = None) -> str:
+    summary = summarize(stats, source)
+    risks = identify_risks(stats)
+    suggestions = suggest_improvements(stats)
+    score = confidence(stats)
+
+    lines = ["## PR Review", "", "### Summary"]
+    lines.extend(f"- {sentence}" for sentence in summary)
+    lines.extend(["", "### Identified Risks"])
+    lines.extend(f"- {risk}" for risk in risks)
+    lines.extend(["", "### Improvement Suggestions"])
+    lines.extend(f"- {suggestion}" for suggestion in suggestions)
+    lines.extend(["", "### Confidence", score, ""])
+    return "\n".join(lines)
+
+
+def build_diff_url(pr_url: str) -> str:
+    parsed = urllib.parse.urlparse(pr_url)
+    if parsed.netloc.lower() != "github.com":
+        raise ValueError("Only github.com pull request URLs are supported.")
+
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) != 4 or parts[2] != "pull" or not parts[3].isdigit():
+        raise ValueError("Expected a URL like https://github.com/owner/repo/pull/123.")
+
+    owner, repo, _, number = parts
+    return f"https://github.com/{owner}/{repo}/pull/{number}.diff"
+
+
+def fetch_pr_diff(pr_url: str, timeout: int = 20) -> str:
+    diff_url = build_diff_url(pr_url)
+    request = urllib.request.Request(
+        diff_url,
+        headers={
+            "Accept": "application/vnd.github.v3.diff",
+            "User-Agent": "claude-review-agent",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def load_diff(args: argparse.Namespace) -> tuple[str, str | None]:
+    if args.diff_file:
+        path = Path(args.diff_file)
+        return path.read_text(encoding="utf-8"), path.as_posix()
+    return fetch_pr_diff(args.pr), args.pr
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="claude-review",
+        description="Review a GitHub PR diff and print a structured Markdown comment.",
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--pr", help="GitHub pull request URL to fetch and review.")
+    source.add_argument("--diff-file", help="Local unified diff file to review.")
+    parser.add_argument("--output", help="Write Markdown review output to this file.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = make_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        diff_text, source = load_diff(args)
+        review = render_markdown(parse_diff(diff_text), source)
+    except (OSError, TimeoutError, ValueError) as exc:
+        parser.error(str(exc))
+        return 2
+
+    if args.output:
+        Path(args.output).write_text(review, encoding="utf-8")
+    else:
+        sys.stdout.write(review)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pr_reviewer/claude_review.py
+++ b/pr_reviewer/claude_review.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
 import sys
 import urllib.parse
@@ -358,6 +360,40 @@ def fetch_pr_diff(pr_url: str, timeout: int = 20) -> str:
         return response.read().decode("utf-8", errors="replace")
 
 
+def parse_github_pr_url(pr_url: str) -> tuple[str, str, int]:
+    parsed = urllib.parse.urlparse(pr_url)
+    if parsed.netloc.lower() != "github.com":
+        raise ValueError("Only github.com pull request URLs are supported.")
+
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) != 4 or parts[2] != "pull" or not parts[3].isdigit():
+        raise ValueError("Expected a URL like https://github.com/owner/repo/pull/123.")
+
+    owner, repo, _, number = parts
+    return owner, repo, int(number)
+
+
+def post_pr_comment(pr_url: str, body: str, token: str, timeout: int = 20) -> str:
+    owner, repo, number = parse_github_pr_url(pr_url)
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/issues/{number}/comments"
+    payload = json.dumps({"body": body}).encode("utf-8")
+    request = urllib.request.Request(
+        api_url,
+        data=payload,
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "claude-review-agent",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        data = json.loads(response.read().decode("utf-8", errors="replace"))
+    return str(data.get("html_url", ""))
+
+
 def load_diff(args: argparse.Namespace) -> tuple[str, str | None]:
     if args.diff_file:
         path = Path(args.diff_file)
@@ -374,6 +410,16 @@ def make_parser() -> argparse.ArgumentParser:
     source.add_argument("--pr", help="GitHub pull request URL to fetch and review.")
     source.add_argument("--diff-file", help="Local unified diff file to review.")
     parser.add_argument("--output", help="Write Markdown review output to this file.")
+    parser.add_argument(
+        "--post-comment",
+        action="store_true",
+        help="Post the generated Markdown review as a GitHub PR comment. Requires --pr.",
+    )
+    parser.add_argument(
+        "--github-token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub token for --post-comment. Defaults to GITHUB_TOKEN.",
+    )
     return parser
 
 
@@ -381,9 +427,19 @@ def main(argv: list[str] | None = None) -> int:
     parser = make_parser()
     args = parser.parse_args(argv)
 
+    if args.post_comment and not args.pr:
+        parser.error("--post-comment requires --pr.")
+    if args.post_comment and not args.github_token:
+        parser.error("--post-comment requires --github-token or GITHUB_TOKEN.")
+
     try:
         diff_text, source = load_diff(args)
         review = render_markdown(parse_diff(diff_text), source)
+        comment_url = (
+            post_pr_comment(args.pr, review, args.github_token)
+            if args.post_comment
+            else None
+        )
     except (OSError, TimeoutError, ValueError) as exc:
         parser.error(str(exc))
         return 2
@@ -392,6 +448,8 @@ def main(argv: list[str] | None = None) -> int:
         Path(args.output).write_text(review, encoding="utf-8")
     else:
         sys.stdout.write(review)
+    if comment_url:
+        sys.stdout.write(f"\nPosted review comment: {comment_url}\n")
     return 0
 
 

--- a/pr_reviewer/test_claude_review.py
+++ b/pr_reviewer/test_claude_review.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Smoke tests for the PR review agent."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from claude_review import build_diff_url, main, parse_diff, render_markdown
+
+
+CODE_DIFF = """diff --git a/app/auth.py b/app/auth.py
+--- a/app/auth.py
++++ b/app/auth.py
+@@ -1,3 +1,6 @@
+ def can_view(user):
+-    return True
++    if user.role == "admin":
++        return True
++    return False
+"""
+
+DOC_DIFF = """diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
+ # Demo
++More setup notes.
+"""
+
+
+def test_parse_diff_counts_files_and_lines() -> None:
+    stats = parse_diff(CODE_DIFF)
+
+    assert len(stats.files) == 1
+    assert stats.additions == 3
+    assert stats.deletions == 1
+    assert stats.files[0].path == "app/auth.py"
+
+
+def test_render_flags_code_without_tests() -> None:
+    review = render_markdown(parse_diff(CODE_DIFF), "sample")
+
+    assert "Application code changed without a matching test update" in review
+    assert "Security-sensitive paths or names changed" in review
+    assert "### Confidence" in review
+    assert "Medium" in review
+
+
+def test_docs_only_review_is_high_confidence() -> None:
+    review = render_markdown(parse_diff(DOC_DIFF), "docs")
+
+    assert "documentation-only" in review
+    assert "Low functional risk" in review
+    assert "High" in review
+
+
+def test_extensionless_readme_is_documentation() -> None:
+    diff = """diff --git a/README b/README
+--- a/README
++++ b/README
+@@ -1 +1,2 @@
+ Hello World!
++Setup note.
+"""
+    review = render_markdown(parse_diff(diff), "readme")
+
+    assert "documentation-only" in review
+    assert "High" in review
+
+
+def test_build_diff_url_accepts_github_pr_url() -> None:
+    assert (
+        build_diff_url("https://github.com/octocat/Hello-World/pull/6")
+        == "https://github.com/octocat/Hello-World/pull/6.diff"
+    )
+
+
+def test_cli_writes_output_from_diff_file() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        diff_path = root / "sample.diff"
+        output_path = root / "review.md"
+        diff_path.write_text(DOC_DIFF, encoding="utf-8")
+
+        result = main(["--diff-file", str(diff_path), "--output", str(output_path)])
+
+        assert result == 0
+        output = output_path.read_text(encoding="utf-8")
+        assert output.startswith("## PR Review")
+        assert "### Identified Risks" in output
+        assert "### Improvement Suggestions" in output
+
+
+if __name__ == "__main__":
+    test_parse_diff_counts_files_and_lines()
+    test_render_flags_code_without_tests()
+    test_docs_only_review_is_high_confidence()
+    test_extensionless_readme_is_documentation()
+    test_build_diff_url_accepts_github_pr_url()
+    test_cli_writes_output_from_diff_file()
+    print("ok")

--- a/pr_reviewer/test_claude_review.py
+++ b/pr_reviewer/test_claude_review.py
@@ -77,6 +77,28 @@ def test_build_diff_url_accepts_github_pr_url() -> None:
     )
 
 
+def test_cli_rejects_post_comment_without_pr() -> None:
+    try:
+        main(["--diff-file", "sample.diff", "--post-comment", "--github-token", "token"])
+    except SystemExit as exc:
+        result = exc.code
+    else:
+        result = 0
+
+    assert result == 2
+
+
+def test_cli_rejects_post_comment_without_token() -> None:
+    try:
+        main(["--pr", "https://github.com/octocat/Hello-World/pull/6", "--post-comment"])
+    except SystemExit as exc:
+        result = exc.code
+    else:
+        result = 0
+
+    assert result == 2
+
+
 def test_cli_writes_output_from_diff_file() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -109,6 +131,8 @@ if __name__ == "__main__":
     test_docs_only_review_is_high_confidence()
     test_extensionless_readme_is_documentation()
     test_build_diff_url_accepts_github_pr_url()
+    test_cli_rejects_post_comment_without_pr()
+    test_cli_rejects_post_comment_without_token()
     test_cli_writes_output_from_diff_file()
     test_claude_sub_agent_contract_is_present()
     print("ok")

--- a/pr_reviewer/test_claude_review.py
+++ b/pr_reviewer/test_claude_review.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from claude_review import build_diff_url, main, parse_diff, render_markdown
 
+ROOT = Path(__file__).resolve().parents[1]
 
 CODE_DIFF = """diff --git a/app/auth.py b/app/auth.py
 --- a/app/auth.py
@@ -92,6 +93,16 @@ def test_cli_writes_output_from_diff_file() -> None:
         assert "### Improvement Suggestions" in output
 
 
+def test_claude_sub_agent_contract_is_present() -> None:
+    agent = ROOT / ".claude" / "agents" / "pr-reviewer.md"
+    content = agent.read_text(encoding="utf-8")
+
+    assert "name: pr-reviewer" in content
+    assert "### Identified Risks" in content
+    assert "### Improvement Suggestions" in content
+    assert "### Confidence" in content
+
+
 if __name__ == "__main__":
     test_parse_diff_counts_files_and_lines()
     test_render_flags_code_without_tests()
@@ -99,4 +110,5 @@ if __name__ == "__main__":
     test_extensionless_readme_is_documentation()
     test_build_diff_url_accepts_github_pr_url()
     test_cli_writes_output_from_diff_file()
+    test_claude_sub_agent_contract_is_present()
     print("ok")

--- a/samples/octocat-hello-world-1.diff
+++ b/samples/octocat-hello-world-1.diff
@@ -1,0 +1,12 @@
+diff --git a/README b/README
+index 980a0d5..7044a8a 100644
+--- a/README
++++ b/README
+@@ -1 +1,6 @@
+-Hello World!
++Hello World!
++
++$ mkdir ~/Hello-World
++Creates a directory for your project called "Hello-World" in your user directory.
++
++This line documents the local setup step.

--- a/samples/octocat-hello-world-1.md
+++ b/samples/octocat-hello-world-1.md
@@ -1,0 +1,15 @@
+## PR Review
+
+### Summary
+- This PR for `samples/octocat-hello-world-1.diff` changes 1 file(s) with 6 additions and 1 deletions.
+- The diff appears to be documentation-only; the largest changed paths are README (+6/-1).
+
+### Identified Risks
+- Low functional risk because the diff only changes documentation or text files.
+
+### Improvement Suggestions
+- Preview the rendered documentation and verify headings, links, and examples.
+- Have a maintainer compare this generated review with project-specific context.
+
+### Confidence
+High

--- a/samples/octocat-hello-world-6.diff
+++ b/samples/octocat-hello-world-6.diff
@@ -1,0 +1,8 @@
+diff --git a/README b/README
+index 980a0d5..7629413 100644
+--- a/README
++++ b/README
+@@ -1 +1 @@
+-Hello World!
+\ No newline at end of file
++Hello World!

--- a/samples/octocat-hello-world-6.md
+++ b/samples/octocat-hello-world-6.md
@@ -1,0 +1,15 @@
+## PR Review
+
+### Summary
+- This PR for `samples/octocat-hello-world-6.diff` changes 1 file(s) with 1 additions and 1 deletions.
+- The diff appears to be documentation-only; the largest changed paths are README (+1/-1).
+
+### Identified Risks
+- Low functional risk because the diff only changes documentation or text files.
+
+### Improvement Suggestions
+- Preview the rendered documentation and verify headings, links, and examples.
+- Have a maintainer compare this generated review with project-specific context.
+
+### Confidence
+High


### PR DESCRIPTION
Fixes #4. Adds a dependency-free Claude review CLI that fetches or reads a PR diff and emits structured Markdown with summary, identified risks, improvement suggestions, and confidence. Includes Windows and POSIX launchers, tests, docs, and two sample outputs from public GitHub PR diffs.

Verification passed:
- python -m py_compile pr_reviewer/claude_review.py pr_reviewer/test_claude_review.py
- python pr_reviewer/test_claude_review.py