### PR TITLE
Add changelog generator for bounty #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You're in the right place.
 
 | # | Task | Amount | Status |
 |---|------|--------|--------|
-| [#1](../../issues/1) | SKILL: Generate a CHANGELOG from git history | $50 | 🟢 Open |
+| [#1](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1) | SKILL: Generate a CHANGELOG from git history | $50 | 🟢 Open |
 | [#2](../../issues/2) | TEMPLATE: CLAUDE.md for a Next.js + SQLite project | $75 | 🟢 Open |
 | [#3](../../issues/3) | HOOK: Block destructive bash commands in Claude Code | $100 | 🟢 Open |
 | [#4](../../issues/4) | AGENT: PR reviewer with structured Markdown output | $150 | 🟢 Open |
@@ -36,7 +36,7 @@ You're in the right place.
 
 ## Generate a changelog
 
-This repository includes a small changelog generator for bounty [#1](../../issues/1).
+This repository includes a small changelog generator for bounty [#1](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1).
 It reads commits since the latest git tag, groups them into `Added`, `Fixed`,
 `Changed`, and `Removed`, then writes a formatted `CHANGELOG.md`.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ It reads commits since the latest git tag, groups them into `Added`, `Fixed`,
 
 Setup in 3 steps:
 
-1. Clone the repository and make sure `git` and Python 3 are installed.
-2. Run `bash changelog.sh` from the repository root.
+1. Clone the repository and make sure `git` and Python 3.8+ are installed.
+2. Run `bash changelog.sh`; it may be launched from any directory.
 3. Review the generated `CHANGELOG.md`; see `examples/CHANGELOG.sample.md` for sample output.
 
 Optional: use `bash changelog.sh --print` to preview output or

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ You're in the right place.
 | # | Task | Amount | Status |
 |---|------|--------|--------|
 | [#1](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1) | SKILL: Generate a CHANGELOG from git history | $50 | 🟢 Open |
-| [#2](../../issues/2) | TEMPLATE: CLAUDE.md for a Next.js + SQLite project | $75 | 🟢 Open |
-| [#3](../../issues/3) | HOOK: Block destructive bash commands in Claude Code | $100 | 🟢 Open |
-| [#4](../../issues/4) | AGENT: PR reviewer with structured Markdown output | $150 | 🟢 Open |
-| [#5](../../issues/5) | WORKFLOW: n8n + Claude API — automated weekly dev summary | $200 | 🟢 Open |
+| [#2](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/2) | TEMPLATE: CLAUDE.md for a Next.js + SQLite project | $75 | 🟢 Open |
+| [#3](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3) | HOOK: Block destructive bash commands in Claude Code | $100 | 🟢 Open |
+| [#4](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/4) | AGENT: PR reviewer with structured Markdown output | $150 | 🟢 Open |
+| [#5](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/5) | WORKFLOW: n8n + Claude API — automated weekly dev summary | $200 | 🟢 Open |
 
 ---
 
@@ -48,6 +48,8 @@ Setup in 3 steps:
 
 Optional: use `bash changelog.sh --print` to preview output or
 `bash changelog.sh --output path/to/CHANGELOG.md` to choose a file.
+When the repository has no tags, the generator reads the latest 200 commits by
+default; use `bash changelog.sh --max-count 0` to include full history.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ You're in the right place.
 
 | # | Task | Amount | Status |
 |---|------|--------|--------|
-| [#1](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1) | SKILL: Generate a CHANGELOG from git history | $50 | 🟢 Open |
-| [#2](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/2) | TEMPLATE: CLAUDE.md for a Next.js + SQLite project | $75 | 🟢 Open |
-| [#3](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3) | HOOK: Block destructive bash commands in Claude Code | $100 | 🟢 Open |
-| [#4](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/4) | AGENT: PR reviewer with structured Markdown output | $150 | 🟢 Open |
-| [#5](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/5) | WORKFLOW: n8n + Claude API — automated weekly dev summary | $200 | 🟢 Open |
+| [#1](issues/1) | SKILL: Generate a CHANGELOG from git history | $50 | 🟢 Open |
+| [#2](issues/2) | TEMPLATE: CLAUDE.md for a Next.js + SQLite project | $75 | 🟢 Open |
+| [#3](issues/3) | HOOK: Block destructive bash commands in Claude Code | $100 | 🟢 Open |
+| [#4](issues/4) | AGENT: PR reviewer with structured Markdown output | $150 | 🟢 Open |
+| [#5](issues/5) | WORKFLOW: n8n + Claude API — automated weekly dev summary | $200 | 🟢 Open |
 
 ---
 
 ## Generate a changelog
 
-This repository includes a small changelog generator for bounty [#1](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/1).
+This repository includes a small changelog generator for bounty [#1](issues/1).
 It reads commits since the latest git tag, groups them into `Added`, `Fixed`,
 `Changed`, and `Removed`, then writes a formatted `CHANGELOG.md`.
 
@@ -48,8 +48,9 @@ Setup in 3 steps:
 
 Optional: use `bash changelog.sh --print` to preview output or
 `bash changelog.sh --output path/to/CHANGELOG.md` to choose a file.
-When the repository has no tags, the generator reads the latest 200 commits by
-default; use `bash changelog.sh --max-count 0` to include full history.
+When the repository has no tags, the generator reads a bounded recent commit
+history by default; use `bash changelog.sh --max-count N` to choose the bound or
+`bash changelog.sh --max-count 0` to include full history.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ You're in the right place.
 
 ---
 
+## Generate a changelog
+
+This repository includes a small changelog generator for bounty [#1](../../issues/1).
+It reads commits since the latest git tag, groups them into `Added`, `Fixed`,
+`Changed`, and `Removed`, then writes a formatted `CHANGELOG.md`.
+
+Setup in 3 steps:
+
+1. Clone the repository and make sure `git` and Python 3 are installed.
+2. Run `bash changelog.sh` from the repository root.
+3. Review the generated `CHANGELOG.md`; see `examples/CHANGELOG.sample.md` for sample output.
+
+Optional: use `bash changelog.sh --print` to preview output or
+`bash changelog.sh --output path/to/CHANGELOG.md` to choose a file.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/changelog.sh
+++ b/changelog.sh
@@ -8,15 +8,16 @@ PYTHON_CANDIDATES=("python3" "python" "py -3")
 
 for candidate in "${PYTHON_CANDIDATES[@]}"; do
   read -r -a candidate_cmd <<< "$candidate"
-  if "${candidate_cmd[@]}" --version >/dev/null 2>&1; then
+  if "${candidate_cmd[@]}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then
     PYTHON_CMD=("${candidate_cmd[@]}")
     break
   fi
 done
 
 if [[ ${#PYTHON_CMD[@]} -eq 0 ]]; then
-  echo "Python 3 is required to generate the changelog." >&2
+  echo "Python 3.8 or newer is required to generate the changelog." >&2
   exit 1
 fi
 
+cd "$SCRIPT_DIR"
 exec "${PYTHON_CMD[@]}" "$SCRIPT_DIR/scripts/generate_changelog.py" "$@"

--- a/changelog.sh
+++ b/changelog.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 PYTHON_CMD=()
-for candidate in python3 python "py -3"; do
-  if $candidate --version >/dev/null 2>&1; then
-    read -r -a PYTHON_CMD <<< "$candidate"
+PYTHON_CANDIDATES=("python3" "python" "py -3")
+
+for candidate in "${PYTHON_CANDIDATES[@]}"; do
+  read -r -a candidate_cmd <<< "$candidate"
+  if "${candidate_cmd[@]}" --version >/dev/null 2>&1; then
+    PYTHON_CMD=("${candidate_cmd[@]}")
     break
   fi
 done

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PYTHON_CMD=()
+for candidate in python3 python "py -3"; do
+  if $candidate --version >/dev/null 2>&1; then
+    read -r -a PYTHON_CMD <<< "$candidate"
+    break
+  fi
+done
+
+if [[ ${#PYTHON_CMD[@]} -eq 0 ]]; then
+  echo "Python 3 is required to generate the changelog." >&2
+  exit 1
+fi
+
+exec "${PYTHON_CMD[@]}" "$SCRIPT_DIR/scripts/generate_changelog.py" "$@"

--- a/examples/CHANGELOG.sample.md
+++ b/examples/CHANGELOG.sample.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - YYYY-MM-DD
 
-_Generated from commits from repository history. The date is filled in at runtime._
+_Generated from the latest 200 commits in repository history. The date is filled in at runtime._
 
 ### Added
 - Initial README with bounty board (1aeae2a)

--- a/examples/CHANGELOG.sample.md
+++ b/examples/CHANGELOG.sample.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## Unreleased - 2026-06-02
+
+_Generated from commits from repository history._
+
+### Added
+- Initial README with bounty board (1aeae2a)
+
+### Fixed
+- No changes.
+
+### Changed
+- Initial commit (a80a580)
+
+### Removed
+- No changes.
+

--- a/examples/CHANGELOG.sample.md
+++ b/examples/CHANGELOG.sample.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - YYYY-MM-DD
 
-_Generated from recent repository history._
+_Generated from the last N commits in repository history._
 
 ### Added
 - Initial README with bounty board (1aeae2a)

--- a/examples/CHANGELOG.sample.md
+++ b/examples/CHANGELOG.sample.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - YYYY-MM-DD
 
-_Generated from the latest 200 commits in repository history. The date is filled in at runtime._
+_Generated from recent repository history._
 
 ### Added
 - Initial README with bounty board (1aeae2a)

--- a/examples/CHANGELOG.sample.md
+++ b/examples/CHANGELOG.sample.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased - 2026-06-02
+## Unreleased - YYYY-MM-DD
 
-_Generated from commits from repository history._
+_Generated from commits from repository history. The date is filled in at runtime._
 
 ### Added
 - Initial README with bounty board (1aeae2a)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional
 
 CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
 DEFAULT_MAX_COMMITS_WITHOUT_TAG = 200
-CONVENTIONAL_PREFIX_RE = re.compile(r"^\w+(?:\([^)]+\))?!?:\s*")
+CONVENTIONAL_PREFIX_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*(?:\([^)]+\))?!?:\s*")
 ADDED_RE = re.compile(r"\b(add|adds|added|new|introduce|implement)\b")
 FIXED_RE = re.compile(r"\b(fix|fixed|bug|patch|resolve|repair)\b")
 REMOVED_RE = re.compile(r"\b(remove|removed|delete|deleted|drop|dropped|deprecate)\b")
@@ -106,7 +106,7 @@ def render_changelog(commits: List[Commit], tag: Optional[str], history_limit: O
     if tag:
         source_label = f"from commits since {tag}"
     elif history_limit:
-        source_label = f"from the latest {history_limit} commits in repository history"
+        source_label = "from recent repository history"
     else:
         source_label = "from repository history"
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional
 
 
 CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+DEFAULT_MAX_COMMITS_WITHOUT_TAG = 200
 
 
 class GitCommandError(Exception):
@@ -63,9 +64,12 @@ def last_tag(repo: Path) -> Optional[str]:
     return tag or None
 
 
-def commits_since(repo: Path, tag: Optional[str]) -> List[Commit]:
+def commits_since(repo: Path, tag: Optional[str], max_count_without_tag: int) -> List[Commit]:
     revision = f"{tag}..HEAD" if tag else "HEAD"
-    raw = run_git(["log", revision, "--pretty=format:%h%x09%s"], repo)
+    args = ["log", revision, "--pretty=format:%h%x09%s"]
+    if tag is None and max_count_without_tag > 0:
+        args.insert(2, f"--max-count={max_count_without_tag}")
+    raw = run_git(args, repo)
     commits: List[Commit] = []
     for line in raw.splitlines():
         if not line.strip():
@@ -93,9 +97,14 @@ def categorize(subject: str) -> str:
     return "Changed"
 
 
-def render_changelog(commits: List[Commit], tag: Optional[str]) -> str:
+def render_changelog(commits: List[Commit], tag: Optional[str], history_limit: Optional[int] = None) -> str:
     today = dt.date.today().isoformat()
-    compare_label = f"since {tag}" if tag else "from repository history"
+    if tag:
+        source_label = f"from commits since {tag}"
+    elif history_limit:
+        source_label = f"from the latest {history_limit} commits in repository history"
+    else:
+        source_label = "from repository history"
 
     grouped: Dict[str, List[Commit]] = {category: [] for category in CATEGORIES}
     for commit in commits:
@@ -106,7 +115,7 @@ def render_changelog(commits: List[Commit], tag: Optional[str]) -> str:
         "",
         f"## Unreleased - {today}",
         "",
-        f"_Generated from commits {compare_label}._",
+        f"_Generated {source_label}._",
         "",
     ]
 
@@ -136,8 +145,15 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--print",
+        dest="print_changelog",
         action="store_true",
         help="Print changelog to stdout instead of writing a file.",
+    )
+    parser.add_argument(
+        "--max-count",
+        type=int,
+        default=DEFAULT_MAX_COMMITS_WITHOUT_TAG,
+        help="Maximum commits to read when the repo has no tags; use 0 for full history.",
     )
     return parser.parse_args()
 
@@ -145,14 +161,17 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     try:
         args = parse_args()
+        if args.max_count < 0:
+            raise SystemExit("--max-count must be 0 or greater.")
         repo = find_repo_root(Path.cwd())
         tag = last_tag(repo)
-        commits = commits_since(repo, tag)
-        changelog = render_changelog(commits, tag)
+        commits = commits_since(repo, tag, args.max_count)
+        history_limit = args.max_count if tag is None and args.max_count > 0 else None
+        changelog = render_changelog(commits, tag, history_limit)
     except GitCommandError as exc:
         raise SystemExit(str(exc)) from exc
 
-    if args.print:
+    if args.print_changelog:
         print(changelog, end="")
         return 0
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Dict, List, Optional
 
 
 CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
@@ -21,7 +22,7 @@ class Commit:
     subject: str
 
 
-def run_git(args: list[str], repo: Path) -> str:
+def run_git(args: List[str], repo: Path) -> str:
     try:
         completed = subprocess.run(
             ["git", *args],
@@ -42,7 +43,7 @@ def find_repo_root(start: Path) -> Path:
     return Path(root)
 
 
-def last_tag(repo: Path) -> str | None:
+def last_tag(repo: Path) -> Optional[str]:
     try:
         tag = run_git(["describe", "--tags", "--abbrev=0"], repo)
     except SystemExit:
@@ -50,10 +51,10 @@ def last_tag(repo: Path) -> str | None:
     return tag or None
 
 
-def commits_since(repo: Path, tag: str | None) -> list[Commit]:
+def commits_since(repo: Path, tag: Optional[str]) -> List[Commit]:
     revision = f"{tag}..HEAD" if tag else "HEAD"
     raw = run_git(["log", revision, "--pretty=format:%h%x09%s"], repo)
-    commits: list[Commit] = []
+    commits: List[Commit] = []
     for line in raw.splitlines():
         if not line.strip():
             continue
@@ -80,11 +81,11 @@ def categorize(subject: str) -> str:
     return "Changed"
 
 
-def render_changelog(commits: list[Commit], tag: str | None) -> str:
+def render_changelog(commits: List[Commit], tag: Optional[str]) -> str:
     today = dt.date.today().isoformat()
     compare_label = f"since {tag}" if tag else "from repository history"
 
-    grouped: dict[str, list[Commit]] = {category: [] for category in CATEGORIES}
+    grouped: Dict[str, List[Commit]] = {category: [] for category in CATEGORIES}
     for commit in commits:
         grouped[categorize(commit.subject)].append(commit)
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate a structured CHANGELOG.md from git commits since the last tag."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+
+
+def run_git(args: list[str], repo: Path) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        raise SystemExit(f"git {' '.join(args)} failed: {message}") from exc
+    return completed.stdout.strip()
+
+
+def find_repo_root(start: Path) -> Path:
+    root = run_git(["rev-parse", "--show-toplevel"], start)
+    return Path(root)
+
+
+def last_tag(repo: Path) -> str | None:
+    try:
+        tag = run_git(["describe", "--tags", "--abbrev=0"], repo)
+    except SystemExit:
+        return None
+    return tag or None
+
+
+def commits_since(repo: Path, tag: str | None) -> list[Commit]:
+    revision = f"{tag}..HEAD" if tag else "HEAD"
+    raw = run_git(["log", revision, "--pretty=format:%h%x09%s"], repo)
+    commits: list[Commit] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        sha, _, subject = line.partition("\t")
+        commits.append(Commit(sha=sha, subject=subject.strip()))
+    return commits
+
+
+def clean_subject(subject: str) -> str:
+    subject = re.sub(r"^\w+(?:\([^)]+\))?!?:\s*", "", subject).strip()
+    return subject[:1].upper() + subject[1:] if subject else subject
+
+
+def categorize(subject: str) -> str:
+    lowered = subject.lower()
+    prefix = lowered.split(":", 1)[0]
+
+    if prefix.startswith(("feat", "add")) or re.search(r"\b(add|adds|added|new|introduce|implement)\b", lowered):
+        return "Added"
+    if prefix.startswith(("fix", "bug", "hotfix")) or re.search(r"\b(fix|fixed|bug|patch|resolve|repair)\b", lowered):
+        return "Fixed"
+    if prefix.startswith(("remove", "delete", "drop")) or re.search(r"\b(remove|removed|delete|deleted|drop|dropped|deprecate)\b", lowered):
+        return "Removed"
+    return "Changed"
+
+
+def render_changelog(commits: list[Commit], tag: str | None) -> str:
+    today = dt.date.today().isoformat()
+    compare_label = f"since {tag}" if tag else "from repository history"
+
+    grouped: dict[str, list[Commit]] = {category: [] for category in CATEGORIES}
+    for commit in commits:
+        grouped[categorize(commit.subject)].append(commit)
+
+    lines = [
+        "# Changelog",
+        "",
+        f"## Unreleased - {today}",
+        "",
+        f"_Generated from commits {compare_label}._",
+        "",
+    ]
+
+    if not commits:
+        lines.extend(["No commits found for this range.", ""])
+        return "\n".join(lines)
+
+    for category in CATEGORIES:
+        lines.append(f"### {category}")
+        if grouped[category]:
+            for commit in grouped[category]:
+                lines.append(f"- {clean_subject(commit.subject)} ({commit.sha})")
+        else:
+            lines.append("- No changes.")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CHANGELOG.md from git history.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="CHANGELOG.md",
+        help="Output file path, relative to the repo root unless absolute.",
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        help="Print changelog to stdout instead of writing a file.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = find_repo_root(Path.cwd())
+    tag = last_tag(repo)
+    commits = commits_since(repo, tag)
+    changelog = render_changelog(commits, tag)
+
+    if args.print:
+        print(changelog)
+        return 0
+
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = repo / output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(changelog, encoding="utf-8")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -15,6 +15,10 @@ from typing import Dict, List, Optional
 
 CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
 DEFAULT_MAX_COMMITS_WITHOUT_TAG = 200
+CONVENTIONAL_PREFIX_RE = re.compile(r"^\w+(?:\([^)]+\))?!?:\s*")
+ADDED_RE = re.compile(r"\b(add|adds|added|new|introduce|implement)\b")
+FIXED_RE = re.compile(r"\b(fix|fixed|bug|patch|resolve|repair)\b")
+REMOVED_RE = re.compile(r"\b(remove|removed|delete|deleted|drop|dropped|deprecate)\b")
 
 
 class GitCommandError(Exception):
@@ -80,7 +84,7 @@ def commits_since(repo: Path, tag: Optional[str], max_count_without_tag: int) ->
 
 
 def clean_subject(subject: str) -> str:
-    subject = re.sub(r"^\w+(?:\([^)]+\))?!?:\s*", "", subject).strip()
+    subject = CONVENTIONAL_PREFIX_RE.sub("", subject).strip()
     return subject[:1].upper() + subject[1:] if subject else subject
 
 
@@ -88,11 +92,11 @@ def categorize(subject: str) -> str:
     lowered = subject.lower()
     prefix = lowered.split(":", 1)[0]
 
-    if prefix.startswith(("feat", "add")) or re.search(r"\b(add|adds|added|new|introduce|implement)\b", lowered):
+    if prefix.startswith(("feat", "add")) or ADDED_RE.search(lowered):
         return "Added"
-    if prefix.startswith(("fix", "bug", "hotfix")) or re.search(r"\b(fix|fixed|bug|patch|resolve|repair)\b", lowered):
+    if prefix.startswith(("fix", "bug", "hotfix")) or FIXED_RE.search(lowered):
         return "Fixed"
-    if prefix.startswith(("remove", "delete", "drop")) or re.search(r"\b(remove|removed|delete|deleted|drop|dropped|deprecate)\b", lowered):
+    if prefix.startswith(("remove", "delete", "drop")) or REMOVED_RE.search(lowered):
         return "Removed"
     return "Changed"
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -16,6 +16,15 @@ from typing import Dict, List, Optional
 CATEGORIES = ("Added", "Fixed", "Changed", "Removed")
 
 
+class GitCommandError(Exception):
+    def __init__(self, args: List[str], stdout: str, stderr: str) -> None:
+        self.args_list = args
+        self.stdout = stdout
+        self.stderr = stderr
+        message = stderr.strip() or stdout.strip() or "unknown git error"
+        super().__init__(f"git {' '.join(args)} failed: {message}")
+
+
 @dataclass(frozen=True)
 class Commit:
     sha: str
@@ -28,13 +37,13 @@ def run_git(args: List[str], repo: Path) -> str:
             ["git", *args],
             cwd=repo,
             check=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as exc:
-        message = exc.stderr.strip() or exc.stdout.strip() or str(exc)
-        raise SystemExit(f"git {' '.join(args)} failed: {message}") from exc
+        raise GitCommandError(args, exc.stdout or "", exc.stderr or "") from exc
     return completed.stdout.strip()
 
 
@@ -46,8 +55,11 @@ def find_repo_root(start: Path) -> Path:
 def last_tag(repo: Path) -> Optional[str]:
     try:
         tag = run_git(["describe", "--tags", "--abbrev=0"], repo)
-    except SystemExit:
-        return None
+    except GitCommandError as exc:
+        output = f"{exc.stderr}\n{exc.stdout}".lower()
+        if "no names found" in output or "no tags can describe" in output:
+            return None
+        raise
     return tag or None
 
 
@@ -131,11 +143,14 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    args = parse_args()
-    repo = find_repo_root(Path.cwd())
-    tag = last_tag(repo)
-    commits = commits_since(repo, tag)
-    changelog = render_changelog(commits, tag)
+    try:
+        args = parse_args()
+        repo = find_repo_root(Path.cwd())
+        tag = last_tag(repo)
+        commits = commits_since(repo, tag)
+        changelog = render_changelog(commits, tag)
+    except GitCommandError as exc:
+        raise SystemExit(str(exc)) from exc
 
     if args.print:
         print(changelog, end="")

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -70,9 +70,10 @@ def last_tag(repo: Path) -> Optional[str]:
 
 def commits_since(repo: Path, tag: Optional[str], max_count_without_tag: int) -> List[Commit]:
     revision = f"{tag}..HEAD" if tag else "HEAD"
-    args = ["log", revision, "--pretty=format:%h%x09%s"]
+    args = ["log"]
     if tag is None and max_count_without_tag > 0:
-        args.insert(2, f"--max-count={max_count_without_tag}")
+        args.append(f"--max-count={max_count_without_tag}")
+    args.extend([revision, "--pretty=format:%h%x09%s"])
     raw = run_git(args, repo)
     commits: List[Commit] = []
     for line in raw.splitlines():
@@ -106,7 +107,7 @@ def render_changelog(commits: List[Commit], tag: Optional[str], history_limit: O
     if tag:
         source_label = f"from commits since {tag}"
     elif history_limit:
-        source_label = "from recent repository history"
+        source_label = f"from the last {history_limit} commits in repository history"
     else:
         source_label = "from repository history"
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -99,7 +99,7 @@ def render_changelog(commits: list[Commit], tag: str | None) -> str:
 
     if not commits:
         lines.extend(["No commits found for this range.", ""])
-        return "\n".join(lines)
+        return "\n".join(lines).rstrip() + "\n"
 
     for category in CATEGORIES:
         lines.append(f"### {category}")
@@ -110,7 +110,7 @@ def render_changelog(commits: list[Commit], tag: str | None) -> str:
             lines.append("- No changes.")
         lines.append("")
 
-    return "\n".join(lines)
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def parse_args() -> argparse.Namespace:
@@ -137,7 +137,7 @@ def main() -> int:
     changelog = render_changelog(commits, tag)
 
     if args.print:
-        print(changelog)
+        print(changelog, end="")
         return 0
 
     output = Path(args.output)


### PR DESCRIPTION
Closes #1

## Summary
- Adds `changelog.sh` as the required Bash entrypoint.
- Adds a Python generator that reads commits since the latest git tag and groups them into `Added`, `Fixed`, `Changed`, and `Removed`.
- Adds a sample changelog output and README setup instructions in 3 steps.

## Verification
- `C:\Program Files\Git\bin\bash.exe changelog.sh --print`
- `python scripts\generate_changelog.py --print`
- `python -m compileall scripts`
