### PR TITLE
Add destructive command guard hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,37 @@
+# Destructive Command Guard Hook
+
+Claude Code pre-tool-use hook that blocks dangerous shell and SQL commands before execution.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks
+cp hooks/block_destructive_commands.py ~/.claude/hooks/block_destructive_commands.py
+chmod +x ~/.claude/hooks/block_destructive_commands.py
+```
+
+Configure Claude Code to run `~/.claude/hooks/block_destructive_commands.py` as a pre-tool-use hook for bash/shell tools.
+
+## What It Blocks
+
+- `rm -rf` style recursive force deletion
+- `DROP TABLE`
+- `TRUNCATE`
+- `git push --force` or `git push -f`
+- `DELETE FROM ...` without `WHERE`
+
+## Log
+
+Blocked attempts are appended as JSON Lines to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each record contains timestamp, rule, project path, and attempted command.
+
+## Test
+
+```bash
+python hooks/test_block_destructive_commands.py
+```

--- a/hooks/SUBMISSION_NOTES.md
+++ b/hooks/SUBMISSION_NOTES.md
@@ -1,0 +1,32 @@
+# Submission Notes
+
+Issue: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3
+
+## Summary
+
+This package adds a Claude Code pre-tool-use hook that blocks destructive bash and SQL commands before execution.
+
+It blocks:
+
+- `rm -rf`
+- `DROP TABLE`
+- `TRUNCATE`
+- `git push --force` and `git push -f`
+- `DELETE FROM ...` without a `WHERE` clause
+
+Blocked attempts are logged as JSON Lines to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and matched rule.
+
+## Verification
+
+```powershell
+python -m py_compile .\hooks\block_destructive_commands.py .\hooks\test_block_destructive_commands.py
+python .\hooks\test_block_destructive_commands.py
+```
+
+All commands passed locally.
+
+## Files
+
+- `hooks/block_destructive_commands.py`
+- `hooks/test_block_destructive_commands.py`
+- `hooks/README.md`

--- a/hooks/block_destructive_commands.py
+++ b/hooks/block_destructive_commands.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Claude Code pre-tool-use hook that blocks destructive bash commands."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+BLOCK_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "recursive-force-delete",
+        re.compile(r"(^|[;&|]\s*)rm\s+(-[A-Za-z]*r[A-Za-z]*f|- [^\n]*|-[A-Za-z]*f[A-Za-z]*r)\b"),
+        "Blocks rm commands that combine recursive and force deletion.",
+    ),
+    (
+        "drop-table",
+        re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE),
+        "Blocks SQL DROP TABLE statements.",
+    ),
+    (
+        "truncate",
+        re.compile(r"\bTRUNCATE\b", re.IGNORECASE),
+        "Blocks SQL TRUNCATE statements.",
+    ),
+    (
+        "force-push",
+        re.compile(r"\bgit\s+push\b[^\n]*(--force|-f\b)", re.IGNORECASE),
+        "Blocks force pushes.",
+    ),
+    (
+        "delete-without-where",
+        re.compile(r"\bDELETE\s+FROM\s+[\w.\"`\[\]-]+(?:(?!\bWHERE\b).)*;?\s*$", re.IGNORECASE | re.DOTALL),
+        "Blocks DELETE FROM statements that do not include a WHERE clause.",
+    ),
+]
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    for key in ("command", "cmd", "input"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd", "input"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def extract_project_path(payload: dict[str, Any]) -> str:
+    for key in ("cwd", "project_path", "workspace", "repo_path"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("cwd", "project_path", "workspace", "repo_path"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+    return str(Path.cwd())
+
+
+def blocked_reason(command: str) -> tuple[str, str] | None:
+    for rule_name, pattern, description in BLOCK_RULES:
+        if pattern.search(command):
+            return rule_name, description
+    return None
+
+
+def append_log(log_path: Path, command: str, project_path: str, rule_name: str) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "rule": rule_name,
+        "project_path": project_path,
+        "command": command,
+    }
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def load_payload(raw: str) -> dict[str, Any]:
+    if not raw.strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"command": raw}
+    return payload if isinstance(payload, dict) else {}
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Block destructive bash commands for Claude Code hooks.")
+    parser.add_argument("--log", type=Path, default=DEFAULT_LOG)
+    parser.add_argument("--command", help="Command to inspect. If omitted, JSON is read from stdin.")
+    parser.add_argument("--project-path", help="Project path to record in blocked.log.")
+    args = parser.parse_args(argv)
+
+    if args.command is not None:
+        command = args.command
+        project_path = args.project_path or str(Path.cwd())
+    else:
+        payload = load_payload(sys.stdin.read())
+        command = extract_command(payload)
+        project_path = args.project_path or extract_project_path(payload)
+
+    reason = blocked_reason(command)
+    if reason is None:
+        print(json.dumps({"decision": "allow"}))
+        return 0
+
+    rule_name, description = reason
+    append_log(args.log, command, project_path, rule_name)
+    print(
+        json.dumps(
+            {
+                "decision": "block",
+                "reason": f"{description} Rule: {rule_name}.",
+                "message": "Command blocked before execution because it matches a destructive pattern.",
+            }
+        )
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/hooks/test_block_destructive_commands.py
+++ b/hooks/test_block_destructive_commands.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for block_destructive_commands.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "block_destructive_commands.py"
+
+
+def run_hook(command: str, log_path: Path) -> subprocess.CompletedProcess[str]:
+    payload = json.dumps({"tool_input": {"command": command}, "cwd": "C:/repo"})
+    return subprocess.run(
+        [sys.executable, str(HOOK), "--log", str(log_path)],
+        input=payload,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def assert_blocked(command: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "blocked.log"
+        result = run_hook(command, log_path)
+        assert result.returncode == 2, result.stdout + result.stderr
+        response = json.loads(result.stdout)
+        assert response["decision"] == "block"
+        log_lines = log_path.read_text(encoding="utf-8").splitlines()
+        assert len(log_lines) == 1
+        log_record = json.loads(log_lines[0])
+        assert log_record["command"] == command
+        assert log_record["project_path"] == "C:/repo"
+
+
+def assert_allowed(command: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "blocked.log"
+        result = run_hook(command, log_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+        response = json.loads(result.stdout)
+        assert response["decision"] == "allow"
+        assert not log_path.exists()
+
+
+def test_blocks_required_patterns() -> None:
+    assert_blocked("rm -rf dist")
+    assert_blocked("git push origin main --force")
+    assert_blocked("psql -c 'DROP TABLE users'")
+    assert_blocked("TRUNCATE audit_log")
+    assert_blocked("DELETE FROM users")
+
+
+def test_allows_safe_commands() -> None:
+    assert_allowed("git status --short")
+    assert_allowed("npm test")
+    assert_allowed("DELETE FROM users WHERE id = 1")
+    assert_allowed("rm -r dist")
+
+
+if __name__ == "__main__":
+    test_blocks_required_patterns()
+    test_allows_safe_commands()
+    print("ok")


### PR DESCRIPTION
Fixes #3. Adds a dependency-free pre-tool-use hook that detects destructive shell commands and blocks unsafe patterns before execution. Includes documentation, tests, and submission notes.

Verification passed:
- python -m py_compile hooks/block_destructive_commands.py hooks/test_block_destructive_commands.py
- python hooks/test_block_destructive_commands.py