### PR TITLE
Add changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes are generated from git history.
+
+## Unreleased - 2026-05-30
+
+Commits since: `repository start`
+
+### Added
+
+- Initial commit (a80a580)
+- Initial README with bounty board (1aeae2a)
+
+### Fixed
+
+- None
+
+### Changed
+
+- None
+
+### Removed
+
+- None

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ You're in the right place.
 
 ---
 
+## Generate a Changelog
+
+1. Run `python generate_changelog.py` or `bash changelog.sh`.
+2. Review the generated `CHANGELOG.md`.
+3. Use `--since <tag>` to override the latest git tag.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history since the latest tag.
+---
+
+# Generate Changelog
+
+Use this skill when a user asks for `/generate-changelog` or wants a changelog generated from the current git repository.
+
+## Steps
+
+1. Run `python generate_changelog.py` from the repository root.
+2. Review the generated `CHANGELOG.md` sections: Added, Fixed, Changed, Removed.
+3. If the user specifies a range, pass it with `--since <tag-or-ref>`.
+
+## Command
+
+```bash
+python generate_changelog.py
+```
+
+Optional:
+
+```bash
+python generate_changelog.py --since v1.0.0 --output CHANGELOG.md
+```

--- a/SUBMISSION_NOTES.md
+++ b/SUBMISSION_NOTES.md
@@ -1,0 +1,31 @@
+# Submission Notes
+
+Issue: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1
+
+## Summary
+
+This package adds a changelog generator that creates a structured `CHANGELOG.md` from git history. It supports:
+
+- `python generate_changelog.py`
+- `bash changelog.sh`
+- `python generate_changelog.py --since <tag-or-ref> --output CHANGELOG.md`
+- A Claude Code-style `SKILL.md` for `/generate-changelog`
+
+## Verification
+
+```powershell
+python -m py_compile .\generate_changelog.py .\test_generate_changelog.py
+python .\test_generate_changelog.py
+python .\generate_changelog.py --output .\CHANGELOG.md
+```
+
+All commands passed locally.
+
+## Files
+
+- `generate_changelog.py`
+- `changelog.sh`
+- `SKILL.md`
+- `CHANGELOG.md`
+- `test_generate_changelog.py`
+- `README.md`

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v python3 >/dev/null 2>&1; then
+  python3 "$SCRIPT_DIR/generate_changelog.py" "$@"
+else
+  python "$SCRIPT_DIR/generate_changelog.py" "$@"
+fi

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import subprocess
+import sys
+from pathlib import Path
+
+
+CATEGORIES = {
+    "Added": ("feat", "feature", "add", "added", "initial"),
+    "Fixed": ("fix", "fixed", "bug", "bugfix", "patch", "resolve", "resolved"),
+    "Changed": (
+        "change",
+        "changed",
+        "update",
+        "updated",
+        "refactor",
+        "perf",
+        "docs",
+        "doc",
+        "chore",
+        "style",
+        "test",
+        "build",
+        "ci",
+    ),
+    "Removed": ("remove", "removes", "removed", "delete", "deletes", "deleted", "deprecate", "deprecated"),
+}
+
+
+def run_git(repo: Path, args: list[str], check: bool = True, strip: bool = True) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if check and completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or f"git {' '.join(args)} failed")
+    return completed.stdout.strip() if strip else completed.stdout
+
+
+def ensure_git_repo(repo: Path) -> None:
+    run_git(repo, ["rev-parse", "--is-inside-work-tree"])
+
+
+def latest_tag(repo: Path) -> str | None:
+    tag = run_git(repo, ["describe", "--tags", "--abbrev=0"], check=False)
+    return tag or None
+
+
+def commit_range(repo: Path, since: str | None) -> tuple[str, str | None]:
+    if since:
+        return since, f"{since}..HEAD"
+    tag = latest_tag(repo)
+    if tag:
+        return tag, f"{tag}..HEAD"
+    return "repository start", None
+
+
+def git_log(repo: Path, rev_range: str | None) -> list[tuple[str, str, str]]:
+    fmt = "%H%x1f%s%x1f%b%x1e"
+    args = ["log", "--reverse", f"--pretty=format:{fmt}"]
+    if rev_range:
+        args.append(rev_range)
+    output = run_git(repo, args, strip=False)
+    commits: list[tuple[str, str, str]] = []
+    for record in output.split("\x1e"):
+        record = record.strip("\r\n")
+        if not record.strip():
+            continue
+        parts = record.split("\x1f")
+        if len(parts) < 3:
+            continue
+        commits.append((parts[0], parts[1].strip(), parts[2].strip()))
+    return commits
+
+
+def normalize_subject(subject: str) -> str:
+    subject = subject.strip()
+    if ":" in subject:
+        prefix, rest = subject.split(":", 1)
+        if prefix.replace("!", "").lower() in {
+            "feat",
+            "fix",
+            "docs",
+            "chore",
+            "refactor",
+            "perf",
+            "test",
+            "build",
+            "ci",
+            "style",
+        }:
+            subject = rest.strip()
+    return subject[:1].upper() + subject[1:] if subject else "Update"
+
+
+def category_for(subject: str, body: str) -> str:
+    text = f"{subject} {body}".lower()
+    conventional_type = subject.split(":", 1)[0].replace("!", "").lower() if ":" in subject else ""
+    if any(keyword in text for keyword in CATEGORIES["Removed"]):
+        return "Removed"
+    for category, keywords in CATEGORIES.items():
+        if conventional_type in keywords:
+            return category
+    for category, keywords in CATEGORIES.items():
+        if any(keyword in text for keyword in keywords):
+            return category
+    return "Changed"
+
+
+def render_changelog(since_label: str, commits: list[tuple[str, str, str]]) -> str:
+    grouped: dict[str, list[str]] = {category: [] for category in CATEGORIES}
+    for commit_hash, subject, body in commits:
+        category = category_for(subject, body)
+        short_hash = commit_hash[:7]
+        grouped[category].append(f"- {normalize_subject(subject)} ({short_hash})")
+
+    today = dt.date.today().isoformat()
+    lines = [
+        "# Changelog",
+        "",
+        "All notable changes are generated from git history.",
+        "",
+        f"## Unreleased - {today}",
+        "",
+        f"Commits since: `{since_label}`",
+        "",
+    ]
+    if not commits:
+        lines.extend(["No commits found for this range.", ""])
+        return "\n".join(lines)
+
+    for category in ("Added", "Fixed", "Changed", "Removed"):
+        lines.append(f"### {category}")
+        lines.append("")
+        entries = grouped[category]
+        if entries:
+            lines.extend(entries)
+        else:
+            lines.append("- None")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git commits.")
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Git repository path.")
+    parser.add_argument("--output", type=Path, default=Path("CHANGELOG.md"), help="Output markdown file.")
+    parser.add_argument("--since", help="Git ref/tag to use as the start of the range.")
+    args = parser.parse_args(argv)
+
+    repo = args.repo.resolve()
+    ensure_git_repo(repo)
+    since_label, rev_range = commit_range(repo, args.since)
+    commits = git_log(repo, rev_range)
+    changelog = render_changelog(since_label, commits)
+
+    output = args.output if args.output.is_absolute() else repo / args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(changelog, encoding="utf-8")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test_generate_changelog.py
+++ b/test_generate_changelog.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Smoke tests for generate_changelog.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SCRIPT = ROOT / "generate_changelog.py"
+
+
+def run(args: list[str], cwd: Path) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return completed.stdout
+
+
+def git(repo: Path, *args: str) -> str:
+    return run(["git", *args], repo)
+
+
+def test_generates_expected_sections() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        git(repo, "init")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test User")
+
+        (repo / "app.txt").write_text("hello\n", encoding="utf-8")
+        git(repo, "add", "app.txt")
+        git(repo, "commit", "-m", "feat: add greeting file")
+
+        (repo / "app.txt").write_text("hello fixed\n", encoding="utf-8")
+        git(repo, "add", "app.txt")
+        git(repo, "commit", "-m", "fix: correct greeting")
+
+        (repo / "old.txt").write_text("remove me\n", encoding="utf-8")
+        git(repo, "add", "old.txt")
+        git(repo, "commit", "-m", "chore: add temporary file")
+
+        (repo / "old.txt").unlink()
+        git(repo, "add", "old.txt")
+        git(repo, "commit", "-m", "remove temporary file")
+
+        run([sys.executable, str(SCRIPT), "--repo", str(repo)], repo)
+        changelog = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        assert "### Added" in changelog
+        assert "- Add greeting file" in changelog
+        assert "### Fixed" in changelog
+        assert "- Correct greeting" in changelog
+        assert "### Changed" in changelog
+        assert "- Add temporary file" in changelog
+        assert "### Removed" in changelog
+        assert "- Remove temporary file" in changelog
+
+
+if __name__ == "__main__":
+    test_generates_expected_sections()
+    print("ok")


### PR DESCRIPTION
Fixes #1. Adds a structured changelog generator that reads git history and writes CHANGELOG.md, plus a shell wrapper, Claude skill instructions, tests, README usage notes, and submission notes.

Verification passed:
- python -m py_compile generate_changelog.py test_generate_changelog.py
- python test_generate_changelog.py