### PR TITLE
Add Claude Code destructive Bash command blocker hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,75 @@
+# Claude Code Destructive Bash Blocker
+
+PreToolUse hook for Claude Code that blocks destructive Bash commands before execution and logs every blocked attempt.
+
+## Install
+
+```bash
+python3 ~/.claude/hooks/block_destructive_bash.py --install
+```
+
+If you are installing from this repository, first copy `block_destructive_bash.py` into `~/.claude/hooks/`, then run the command above.
+
+## What It Blocks
+
+- `rm -rf` and equivalent `rm -fr` flag order.
+- `DROP TABLE`.
+- `git push --force`, including `--force-with-lease` and `-f`.
+- `TRUNCATE`.
+- `DELETE FROM` statements that do not include a `WHERE` clause before the statement terminator.
+
+Normal Bash commands pass through without output.
+
+## Log File
+
+Blocked attempts are appended to:
+
+```text
+~/.claude/hooks/blocked.log
+```
+
+Each line is JSON with:
+
+- `timestamp`
+- `command`
+- `project_path`
+
+## Claude Code Settings
+
+The installer adds this hook entry to `~/.claude/settings.json`. A copy is also available at `settings.example.json`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The actual installed command uses the current Python interpreter and an absolute path.
+
+## Manual Test
+
+Allowed command:
+
+```bash
+printf '{"tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp/demo"}' | python3 block_destructive_bash.py
+```
+
+Blocked command:
+
+```bash
+printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf build"},"cwd":"/tmp/demo"}' | python3 block_destructive_bash.py
+```
+
+The blocked command returns a Claude Code denial response with a clear reason.

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import stat
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+RM_RF_RE = re.compile(r"\brm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b|\brm\s+-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*\b")
+DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\btruncate\b", re.IGNORECASE)
+GIT_FORCE_PUSH_RE = re.compile(r"\bgit\s+push\b(?:(?![;&|]).)*(?:--force(?:-with-lease)?|-f)\b", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bwhere\b", re.IGNORECASE)
+
+HOOK_NAME = "block_destructive_bash.py"
+
+
+def classify_command(command: str) -> str | None:
+    """Return the blocking reason for a command, or None if it should run."""
+    checks = [
+        (RM_RF_RE, "rm -rf recursively deletes files and is blocked by policy"),
+        (GIT_FORCE_PUSH_RE, "git push --force can rewrite shared history and is blocked by policy"),
+    ]
+
+    for pattern, reason in checks:
+        if pattern.search(command):
+            return reason
+
+    if is_read_only_search_command(command):
+        return None
+
+    sql_checks = [
+        (DROP_TABLE_RE, "DROP TABLE can destroy database schema/data and is blocked by policy"),
+        (TRUNCATE_RE, "TRUNCATE can erase table contents and is blocked by policy"),
+    ]
+    for pattern, reason in sql_checks:
+        if pattern.search(command):
+            return reason
+
+    delete_match = DELETE_FROM_RE.search(command)
+    if delete_match and not delete_statement_has_where(command, delete_match.end()):
+        return "DELETE FROM without a WHERE clause can erase table contents and is blocked by policy"
+
+    return None
+
+
+def is_read_only_search_command(command: str) -> bool:
+    """Avoid blocking harmless searches for dangerous SQL strings."""
+    if any(delimiter in command for delimiter in (";", "&&", "||", "|", "`", "$(")):
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    executable = Path(tokens[0]).name
+    return executable in {"grep", "rg", "ag"}
+
+
+def delete_statement_has_where(command: str, start: int) -> bool:
+    """Check whether the DELETE FROM statement segment has a WHERE clause."""
+    remainder = command[start:]
+    terminators = [idx for idx in (remainder.find(";"), remainder.find("&&"), remainder.find("||"), remainder.find("|")) if idx != -1]
+    statement = remainder[: min(terminators)] if terminators else remainder
+    return bool(WHERE_RE.search(statement))
+
+
+def project_path(payload: dict[str, Any]) -> str:
+    """Extract the best available project path from hook input or environment."""
+    candidates = [
+        os.environ.get("CLAUDE_PROJECT_DIR"),
+        payload.get("cwd"),
+        payload.get("project_dir"),
+        payload.get("workspace", {}).get("current_dir") if isinstance(payload.get("workspace"), dict) else None,
+        os.getcwd(),
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    return "unknown"
+
+
+def log_blocked(command: str, path: str) -> None:
+    """Append a blocked attempt to the log file."""
+    log_path = Path(os.environ.get("CLAUDE_BLOCKED_LOG", "~/.claude/hooks/blocked.log")).expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "command": command,
+        "project_path": path,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=True) + "\n")
+
+
+def deny(reason: str, command: str, path: str) -> dict[str, Any]:
+    """Build a Claude Code PreToolUse denial response."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Blocked destructive Bash command: {reason}. "
+                f"Project path: {path}. Command: {command}"
+            ),
+        }
+    }
+
+
+def handle(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a denial payload for blocked commands; None allows execution."""
+    if payload.get("tool_name") != "Bash":
+        return None
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return None
+
+    reason = classify_command(command)
+    if not reason:
+        return None
+
+    path = project_path(payload)
+    log_blocked(command, path)
+    return deny(reason, command, path)
+
+
+def install() -> None:
+    """Install this hook under ~/.claude/hooks and update ~/.claude/settings.json."""
+    claude_dir = Path.home() / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    target = hooks_dir / HOOK_NAME
+    source = Path(__file__).resolve()
+    if source != target:
+        shutil.copy2(source, target)
+    mode = target.stat().st_mode
+    target.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    settings_path = claude_dir / "settings.json"
+    if settings_path.exists():
+        with settings_path.open("r", encoding="utf-8") as handle:
+            settings = json.load(handle)
+    else:
+        settings = {}
+
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    command = f"{sys.executable} {target}"
+    entry = {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": command,
+            }
+        ],
+    }
+
+    existing_commands = {
+        hook.get("command")
+        for group in pre_tool_use
+        if isinstance(group, dict)
+        for hook in group.get("hooks", [])
+        if isinstance(hook, dict)
+    }
+    if command not in existing_commands:
+        pre_tool_use.append(entry)
+
+    with settings_path.open("w", encoding="utf-8") as handle:
+        json.dump(settings, handle, indent=2)
+        handle.write("\n")
+
+    print(f"Installed {target}")
+    print(f"Updated {settings_path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Block destructive Bash commands in Claude Code.")
+    parser.add_argument("--install", action="store_true", help="Install the hook into ~/.claude/hooks.")
+    args = parser.parse_args(argv)
+
+    if args.install:
+        install()
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"Invalid hook JSON input: {exc}", file=sys.stderr)
+        return 1
+
+    response = handle(payload)
+    if response is not None:
+        print(json.dumps(response, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/settings.example.json
+++ b/hooks/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/test_block_destructive_bash.py
+++ b/hooks/test_block_destructive_bash.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HOOK_PATH = Path(__file__).parent / "block_destructive_bash.py"
+SPEC = importlib.util.spec_from_file_location("block_destructive_bash", HOOK_PATH)
+HOOK = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(HOOK)
+
+
+class DestructiveBashHookTests(unittest.TestCase):
+    def test_blocks_required_patterns(self):
+        blocked = [
+            "rm -rf build",
+            "rm -fr build",
+            "psql -c 'DROP TABLE users'",
+            "git push --force origin main",
+            "git push -f origin main",
+            "psql -c 'TRUNCATE audit_log'",
+            "psql -c 'DELETE FROM users'",
+        ]
+        for command in blocked:
+            with self.subTest(command=command):
+                self.assertIsNotNone(HOOK.classify_command(command))
+
+    def test_allows_normal_commands(self):
+        allowed = [
+            "git status",
+            "npm test",
+            "python3 -m unittest",
+            "psql -c 'DELETE FROM users WHERE id = 1'",
+            "grep -R 'DROP TABLE' docs/",
+        ]
+        for command in allowed:
+            with self.subTest(command=command):
+                self.assertIsNone(HOOK.classify_command(command))
+
+    def test_cli_denies_and_logs_blocked_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "blocked.log"
+            payload = {
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf build"},
+                "cwd": "/tmp/project",
+            }
+            env = os.environ.copy()
+            env["CLAUDE_BLOCKED_LOG"] = str(log_path)
+            result = subprocess.run(
+                [sys.executable, str(HOOK_PATH)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            response = json.loads(result.stdout)
+            decision = response["hookSpecificOutput"]
+            self.assertEqual(decision["permissionDecision"], "deny")
+            self.assertIn("rm -rf", decision["permissionDecisionReason"])
+
+            log_entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+            self.assertEqual(log_entry["command"], "rm -rf build")
+            self.assertEqual(log_entry["project_path"], "/tmp/project")
+            self.assertIn("timestamp", log_entry)
+
+    def test_cli_allows_normal_command_without_output(self):
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+            "cwd": "/tmp/project",
+        }
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

Adds a Claude Code `PreToolUse` hook that blocks destructive Bash commands before execution.

The hook:

- runs from `~/.claude/hooks/`;
- matches the `Bash` tool via Claude Code settings;
- blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` statements without a `WHERE` clause;
- logs every blocked attempt to `~/.claude/hooks/blocked.log` as JSON lines with timestamp, command, and project path;
- returns a clear Claude Code denial response and stays silent for normal commands.
- includes a `settings.example.json` entry for manual installation/reference.
- keeps the hook, tests, and README together under `hooks/`.

## Verification

```bash
python3 hooks/test_block_destructive_bash.py
```

## Claim

Closes #3.
