### PR TITLE
Add PR review agent and CLI

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,30 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request diff and return a concise structured Markdown review comment.
+tools: Bash, Read, WebFetch
+---
+
+You are a focused PR review sub-agent. Your job is to inspect a pull request diff and produce a comment that a maintainer can paste into GitHub.
+
+Always return Markdown with exactly these sections:
+
+1. `## Summary`
+   - Write 2 or 3 sentences describing what changed and where the main behavior lives.
+2. `## Identified Risks`
+   - List concrete risks tied to files, patterns, or missing validation.
+   - If no meaningful risk is visible, say `- No major risks found in the reviewed diff.`
+3. `## Improvement Suggestions`
+   - List practical changes that would improve maintainability, testability, or safety.
+   - Avoid generic advice.
+4. `## Confidence`
+   - One of `Low`, `Medium`, or `High`, followed by one sentence explaining why.
+
+Review priorities:
+
+- Behavioral regressions and data loss risk.
+- Missing tests around changed behavior.
+- Unsafe shell, SQL, auth, billing, or secret handling.
+- API compatibility and migration concerns.
+- Overly broad abstractions that hide failure modes.
+
+Keep the tone direct and useful. Do not approve or reject the PR. Do not invent code that is not visible in the diff.

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -35,8 +35,9 @@ The companion Claude Code sub-agent definition lives at `.claude/agents/pr-revie
 ## Verification
 
 ```bash
-python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400
-python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401
+python agents/pr-reviewer/test_claude_review.py
+python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400 --output agents/pr-reviewer/examples/pr-2400-review.md
+python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401 --output agents/pr-reviewer/examples/pr-2401-review.md
 python -m compileall agents/pr-reviewer
 ```
 

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -15,7 +15,7 @@ Requires Python 3.8 or newer.
 Optional for private repositories or higher GitHub rate limits:
 
 ```bash
-export GITHUB_TOKEN=ghp_your_token_here
+export GITHUB_TOKEN=YOUR_TOKEN_HERE
 ```
 
 ## Usage

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -10,6 +10,8 @@ From the repository root:
 chmod +x claude-review
 ```
 
+Requires Python 3.8 or newer.
+
 Optional for private repositories or higher GitHub rate limits:
 
 ```bash
@@ -36,8 +38,8 @@ The companion Claude Code sub-agent definition lives at `.claude/agents/pr-revie
 
 ```bash
 python agents/pr-reviewer/test_claude_review.py
-python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400 --output agents/pr-reviewer/examples/pr-2400-review.md
-python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401 --output agents/pr-reviewer/examples/pr-2401-review.md
+./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400 --output agents/pr-reviewer/examples/pr-2400-review.md
+./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401 --output agents/pr-reviewer/examples/pr-2401-review.md
 python -m compileall agents/pr-reviewer
 ```
 

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -37,10 +37,10 @@ The companion Claude Code sub-agent definition lives at `.claude/agents/pr-revie
 ## Verification
 
 ```bash
-python agents/pr-reviewer/test_claude_review.py
+python3 agents/pr-reviewer/test_claude_review.py
 ./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400 --output agents/pr-reviewer/examples/pr-2400-review.md
 ./claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401 --output agents/pr-reviewer/examples/pr-2401-review.md
-python -m compileall agents/pr-reviewer
+python3 -m compileall agents/pr-reviewer
 ```
 
 Sample outputs are included in `agents/pr-reviewer/examples/`.

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,0 +1,43 @@
+# PR Reviewer Agent
+
+Claude Code sub-agent and CLI for bounty #4. It accepts a GitHub pull request URL, reads the public diff, and returns a structured Markdown review comment.
+
+## Setup
+
+From the repository root:
+
+```bash
+chmod +x claude-review
+```
+
+Optional for private repositories or higher GitHub rate limits:
+
+```bash
+export GITHUB_TOKEN=ghp_your_token_here
+```
+
+## Usage
+
+```bash
+./claude-review --pr https://github.com/owner/repo/pull/123
+./claude-review --pr https://github.com/owner/repo/pull/123 --output review.md
+```
+
+The output always includes:
+
+- Summary of changes.
+- Identified risks.
+- Improvement suggestions.
+- Confidence score: Low, Medium, or High.
+
+The companion Claude Code sub-agent definition lives at `.claude/agents/pr-reviewer.md`. Use the sub-agent when you want Claude Code to reason over the same structure with repository context; use the CLI when you want a deterministic review comment from a public PR URL.
+
+## Verification
+
+```bash
+python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400
+python agents/pr-reviewer/claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401
+python -m compileall agents/pr-reviewer
+```
+
+Sample outputs are included in `agents/pr-reviewer/examples/`.

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,6 +1,6 @@
 # PR Reviewer Agent
 
-Claude Code sub-agent and CLI for bounty #4. It accepts a GitHub pull request URL, reads the public diff, and returns a structured Markdown review comment.
+Claude Code sub-agent and CLI for bounty #4. It accepts a GitHub pull request URL, reads the PR diff from GitHub, and returns a structured Markdown review comment.
 
 ## Setup
 
@@ -32,7 +32,7 @@ The output always includes:
 - Improvement suggestions.
 - Confidence score: Low, Medium, or High.
 
-The companion Claude Code sub-agent definition lives at `.claude/agents/pr-reviewer.md`. Use the sub-agent when you want Claude Code to reason over the same structure with repository context; use the CLI when you want a deterministic review comment from a public PR URL.
+The companion Claude Code sub-agent definition lives at `.claude/agents/pr-reviewer.md`. Use the sub-agent when you want Claude Code to reason over the same structure with repository context; use the CLI when you want a deterministic review comment from a GitHub PR URL.
 
 ## Verification
 

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -28,6 +28,7 @@ RISKY_PATTERNS = (
     ("secret or environment handling", re.compile(r"(?i)\b(secret|api[_-]?key|process\.env|env\.)\b|\.env\b")),
 )
 TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\.test|\.spec)|__tests__|tests?)(/|\.|$)")
+DIFF_HEADER_RE = re.compile(r"^diff --git a/(.*) b/(.*)$")
 
 
 @dataclass(frozen=True)
@@ -51,7 +52,10 @@ class PullRequestDiff:
 def parse_pr_url(url: str) -> Tuple[str, str, str]:
     match = PR_RE.match(url)
     if not match:
-        raise SystemExit("Expected a GitHub PR URL like https://github.com/owner/repo/pull/123")
+        raise SystemExit(
+            "Expected a GitHub PR URL like https://github.com/owner/repo/pull/123; "
+            f"got {short_text(url)!r}"
+        )
     return match.group(1), match.group(2), match.group(3)
 
 
@@ -70,9 +74,36 @@ def fetch_diff(owner: str, repo: str, number: str) -> str:
             text = response.read().decode("utf-8", errors="replace")
             return validate_diff_response(text)
     except urllib.error.HTTPError as exc:
-        raise SystemExit(f"GitHub request failed with HTTP {exc.code}: {url}") from exc
+        raise SystemExit(format_http_error(exc, url)) from exc
     except urllib.error.URLError as exc:
         raise SystemExit(f"GitHub request failed: {exc.reason}") from exc
+
+
+def short_text(value: str, limit: int = 120) -> str:
+    compact = value.replace("\r", "\\r").replace("\n", "\\n")
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3] + "..."
+
+
+def github_json_message(text: str) -> Optional[str]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, dict) and isinstance(payload.get("message"), str):
+        return payload["message"]
+    return None
+
+
+def format_http_error(exc: urllib.error.HTTPError, url: str) -> str:
+    try:
+        body = exc.read().decode("utf-8", errors="replace")
+    except Exception:
+        body = ""
+    message = github_json_message(body.lstrip()) if body else None
+    detail = f": {message}" if message else ""
+    return f"GitHub request failed with HTTP {exc.code}{detail}: {url}"
 
 
 def validate_diff_response(text: str) -> str:
@@ -80,11 +111,7 @@ def validate_diff_response(text: str) -> str:
     if stripped.startswith("<"):
         raise SystemExit("GitHub returned HTML instead of a diff; check authentication or PR visibility.")
     if stripped.startswith("{"):
-        try:
-            payload = json.loads(stripped)
-        except json.JSONDecodeError:
-            payload = {}
-        message = payload.get("message") if isinstance(payload, dict) else None
+        message = github_json_message(stripped)
         detail = f": {message}" if message else "."
         raise SystemExit(f"GitHub returned JSON instead of a diff{detail}")
     if not stripped.startswith("diff --git "):
@@ -96,6 +123,13 @@ def strip_prefix(value: str, prefix: str) -> str:
     if value.startswith(prefix):
         return value[len(prefix):]
     return value
+
+
+def path_from_diff_header(line: str) -> Optional[str]:
+    match = DIFF_HEADER_RE.match(line)
+    if match:
+        return match.group(2)
+    return None
 
 
 def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequestDiff:
@@ -122,7 +156,7 @@ def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequest
     for line in raw_diff.splitlines():
         if line.startswith("diff --git "):
             finish_file()
-            fallback_path = strip_prefix(line.rsplit(" ", 1)[-1], "b/")
+            fallback_path = path_from_diff_header(line) or strip_prefix(line.rsplit(" ", 1)[-1], "b/")
             continue
         if line.startswith("+++ "):
             marker = line[4:]

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -22,7 +22,7 @@ RISKY_PATTERNS = (
     ("destructive shell or git operations", re.compile(r"(?i)\b(rm\s+[^;&|\n]*-[^\s;&|]*r[^\s;&|]*f|git\s+push\b[^\n;&|]*(?:--force|-f\b))")),
     ("secret or environment handling", re.compile(r"(?i)\b(secret|api[_-]?key|process\.env|env\.)\b|\.env\b")),
 )
-TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\\.test|\\.spec)|__tests__|tests?)(/|\\.|$)")
+TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\.test|\.spec)|__tests__|tests?)(/|\.|$)")
 
 
 @dataclass(frozen=True)
@@ -72,6 +72,12 @@ def fetch_diff(owner: str, repo: str, number: str) -> str:
         raise SystemExit(f"GitHub request failed: {exc.reason}") from exc
 
 
+def strip_prefix(value: str, prefix: str) -> str:
+    if value.startswith(prefix):
+        return value[len(prefix):]
+    return value
+
+
 def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequestDiff:
     title = f"{owner}/{repo}#{number}"
     files: list[ChangedFile] = []
@@ -96,7 +102,7 @@ def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequest
     for line in raw_diff.splitlines():
         if line.startswith("diff --git "):
             finish_file()
-            fallback_path = line.rsplit(" ", 1)[-1].removeprefix("b/")
+            fallback_path = strip_prefix(line.rsplit(" ", 1)[-1], "b/")
             continue
         if line.startswith("+++ "):
             marker = line[4:]

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Generate a structured Markdown PR review from a GitHub pull request diff."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")
+RISKY_PATTERNS = (
+    ("SQL data destruction handling", re.compile(r"(?i)(drop\s+table|truncate|delete\s+from|sql|sqlite|db/)")),
+    ("authentication or authorization changes", re.compile(r"(?i)(auth|session|permission|role|token)")),
+    ("billing or payment changes", re.compile(r"(?i)(billing|stripe|invoice|payment|checkout)")),
+    ("destructive shell or git operations", re.compile(r"(?i)(rm\s+-rf|git\s+push\s+--force|drop\s+table|truncate)")),
+    ("secret or environment handling", re.compile(r"(?i)(secret|api[_-]?key|process\.env|\.env)")),
+)
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    path: str
+    added: int
+    deleted: int
+
+
+@dataclass(frozen=True)
+class PullRequestDiff:
+    owner: str
+    repo: str
+    number: str
+    title: str
+    files: tuple[ChangedFile, ...]
+    raw_diff: str
+
+
+def parse_pr_url(url: str) -> tuple[str, str, str]:
+    match = PR_RE.match(url)
+    if not match:
+        raise SystemExit("Expected a GitHub PR URL like https://github.com/owner/repo/pull/123")
+    return match.group(1), match.group(2), match.group(3)
+
+
+def fetch_text(url: str) -> str:
+    headers = {"User-Agent": "claude-review/1.0"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"GitHub request failed with HTTP {exc.code}: {url}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"GitHub request failed: {exc.reason}") from exc
+
+
+def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequestDiff:
+    title = f"{owner}/{repo}#{number}"
+    files: list[ChangedFile] = []
+    current_path: str | None = None
+    added = 0
+    deleted = 0
+
+    for line in raw_diff.splitlines():
+        if line.startswith("diff --git "):
+            if current_path is not None:
+                files.append(ChangedFile(current_path, added, deleted))
+            current_path = line.split(" b/", 1)[-1]
+            added = 0
+            deleted = 0
+            continue
+        if current_path is None:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            added += 1
+        elif line.startswith("-"):
+            deleted += 1
+
+    if current_path is not None:
+        files.append(ChangedFile(current_path, added, deleted))
+
+    return PullRequestDiff(owner, repo, number, title, tuple(files), raw_diff)
+
+
+def summarize_files(files: Iterable[ChangedFile]) -> str:
+    file_list = list(files)
+    if not file_list:
+        return "No changed files were found in the diff."
+    total_added = sum(file.added for file in file_list)
+    total_deleted = sum(file.deleted for file in file_list)
+    top_files = sorted(file_list, key=lambda file: file.added + file.deleted, reverse=True)[:3]
+    names = ", ".join(file.path for file in top_files)
+    return f"The diff changes {len(file_list)} file(s), with {total_added} added and {total_deleted} deleted line(s). The largest changes are in {names}."
+
+
+def detect_risks(pr: PullRequestDiff) -> list[str]:
+    haystack = "\n".join(file.path for file in pr.files) + "\n" + pr.raw_diff
+    risks: list[str] = []
+    for label, pattern in RISKY_PATTERNS:
+        if pattern.search(haystack):
+            risks.append(f"- Review {label}; the diff contains related paths or commands.")
+
+    if not re.search(r"(?i)(test|spec|__tests__|pytest|unittest)", haystack):
+        risks.append("- No test file or test command change is visible, so behavior may rely on manual verification.")
+
+    large_files = [file for file in pr.files if file.added + file.deleted > 250]
+    if large_files:
+        names = ", ".join(file.path for file in large_files[:3])
+        risks.append(f"- Large changes in {names} may hide multiple concerns in one review.")
+
+    return risks or ["- No major risks found in the reviewed diff."]
+
+
+def suggestions(pr: PullRequestDiff) -> list[str]:
+    haystack = "\n".join(file.path for file in pr.files) + "\n" + pr.raw_diff
+    items: list[str] = []
+    if not re.search(r"(?i)(test|spec|__tests__|pytest|unittest)", haystack):
+        items.append("- Add a small focused test or sample output that exercises the main changed behavior.")
+    if re.search(r"(?i)(cli|argparse|command)", haystack):
+        items.append("- Document the exact CLI invocation and at least one expected output snippet.")
+    if re.search(r"(?i)(drop\s+table|truncate|delete\s+from|sql)", haystack):
+        items.append("- Add cases for quoted SQL, semicolon-separated SQL, and safe DELETE statements with WHERE clauses.")
+    if re.search(r"(?i)(hook|bash|shell)", haystack):
+        items.append("- Include one allowed and one denied shell example so reviewers can reproduce the boundary.")
+    if not items:
+        items.append("- Keep the PR scoped to the current behavior and add a regression example if a bug motivated it.")
+    return items
+
+
+def confidence(pr: PullRequestDiff) -> str:
+    if not pr.files:
+        return "Low - The diff did not expose changed files."
+    total_lines = sum(file.added + file.deleted for file in pr.files)
+    if total_lines > 600:
+        return "Medium - The diff is reviewable, but the change size limits confidence without running project tests."
+    return "High - The diff is small enough for a reliable static review, assuming the fetched PR diff is complete."
+
+
+def render_review(pr: PullRequestDiff, pr_url: str) -> str:
+    summary = summarize_files(pr.files)
+    risks = "\n".join(detect_risks(pr))
+    improvements = "\n".join(suggestions(pr))
+    return (
+        "## Summary\n"
+        f"This review covers [{pr.title}]({pr_url}). {summary} "
+        "The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.\n\n"
+        "## Identified Risks\n"
+        f"{risks}\n\n"
+        "## Improvement Suggestions\n"
+        f"{improvements}\n\n"
+        "## Confidence\n"
+        f"{confidence(pr)}\n"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a structured Markdown review for a GitHub PR.")
+    parser.add_argument("--pr", required=True, help="GitHub pull request URL.")
+    parser.add_argument("-o", "--output", help="Optional file path for the Markdown review.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    owner, repo, number = parse_pr_url(args.pr)
+    raw_diff = fetch_text(f"https://github.com/{owner}/{repo}/pull/{number}.diff")
+    pr = parse_diff(owner, repo, number, raw_diff)
+    review = render_review(pr, args.pr)
+
+    if args.output:
+        output = Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(review, encoding="utf-8")
+    else:
+        print(review, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import sys
@@ -11,7 +12,11 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List, Optional, Tuple
+
+
+if sys.version_info < (3, 8):
+    raise SystemExit("claude_review.py requires Python 3.8 or newer.")
 
 
 PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")
@@ -19,7 +24,7 @@ RISKY_PATTERNS = (
     ("SQL data destruction handling", re.compile(r"(?i)\b(drop\s+table|truncate\s+(?:table\s+)?\w+|delete\s+from)\b")),
     ("authentication or authorization changes", re.compile(r"(?i)\b(auth|session|permission|role|jwt|oauth)\b")),
     ("billing or payment changes", re.compile(r"(?i)\b(billing|stripe|invoice|payment|checkout)\b")),
-    ("destructive shell or git operations", re.compile(r"(?i)\b(rm\s+[^;&|\n]*-[^\s;&|]*r[^\s;&|]*f|git\s+push\b[^\n;&|]*(?:--force|-f\b))")),
+    ("destructive shell or git operations", re.compile(r"(?i)\b(rm\s+(?=[^;&|\n]*(?:-[A-Za-z]*r|--recursive))(?=[^;&|\n]*(?:-[A-Za-z]*f|--force))[^;&|\n]*|git\s+push\b[^\n;&|]*(?:--force|-f\b))")),
     ("secret or environment handling", re.compile(r"(?i)\b(secret|api[_-]?key|process\.env|env\.)\b|\.env\b")),
 )
 TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\.test|\.spec)|__tests__|tests?)(/|\.|$)")
@@ -38,12 +43,12 @@ class PullRequestDiff:
     repo: str
     number: str
     title: str
-    files: tuple[ChangedFile, ...]
-    added_lines: tuple[str, ...]
+    files: Tuple[ChangedFile, ...]
+    added_lines: Tuple[str, ...]
     raw_diff: str
 
 
-def parse_pr_url(url: str) -> tuple[str, str, str]:
+def parse_pr_url(url: str) -> Tuple[str, str, str]:
     match = PR_RE.match(url)
     if not match:
         raise SystemExit("Expected a GitHub PR URL like https://github.com/owner/repo/pull/123")
@@ -63,13 +68,28 @@ def fetch_diff(owner: str, repo: str, number: str) -> str:
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             text = response.read().decode("utf-8", errors="replace")
-            if text.lstrip().startswith("<"):
-                raise SystemExit("GitHub returned HTML instead of a diff; check authentication or PR visibility.")
-            return text
+            return validate_diff_response(text)
     except urllib.error.HTTPError as exc:
         raise SystemExit(f"GitHub request failed with HTTP {exc.code}: {url}") from exc
     except urllib.error.URLError as exc:
         raise SystemExit(f"GitHub request failed: {exc.reason}") from exc
+
+
+def validate_diff_response(text: str) -> str:
+    stripped = text.lstrip()
+    if stripped.startswith("<"):
+        raise SystemExit("GitHub returned HTML instead of a diff; check authentication or PR visibility.")
+    if stripped.startswith("{"):
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            payload = {}
+        message = payload.get("message") if isinstance(payload, dict) else None
+        detail = f": {message}" if message else "."
+        raise SystemExit(f"GitHub returned JSON instead of a diff{detail}")
+    if not stripped.startswith("diff --git "):
+        raise SystemExit("GitHub response did not look like a PR diff; check the PR URL, authentication, or rate limits.")
+    return text
 
 
 def strip_prefix(value: str, prefix: str) -> str:
@@ -80,13 +100,13 @@ def strip_prefix(value: str, prefix: str) -> str:
 
 def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequestDiff:
     title = f"{owner}/{repo}#{number}"
-    files: list[ChangedFile] = []
-    current_path: str | None = None
-    fallback_path: str | None = None
+    files: List[ChangedFile] = []
+    current_path: Optional[str] = None
+    fallback_path: Optional[str] = None
     added = 0
     deleted = 0
     in_hunk = False
-    added_lines: list[str] = []
+    added_lines: List[str] = []
 
     def finish_file() -> None:
         nonlocal current_path, fallback_path, added, deleted, in_hunk
@@ -142,9 +162,9 @@ def summarize_files(files: Iterable[ChangedFile]) -> str:
     return f"The diff changes {len(file_list)} file(s), with {total_added} added and {total_deleted} deleted line(s). The largest changes are in {names}."
 
 
-def detect_risks(pr: PullRequestDiff) -> list[str]:
+def detect_risks(pr: PullRequestDiff) -> List[str]:
     haystack = review_haystack(pr)
-    risks: list[str] = []
+    risks: List[str] = []
     for label, pattern in RISKY_PATTERNS:
         if pattern.search(haystack):
             risks.append(f"- Review {label}; the diff contains related paths or commands.")
@@ -160,9 +180,9 @@ def detect_risks(pr: PullRequestDiff) -> list[str]:
     return risks or ["- No major risks found in the reviewed diff."]
 
 
-def suggestions(pr: PullRequestDiff) -> list[str]:
+def suggestions(pr: PullRequestDiff) -> List[str]:
     haystack = review_haystack(pr)
-    items: list[str] = []
+    items: List[str] = []
     if not has_test_file(pr):
         items.append("- Add a small focused test or sample output that exercises the main changed behavior.")
     if re.search(r"(?i)(cli|argparse|command)", haystack):

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 
 if sys.version_info < (3, 8):
@@ -63,16 +63,20 @@ def parse_pr_url(url: str) -> Tuple[str, str, str]:
     return match.group(1), match.group(2), match.group(3)
 
 
-def fetch_diff(owner: str, repo: str, number: str) -> str:
+def github_headers() -> Dict[str, str]:
     headers = {
         "Accept": "application/vnd.github.v3.diff",
         "User-Agent": "claude-review/1.0",
     }
     token = os.environ.get("GITHUB_TOKEN")
     if token:
-        headers["Authorization"] = f"Bearer {token}"
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def fetch_diff(owner: str, repo: str, number: str) -> str:
     url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
-    request = urllib.request.Request(url, headers=headers)
+    request = urllib.request.Request(url, headers=github_headers())
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             text = response.read().decode("utf-8", errors="replace")
@@ -106,8 +110,13 @@ def format_http_error(exc: urllib.error.HTTPError, url: str) -> str:
     except Exception:
         body = ""
     message = github_json_message(body.lstrip()) if body else None
-    detail = f": {message}" if message else ""
-    return f"GitHub request failed with HTTP {exc.code}{detail}: {url}"
+    if message:
+        detail = f": {message.rstrip('.')}"
+    elif body.lstrip().startswith("{"):
+        detail = ": JSON error payload did not include a message field; check authentication, PR visibility, or rate limits"
+    else:
+        detail = ""
+    return f"GitHub request failed with HTTP {exc.code}{detail}. URL: {url}"
 
 
 def validate_diff_response(text: str) -> str:
@@ -116,8 +125,11 @@ def validate_diff_response(text: str) -> str:
         raise SystemExit("GitHub returned HTML instead of a diff; check authentication or PR visibility.")
     if stripped.startswith("{"):
         message = github_json_message(stripped)
-        detail = f": {message}" if message else "."
-        raise SystemExit(f"GitHub returned JSON instead of a diff{detail}")
+        if message:
+            detail = f": {message.rstrip('.')}"
+        else:
+            detail = ": JSON payload did not include a message field; check authentication, PR visibility, or rate limits"
+        raise SystemExit(f"GitHub returned JSON instead of a diff{detail}.")
     if not stripped.startswith("diff --git "):
         raise SystemExit("GitHub response did not look like a PR diff; check the PR URL, authentication, or rate limits.")
     return text
@@ -264,7 +276,7 @@ def render_review(pr: PullRequestDiff, pr_url: str) -> str:
     return (
         "## Summary\n"
         f"This review covers [{pr.title}]({pr_url}). {summary} "
-        "The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.\n\n"
+        "The review is based on the GitHub diff and focuses on implementation risk, test coverage, and maintainability.\n\n"
         "## Identified Risks\n"
         f"{risks}\n\n"
         "## Improvement Suggestions\n"

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
 import urllib.request
@@ -27,7 +28,9 @@ RISKY_PATTERNS = (
     ("destructive shell or git operations", re.compile(r"(?i)\b(rm\s+(?=[^;&|\n]*(?:-[A-Za-z]*r|--recursive))(?=[^;&|\n]*(?:-[A-Za-z]*f|--force))[^;&|\n]*|git\s+push\b[^\n;&|]*(?:--force|-f\b))")),
     ("secret or environment handling", re.compile(r"(?i)\b(secret|api[_-]?key|process\.env|env\.)\b|\.env\b")),
 )
-TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\.test|\.spec)|__tests__|tests?)(/|\.|$)")
+TEST_PATH_RE = re.compile(
+    r"(?i)(^|/)(__tests__|tests?|test_[^/]*|[^/]*_(?:test|spec)\.[^/]+|[^/]*\.(?:test|spec)\.[^/]+)(/|$)"
+)
 DIFF_HEADER_PREFIX = "diff --git a/"
 DIFF_HEADER_SEPARATOR = " b/"
 
@@ -120,19 +123,21 @@ def validate_diff_response(text: str) -> str:
     return text
 
 
-def strip_prefix(value: str, prefix: str) -> str:
-    if value.startswith(prefix):
-        return value[len(prefix):]
-    return value
-
-
 def path_from_diff_header(line: str) -> Optional[str]:
-    if not line.startswith(DIFF_HEADER_PREFIX):
+    if not line.startswith("diff --git "):
         return None
-    rest = line[len(DIFF_HEADER_PREFIX):]
-    if DIFF_HEADER_SEPARATOR not in rest:
+    rest = line[len("diff --git "):]
+    if rest.startswith(("'", '"')):
+        try:
+            parts = shlex.split(rest)
+        except ValueError:
+            return None
+        if len(parts) >= 2 and parts[1].startswith("b/"):
+            return parts[1][2:]
         return None
-    return rest.split(DIFF_HEADER_SEPARATOR, 1)[1]
+    if not rest.startswith("a/") or DIFF_HEADER_SEPARATOR not in rest:
+        return None
+    return rest[len("a/"):].split(DIFF_HEADER_SEPARATOR, 1)[1]
 
 
 def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequestDiff:
@@ -159,7 +164,7 @@ def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequest
     for line in raw_diff.splitlines():
         if line.startswith("diff --git "):
             finish_file()
-            fallback_path = path_from_diff_header(line) or strip_prefix(line.rsplit(" ", 1)[-1], "b/")
+            fallback_path = path_from_diff_header(line)
             continue
         if line.startswith("+++ "):
             marker = line[4:]
@@ -207,7 +212,7 @@ def detect_risks(pr: PullRequestDiff) -> List[str]:
             risks.append(f"- Review {label}; the diff contains related paths or commands.")
 
     if not has_test_file(pr):
-        risks.append("- No test file or test command change is visible, so behavior may rely on manual verification.")
+        risks.append("- No test file change is visible, so behavior may rely on manual verification.")
 
     large_files = [file for file in pr.files if file.added + file.deleted > 250]
     if large_files:

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -286,14 +286,14 @@ def main() -> int:
     owner, repo, number = parse_pr_url(args.pr)
     raw_diff = fetch_diff(owner, repo, number)
     pr = parse_diff(owner, repo, number, raw_diff)
-    review = render_review(pr, args.pr)
+    review_text = render_review(pr, args.pr)
 
     if args.output:
         output = Path(args.output)
         output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(review, encoding="utf-8")
+        output.write_text(review_text, encoding="utf-8")
     else:
-        print(review, end="")
+        print(review_text, end="")
     return 0
 
 

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -16,12 +16,13 @@ from typing import Iterable
 
 PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")
 RISKY_PATTERNS = (
-    ("SQL data destruction handling", re.compile(r"(?i)(drop\s+table|truncate|delete\s+from|sql|sqlite|db/)")),
-    ("authentication or authorization changes", re.compile(r"(?i)(auth|session|permission|role|token)")),
-    ("billing or payment changes", re.compile(r"(?i)(billing|stripe|invoice|payment|checkout)")),
-    ("destructive shell or git operations", re.compile(r"(?i)(rm\s+-rf|git\s+push\s+--force|drop\s+table|truncate)")),
-    ("secret or environment handling", re.compile(r"(?i)(secret|api[_-]?key|process\.env|\.env)")),
+    ("SQL data destruction handling", re.compile(r"(?i)\b(drop\s+table|truncate\s+(?:table\s+)?\w+|delete\s+from)\b")),
+    ("authentication or authorization changes", re.compile(r"(?i)\b(auth|session|permission|role|jwt|oauth)\b")),
+    ("billing or payment changes", re.compile(r"(?i)\b(billing|stripe|invoice|payment|checkout)\b")),
+    ("destructive shell or git operations", re.compile(r"(?i)\b(rm\s+[^;&|\n]*-[^\s;&|]*r[^\s;&|]*f|git\s+push\b[^\n;&|]*(?:--force|-f\b))")),
+    ("secret or environment handling", re.compile(r"(?i)\b(secret|api[_-]?key|process\.env|env\.)\b|\.env\b")),
 )
+TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\\.test|\\.spec)|__tests__|tests?)(/|\\.|$)")
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,7 @@ class PullRequestDiff:
     number: str
     title: str
     files: tuple[ChangedFile, ...]
+    added_lines: tuple[str, ...]
     raw_diff: str
 
 
@@ -48,15 +50,22 @@ def parse_pr_url(url: str) -> tuple[str, str, str]:
     return match.group(1), match.group(2), match.group(3)
 
 
-def fetch_text(url: str) -> str:
-    headers = {"User-Agent": "claude-review/1.0"}
+def fetch_diff(owner: str, repo: str, number: str) -> str:
+    headers = {
+        "Accept": "application/vnd.github.v3.diff",
+        "User-Agent": "claude-review/1.0",
+    }
     token = os.environ.get("GITHUB_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
     request = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
-            return response.read().decode("utf-8", errors="replace")
+            text = response.read().decode("utf-8", errors="replace")
+            if text.lstrip().startswith("<"):
+                raise SystemExit("GitHub returned HTML instead of a diff; check authentication or PR visibility.")
+            return text
     except urllib.error.HTTPError as exc:
         raise SystemExit(f"GitHub request failed with HTTP {exc.code}: {url}") from exc
     except urllib.error.URLError as exc:
@@ -67,30 +76,53 @@ def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequest
     title = f"{owner}/{repo}#{number}"
     files: list[ChangedFile] = []
     current_path: str | None = None
+    fallback_path: str | None = None
     added = 0
     deleted = 0
+    in_hunk = False
+    added_lines: list[str] = []
+
+    def finish_file() -> None:
+        nonlocal current_path, fallback_path, added, deleted, in_hunk
+        path = current_path or fallback_path
+        if path is not None:
+            files.append(ChangedFile(path, added, deleted))
+        current_path = None
+        fallback_path = None
+        added = 0
+        deleted = 0
+        in_hunk = False
 
     for line in raw_diff.splitlines():
         if line.startswith("diff --git "):
-            if current_path is not None:
-                files.append(ChangedFile(current_path, added, deleted))
-            current_path = line.split(" b/", 1)[-1]
-            added = 0
-            deleted = 0
+            finish_file()
+            fallback_path = line.rsplit(" ", 1)[-1].removeprefix("b/")
             continue
-        if current_path is None:
+        if line.startswith("+++ "):
+            marker = line[4:]
+            if marker == "/dev/null":
+                current_path = fallback_path
+            elif marker.startswith("b/"):
+                current_path = marker[2:]
             continue
-        if line.startswith("+++") or line.startswith("---"):
+        if line.startswith("--- "):
+            continue
+        if line.startswith("@@ "):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            continue
+        if line.startswith("\\"):
             continue
         if line.startswith("+"):
             added += 1
+            added_lines.append(line[1:])
         elif line.startswith("-"):
             deleted += 1
 
-    if current_path is not None:
-        files.append(ChangedFile(current_path, added, deleted))
+    finish_file()
 
-    return PullRequestDiff(owner, repo, number, title, tuple(files), raw_diff)
+    return PullRequestDiff(owner, repo, number, title, tuple(files), tuple(added_lines), raw_diff)
 
 
 def summarize_files(files: Iterable[ChangedFile]) -> str:
@@ -105,13 +137,13 @@ def summarize_files(files: Iterable[ChangedFile]) -> str:
 
 
 def detect_risks(pr: PullRequestDiff) -> list[str]:
-    haystack = "\n".join(file.path for file in pr.files) + "\n" + pr.raw_diff
+    haystack = review_haystack(pr)
     risks: list[str] = []
     for label, pattern in RISKY_PATTERNS:
         if pattern.search(haystack):
             risks.append(f"- Review {label}; the diff contains related paths or commands.")
 
-    if not re.search(r"(?i)(test|spec|__tests__|pytest|unittest)", haystack):
+    if not has_test_file(pr):
         risks.append("- No test file or test command change is visible, so behavior may rely on manual verification.")
 
     large_files = [file for file in pr.files if file.added + file.deleted > 250]
@@ -123,9 +155,9 @@ def detect_risks(pr: PullRequestDiff) -> list[str]:
 
 
 def suggestions(pr: PullRequestDiff) -> list[str]:
-    haystack = "\n".join(file.path for file in pr.files) + "\n" + pr.raw_diff
+    haystack = review_haystack(pr)
     items: list[str] = []
-    if not re.search(r"(?i)(test|spec|__tests__|pytest|unittest)", haystack):
+    if not has_test_file(pr):
         items.append("- Add a small focused test or sample output that exercises the main changed behavior.")
     if re.search(r"(?i)(cli|argparse|command)", haystack):
         items.append("- Document the exact CLI invocation and at least one expected output snippet.")
@@ -136,6 +168,16 @@ def suggestions(pr: PullRequestDiff) -> list[str]:
     if not items:
         items.append("- Keep the PR scoped to the current behavior and add a regression example if a bug motivated it.")
     return items
+
+
+def review_haystack(pr: PullRequestDiff) -> str:
+    paths = "\n".join(file.path for file in pr.files)
+    additions = "\n".join(pr.added_lines)
+    return f"{paths}\n{additions}"
+
+
+def has_test_file(pr: PullRequestDiff) -> bool:
+    return any(TEST_PATH_RE.search(file.path) for file in pr.files)
 
 
 def confidence(pr: PullRequestDiff) -> str:
@@ -174,7 +216,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     owner, repo, number = parse_pr_url(args.pr)
-    raw_diff = fetch_text(f"https://github.com/{owner}/{repo}/pull/{number}.diff")
+    raw_diff = fetch_diff(owner, repo, number)
     pr = parse_diff(owner, repo, number, raw_diff)
     review = render_review(pr, args.pr)
 

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -28,7 +28,8 @@ RISKY_PATTERNS = (
     ("secret or environment handling", re.compile(r"(?i)\b(secret|api[_-]?key|process\.env|env\.)\b|\.env\b")),
 )
 TEST_PATH_RE = re.compile(r"(?i)(^|/)(test_[^/]*|[^/]*(_test|\.test|\.spec)|__tests__|tests?)(/|\.|$)")
-DIFF_HEADER_RE = re.compile(r"^diff --git a/(.*) b/(.*)$")
+DIFF_HEADER_PREFIX = "diff --git a/"
+DIFF_HEADER_SEPARATOR = " b/"
 
 
 @dataclass(frozen=True)
@@ -126,10 +127,12 @@ def strip_prefix(value: str, prefix: str) -> str:
 
 
 def path_from_diff_header(line: str) -> Optional[str]:
-    match = DIFF_HEADER_RE.match(line)
-    if match:
-        return match.group(2)
-    return None
+    if not line.startswith(DIFF_HEADER_PREFIX):
+        return None
+    rest = line[len(DIFF_HEADER_PREFIX):]
+    if DIFF_HEADER_SEPARATOR not in rest:
+        return None
+    return rest.split(DIFF_HEADER_SEPARATOR, 1)[1]
 
 
 def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequestDiff:

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -31,7 +31,7 @@ RISKY_PATTERNS = (
 TEST_PATH_RE = re.compile(
     r"(?i)(^|/)(__tests__|tests?|test_[^/]*|[^/]*_(?:test|spec)\.[^/]+|[^/]*\.(?:test|spec)\.[^/]+)(/|$)"
 )
-DIFF_HEADER_PREFIX = "diff --git a/"
+DIFF_HEADER_PREFIX = "diff --git "
 DIFF_HEADER_SEPARATOR = " b/"
 
 
@@ -124,9 +124,9 @@ def validate_diff_response(text: str) -> str:
 
 
 def path_from_diff_header(line: str) -> Optional[str]:
-    if not line.startswith("diff --git "):
+    if not line.startswith(DIFF_HEADER_PREFIX):
         return None
-    rest = line[len("diff --git "):]
+    rest = line[len(DIFF_HEADER_PREFIX):]
     if rest.startswith(("'", '"')):
         try:
             parts = shlex.split(rest)
@@ -162,9 +162,21 @@ def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequest
         in_hunk = False
 
     for line in raw_diff.splitlines():
-        if line.startswith("diff --git "):
+        if line.startswith(DIFF_HEADER_PREFIX):
             finish_file()
             fallback_path = path_from_diff_header(line)
+            continue
+        if line.startswith("@@ "):
+            in_hunk = True
+            continue
+        if in_hunk:
+            if line.startswith("\\"):
+                continue
+            if line.startswith("+"):
+                added += 1
+                added_lines.append(line[1:])
+            elif line.startswith("-"):
+                deleted += 1
             continue
         if line.startswith("+++ "):
             marker = line[4:]
@@ -175,18 +187,6 @@ def parse_diff(owner: str, repo: str, number: str, raw_diff: str) -> PullRequest
             continue
         if line.startswith("--- "):
             continue
-        if line.startswith("@@ "):
-            in_hunk = True
-            continue
-        if not in_hunk:
-            continue
-        if line.startswith("\\"):
-            continue
-        if line.startswith("+"):
-            added += 1
-            added_lines.append(line[1:])
-        elif line.startswith("-"):
-            deleted += 1
 
     finish_file()
 

--- a/agents/pr-reviewer/examples/pr-2400-review.md
+++ b/agents/pr-reviewer/examples/pr-2400-review.md
@@ -2,7 +2,7 @@
 This review covers [claude-builders-bounty/claude-builders-bounty#2400](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400). The diff changes 4 file(s), with 210 added and 0 deleted line(s). The largest changes are in scripts/generate_changelog.py, changelog.sh, examples/CHANGELOG.sample.md. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
-- No test file or test command change is visible, so behavior may rely on manual verification.
+- No test file change is visible, so behavior may rely on manual verification.
 
 ## Improvement Suggestions
 - Add a small focused test or sample output that exercises the main changed behavior.

--- a/agents/pr-reviewer/examples/pr-2400-review.md
+++ b/agents/pr-reviewer/examples/pr-2400-review.md
@@ -2,9 +2,10 @@
 This review covers [claude-builders-bounty/claude-builders-bounty#2400](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400). The diff changes 4 file(s), with 210 added and 0 deleted line(s). The largest changes are in scripts/generate_changelog.py, changelog.sh, examples/CHANGELOG.sample.md. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
-- No major risks found in the reviewed diff.
+- No test file or test command change is visible, so behavior may rely on manual verification.
 
 ## Improvement Suggestions
+- Add a small focused test or sample output that exercises the main changed behavior.
 - Document the exact CLI invocation and at least one expected output snippet.
 - Include one allowed and one denied shell example so reviewers can reproduce the boundary.
 

--- a/agents/pr-reviewer/examples/pr-2400-review.md
+++ b/agents/pr-reviewer/examples/pr-2400-review.md
@@ -1,0 +1,12 @@
+## Summary
+This review covers [claude-builders-bounty/claude-builders-bounty#2400](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400). The diff changes 4 file(s), with 210 added and 0 deleted line(s). The largest changes are in scripts/generate_changelog.py, changelog.sh, examples/CHANGELOG.sample.md. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+
+## Identified Risks
+- No major risks found in the reviewed diff.
+
+## Improvement Suggestions
+- Document the exact CLI invocation and at least one expected output snippet.
+- Include one allowed and one denied shell example so reviewers can reproduce the boundary.
+
+## Confidence
+High - The diff is small enough for a reliable static review, assuming the fetched PR diff is complete.

--- a/agents/pr-reviewer/examples/pr-2400-review.md
+++ b/agents/pr-reviewer/examples/pr-2400-review.md
@@ -1,5 +1,5 @@
 ## Summary
-This review covers [claude-builders-bounty/claude-builders-bounty#2400](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400). The diff changes 4 file(s), with 210 added and 0 deleted line(s). The largest changes are in scripts/generate_changelog.py, changelog.sh, examples/CHANGELOG.sample.md. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+This review covers [claude-builders-bounty/claude-builders-bounty#2400](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400). The diff changes 4 file(s), with 210 added and 0 deleted line(s). The largest changes are in scripts/generate_changelog.py, changelog.sh, examples/CHANGELOG.sample.md. The review is based on the GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
 - No test file change is visible, so behavior may rely on manual verification.

--- a/agents/pr-reviewer/examples/pr-2401-review.md
+++ b/agents/pr-reviewer/examples/pr-2401-review.md
@@ -1,5 +1,5 @@
 ## Summary
-This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 379 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/install.py, hooks/destructive-bash-guard/test_block_destructive_bash.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 474 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/test_block_destructive_bash.py, hooks/destructive-bash-guard/install.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
 - Review SQL data destruction handling; the diff contains related paths or commands.

--- a/agents/pr-reviewer/examples/pr-2401-review.md
+++ b/agents/pr-reviewer/examples/pr-2401-review.md
@@ -1,0 +1,16 @@
+## Summary
+This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 295 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block-destructive-bash.py, hooks/destructive-bash-guard/install.py, hooks/destructive-bash-guard/test_block_destructive_bash.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+
+## Identified Risks
+- Review SQL data destruction handling; the diff contains related paths or commands.
+- Review authentication or authorization changes; the diff contains related paths or commands.
+- Review destructive shell or git operations; the diff contains related paths or commands.
+- Review secret or environment handling; the diff contains related paths or commands.
+
+## Improvement Suggestions
+- Document the exact CLI invocation and at least one expected output snippet.
+- Add cases for quoted SQL, semicolon-separated SQL, and safe DELETE statements with WHERE clauses.
+- Include one allowed and one denied shell example so reviewers can reproduce the boundary.
+
+## Confidence
+High - The diff is small enough for a reliable static review, assuming the fetched PR diff is complete.

--- a/agents/pr-reviewer/examples/pr-2401-review.md
+++ b/agents/pr-reviewer/examples/pr-2401-review.md
@@ -1,9 +1,10 @@
 ## Summary
-This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 327 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/install.py, hooks/destructive-bash-guard/test_block_destructive_bash.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 379 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/install.py, hooks/destructive-bash-guard/test_block_destructive_bash.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
 - Review SQL data destruction handling; the diff contains related paths or commands.
 - Review destructive shell or git operations; the diff contains related paths or commands.
+- Review secret or environment handling; the diff contains related paths or commands.
 
 ## Improvement Suggestions
 - Document the exact CLI invocation and at least one expected output snippet.

--- a/agents/pr-reviewer/examples/pr-2401-review.md
+++ b/agents/pr-reviewer/examples/pr-2401-review.md
@@ -1,5 +1,5 @@
 ## Summary
-This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 474 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/test_block_destructive_bash.py, hooks/destructive-bash-guard/install.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 474 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/test_block_destructive_bash.py, hooks/destructive-bash-guard/install.py. The review is based on the GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
 - Review SQL data destruction handling; the diff contains related paths or commands.

--- a/agents/pr-reviewer/examples/pr-2401-review.md
+++ b/agents/pr-reviewer/examples/pr-2401-review.md
@@ -1,11 +1,9 @@
 ## Summary
-This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 295 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block-destructive-bash.py, hooks/destructive-bash-guard/install.py, hooks/destructive-bash-guard/test_block_destructive_bash.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
+This review covers [claude-builders-bounty/claude-builders-bounty#2401](https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401). The diff changes 5 file(s), with 327 added and 0 deleted line(s). The largest changes are in hooks/destructive-bash-guard/block_destructive_bash.py, hooks/destructive-bash-guard/install.py, hooks/destructive-bash-guard/test_block_destructive_bash.py. The review is based on the public GitHub diff and focuses on implementation risk, test coverage, and maintainability.
 
 ## Identified Risks
 - Review SQL data destruction handling; the diff contains related paths or commands.
-- Review authentication or authorization changes; the diff contains related paths or commands.
 - Review destructive shell or git operations; the diff contains related paths or commands.
-- Review secret or environment handling; the diff contains related paths or commands.
 
 ## Improvement Suggestions
 - Document the exact CLI invocation and at least one expected output snippet.

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import io
+import urllib.error
+
 import claude_review as review
 
 
@@ -35,6 +38,13 @@ index 4444444..0000000
 @@ -1,2 +0,0 @@
 -removed
 -content
+diff --git a/src/old report.md b/src/old report.md
+deleted file mode 100644
+index 5555555..0000000
+--- a/src/old report.md
++++ /dev/null
+@@ -1 +0,0 @@
+-legacy note
 """
 
 
@@ -44,8 +54,9 @@ def test_parse_paths_and_counts() -> None:
         "src/new name.py",
         "tests/test_new_name.py",
         "src/delete_me.py",
+        "src/old report.md",
     ]
-    assert [(file.added, file.deleted) for file in parsed.files] == [(2, 1), (2, 0), (0, 2)]
+    assert [(file.added, file.deleted) for file in parsed.files] == [(2, 1), (2, 0), (0, 2), (0, 1)]
     assert "\\ No newline at end of file" not in parsed.added_lines
 
 
@@ -126,12 +137,36 @@ def test_validate_diff_response_rejects_json_payload() -> None:
         raise AssertionError("Expected JSON API payload to be rejected")
 
 
+def test_parse_pr_url_includes_invalid_input() -> None:
+    try:
+        review.parse_pr_url("https://github.com/owner/repo/issues/123\n")
+    except SystemExit as exc:
+        assert "issues/123" in str(exc)
+    else:
+        raise AssertionError("Expected invalid PR URL to be rejected")
+
+
+def test_http_error_includes_github_message() -> None:
+    error = urllib.error.HTTPError(
+        url="https://api.github.test/repos/o/r/pulls/1",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b'{"message":"API rate limit exceeded"}'),
+    )
+    formatted = review.format_http_error(error, error.url)
+    assert "HTTP 403" in formatted
+    assert "API rate limit exceeded" in formatted
+
+
 def main() -> int:
     test_parse_paths_and_counts()
     test_test_detection_uses_paths_only()
     test_risks_use_added_lines_not_removed_lines()
     test_risk_detection_catches_shell_variants()
     test_validate_diff_response_rejects_json_payload()
+    test_parse_pr_url_includes_invalid_input()
+    test_http_error_includes_github_message()
     print("All PR reviewer checks passed.")
     return 0
 

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -74,6 +74,20 @@ def test_test_detection_uses_paths_only() -> None:
             raw_diff="",
         )
     )
+    assert review.has_test_file(
+        review.PullRequestDiff(
+            owner="owner",
+            repo="repo",
+            number="5",
+            title="owner/repo#5",
+            files=(
+                review.ChangedFile("src/component.test.js", 1, 0),
+                review.ChangedFile("src/component.spec.ts", 1, 0),
+            ),
+            added_lines=(),
+            raw_diff="",
+        )
+    )
 
 
 def test_risks_use_added_lines_not_removed_lines() -> None:

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Smoke tests for the PR reviewer parser and heuristics."""
+
+from __future__ import annotations
+
+import claude_review as review
+
+
+SAMPLE_DIFF = """diff --git a/src/old name.py b/src/new name.py
+similarity index 87%
+rename from src/old name.py
+rename to src/new name.py
+index 1111111..2222222 100644
+--- a/src/old name.py
++++ b/src/new name.py
+@@ -1,3 +1,4 @@
+ context
+-old line
++new line
++print("contest should not count as tests")
+\\ No newline at end of file
+diff --git a/tests/test_new_name.py b/tests/test_new_name.py
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/tests/test_new_name.py
+@@ -0,0 +1,2 @@
++def test_new_name():
++    assert True
+diff --git a/src/delete_me.py b/src/delete_me.py
+deleted file mode 100644
+index 4444444..0000000
+--- a/src/delete_me.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+-removed
+-content
+"""
+
+
+def test_parse_paths_and_counts() -> None:
+    parsed = review.parse_diff("owner", "repo", "1", SAMPLE_DIFF)
+    assert [file.path for file in parsed.files] == [
+        "src/new name.py",
+        "tests/test_new_name.py",
+        "src/delete_me.py",
+    ]
+    assert [(file.added, file.deleted) for file in parsed.files] == [(2, 1), (2, 0), (0, 2)]
+    assert "\\ No newline at end of file" not in parsed.added_lines
+
+
+def test_test_detection_uses_paths_only() -> None:
+    parsed = review.parse_diff("owner", "repo", "1", SAMPLE_DIFF)
+    assert review.has_test_file(parsed)
+
+    no_test = review.PullRequestDiff(
+        owner="owner",
+        repo="repo",
+        number="2",
+        title="owner/repo#2",
+        files=(review.ChangedFile("src/latest.py", 1, 0),),
+        added_lines=("contest attestation",),
+        raw_diff="",
+    )
+    assert not review.has_test_file(no_test)
+    assert review.has_test_file(
+        review.PullRequestDiff(
+            owner="owner",
+            repo="repo",
+            number="4",
+            title="owner/repo#4",
+            files=(review.ChangedFile("hooks/destructive-bash-guard/test_block_destructive_bash.py", 1, 0),),
+            added_lines=(),
+            raw_diff="",
+        )
+    )
+
+
+def test_risks_use_added_lines_not_removed_lines() -> None:
+    raw = """diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1,2 +1,2 @@
+-os.system("rm -rf build")
++print("safe replacement")
+"""
+    parsed = review.parse_diff("owner", "repo", "3", raw)
+    assert not any("destructive shell" in risk for risk in review.detect_risks(parsed))
+
+
+def main() -> int:
+    test_parse_paths_and_counts()
+    test_test_detection_uses_paths_only()
+    test_risks_use_added_lines_not_removed_lines()
+    print("All PR reviewer checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -48,6 +48,18 @@ index 5555555..0000000
 """
 
 
+def pr_for(files, added_lines=()):
+    return review.PullRequestDiff(
+        owner="owner",
+        repo="repo",
+        number="99",
+        title="owner/repo#99",
+        files=tuple(files),
+        added_lines=tuple(added_lines),
+        raw_diff="",
+    )
+
+
 def test_parse_paths_and_counts() -> None:
     parsed = review.parse_diff("owner", "repo", "1", SAMPLE_DIFF)
     assert [file.path for file in parsed.files] == [
@@ -166,6 +178,40 @@ index 1111111..2222222 100644
     assert any("destructive shell" in risk for risk in review.detect_risks(parsed))
 
 
+def test_suggestions_cover_each_heuristic_branch() -> None:
+    no_test = pr_for((review.ChangedFile("src/app.py", 1, 0),), ("print('hello')",))
+    assert any("Add a small focused test" in item for item in review.suggestions(no_test))
+
+    cli = pr_for(
+        (review.ChangedFile("tests/test_cli.py", 1, 0), review.ChangedFile("src/cli.py", 1, 0)),
+        ("parser = argparse.ArgumentParser()",),
+    )
+    assert any("exact CLI invocation" in item for item in review.suggestions(cli))
+
+    sql = pr_for(
+        (review.ChangedFile("tests/test_sql.py", 1, 0), review.ChangedFile("src/db.py", 1, 0)),
+        ("cursor.execute('DELETE FROM users')",),
+    )
+    assert any("quoted SQL" in item for item in review.suggestions(sql))
+
+    shell = pr_for(
+        (review.ChangedFile("tests/test_hook.py", 1, 0), review.ChangedFile("hooks/bash_guard.py", 1, 0)),
+        ("shell = 'bash'",),
+    )
+    assert any("allowed and one denied shell example" in item for item in review.suggestions(shell))
+
+    fallback = pr_for((review.ChangedFile("tests/test_models.py", 1, 0), review.ChangedFile("src/models.py", 1, 0)))
+    assert review.suggestions(fallback) == [
+        "- Keep the PR scoped to the current behavior and add a regression example if a bug motivated it."
+    ]
+
+
+def test_confidence_boundaries() -> None:
+    assert review.confidence(pr_for(())) == "Low - The diff did not expose changed files."
+    assert review.confidence(pr_for((review.ChangedFile("src/app.py", 600, 0),))).startswith("High -")
+    assert review.confidence(pr_for((review.ChangedFile("src/app.py", 601, 0),))).startswith("Medium -")
+
+
 def test_validate_diff_response_rejects_json_payload() -> None:
     try:
         review.validate_diff_response('{"message":"API rate limit exceeded"}')
@@ -204,6 +250,8 @@ def main() -> int:
     test_risks_use_added_lines_not_removed_lines()
     test_missing_test_risk_mentions_test_files_only()
     test_risk_detection_catches_shell_variants()
+    test_suggestions_cover_each_heuristic_branch()
+    test_confidence_boundaries()
     test_validate_diff_response_rejects_json_payload()
     test_parse_pr_url_includes_invalid_input()
     test_http_error_includes_github_message()

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -65,6 +65,10 @@ def test_path_from_diff_header_uses_first_separator() -> None:
         review.path_from_diff_header("diff --git a/src/old name.py b/src/new b name.py")
         == "src/new b name.py"
     )
+    assert (
+        review.path_from_diff_header('diff --git "a/src/old name.py" "b/src/new name.py"')
+        == "src/new name.py"
+    )
     assert review.path_from_diff_header("not a diff header") is None
 
 
@@ -107,6 +111,17 @@ def test_test_detection_uses_paths_only() -> None:
             raw_diff="",
         )
     )
+    assert not review.has_test_file(
+        review.PullRequestDiff(
+            owner="owner",
+            repo="repo",
+            number="6",
+            title="owner/repo#6",
+            files=(review.ChangedFile("docs/foo.specification.md", 1, 0),),
+            added_lines=(),
+            raw_diff="",
+        )
+    )
 
 
 def test_risks_use_added_lines_not_removed_lines() -> None:
@@ -120,6 +135,21 @@ index 1111111..2222222 100644
 """
     parsed = review.parse_diff("owner", "repo", "3", raw)
     assert not any("destructive shell" in risk for risk in review.detect_risks(parsed))
+
+
+def test_missing_test_risk_mentions_test_files_only() -> None:
+    parsed = review.PullRequestDiff(
+        owner="owner",
+        repo="repo",
+        number="7",
+        title="owner/repo#7",
+        files=(review.ChangedFile("src/app.py", 1, 0),),
+        added_lines=("print('hello')",),
+        raw_diff="",
+    )
+    risks = "\n".join(review.detect_risks(parsed))
+    assert "No test file change is visible" in risks
+    assert "test command" not in risks
 
 
 def test_risk_detection_catches_shell_variants() -> None:
@@ -172,6 +202,7 @@ def main() -> int:
     test_path_from_diff_header_uses_first_separator()
     test_test_detection_uses_paths_only()
     test_risks_use_added_lines_not_removed_lines()
+    test_missing_test_risk_mentions_test_files_only()
     test_risk_detection_catches_shell_variants()
     test_validate_diff_response_rejects_json_payload()
     test_parse_pr_url_includes_invalid_input()

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -103,10 +103,35 @@ index 1111111..2222222 100644
     assert not any("destructive shell" in risk for risk in review.detect_risks(parsed))
 
 
+def test_risk_detection_catches_shell_variants() -> None:
+    raw = """diff --git a/deploy.sh b/deploy.sh
+index 1111111..2222222 100644
+--- a/deploy.sh
++++ b/deploy.sh
+@@ -0,0 +1,3 @@
++rm -r -f build
++rm --recursive --force dist
++git push --force origin main
+"""
+    parsed = review.parse_diff("owner", "repo", "6", raw)
+    assert any("destructive shell" in risk for risk in review.detect_risks(parsed))
+
+
+def test_validate_diff_response_rejects_json_payload() -> None:
+    try:
+        review.validate_diff_response('{"message":"API rate limit exceeded"}')
+    except SystemExit as exc:
+        assert "API rate limit exceeded" in str(exc)
+    else:
+        raise AssertionError("Expected JSON API payload to be rejected")
+
+
 def main() -> int:
     test_parse_paths_and_counts()
     test_test_detection_uses_paths_only()
     test_risks_use_added_lines_not_removed_lines()
+    test_risk_detection_catches_shell_variants()
+    test_validate_diff_response_rejects_json_payload()
     print("All PR reviewer checks passed.")
     return 0
 

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -60,6 +60,14 @@ def test_parse_paths_and_counts() -> None:
     assert "\\ No newline at end of file" not in parsed.added_lines
 
 
+def test_path_from_diff_header_uses_first_separator() -> None:
+    assert (
+        review.path_from_diff_header("diff --git a/src/old name.py b/src/new b name.py")
+        == "src/new b name.py"
+    )
+    assert review.path_from_diff_header("not a diff header") is None
+
+
 def test_test_detection_uses_paths_only() -> None:
     parsed = review.parse_diff("owner", "repo", "1", SAMPLE_DIFF)
     assert review.has_test_file(parsed)
@@ -161,6 +169,7 @@ def test_http_error_includes_github_message() -> None:
 
 def main() -> int:
     test_parse_paths_and_counts()
+    test_path_from_diff_header_uses_first_separator()
     test_test_detection_uses_paths_only()
     test_risks_use_added_lines_not_removed_lines()
     test_risk_detection_catches_shell_variants()

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -72,6 +72,20 @@ def test_parse_paths_and_counts() -> None:
     assert "\\ No newline at end of file" not in parsed.added_lines
 
 
+def test_hunk_marker_like_content_is_counted() -> None:
+    raw = """diff --git a/docs/example.md b/docs/example.md
+index 1111111..2222222 100644
+--- a/docs/example.md
++++ b/docs/example.md
+@@ -1,2 +1,2 @@
+--- old markdown fence
++++ new markdown fence
+"""
+    parsed = review.parse_diff("owner", "repo", "8", raw)
+    assert parsed.files == (review.ChangedFile("docs/example.md", 1, 1),)
+    assert parsed.added_lines == ("++ new markdown fence",)
+
+
 def test_path_from_diff_header_uses_first_separator() -> None:
     assert (
         review.path_from_diff_header("diff --git a/src/old name.py b/src/new b name.py")
@@ -245,6 +259,7 @@ def test_http_error_includes_github_message() -> None:
 
 def main() -> int:
     test_parse_paths_and_counts()
+    test_hunk_marker_like_content_is_counted()
     test_path_from_diff_header_uses_first_separator()
     test_test_detection_uses_paths_only()
     test_risks_use_added_lines_not_removed_lines()

--- a/agents/pr-reviewer/test_claude_review.py
+++ b/agents/pr-reviewer/test_claude_review.py
@@ -231,8 +231,19 @@ def test_validate_diff_response_rejects_json_payload() -> None:
         review.validate_diff_response('{"message":"API rate limit exceeded"}')
     except SystemExit as exc:
         assert "API rate limit exceeded" in str(exc)
+        assert str(exc).endswith(".")
     else:
         raise AssertionError("Expected JSON API payload to be rejected")
+
+
+def test_validate_diff_response_explains_json_without_message() -> None:
+    try:
+        review.validate_diff_response('{"errors":["missing"]}')
+    except SystemExit as exc:
+        assert "message field" in str(exc)
+        assert "authentication" in str(exc)
+    else:
+        raise AssertionError("Expected JSON API payload without message to be rejected")
 
 
 def test_parse_pr_url_includes_invalid_input() -> None:
@@ -255,6 +266,32 @@ def test_http_error_includes_github_message() -> None:
     formatted = review.format_http_error(error, error.url)
     assert "HTTP 403" in formatted
     assert "API rate limit exceeded" in formatted
+    assert ". URL: https://api.github.test/repos/o/r/pulls/1" in formatted
+
+
+def test_http_error_explains_json_without_message() -> None:
+    error = urllib.error.HTTPError(
+        url="https://api.github.test/repos/o/r/pulls/1",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=io.BytesIO(b'{"errors":["missing"]}'),
+    )
+    formatted = review.format_http_error(error, error.url)
+    assert "message field" in formatted
+    assert "PR visibility" in formatted
+
+
+def test_github_headers_use_classic_token_scheme() -> None:
+    previous = review.os.environ.get("GITHUB_TOKEN")
+    review.os.environ["GITHUB_TOKEN"] = "example-token"
+    try:
+        assert review.github_headers()["Authorization"] == "token example-token"
+    finally:
+        if previous is None:
+            review.os.environ.pop("GITHUB_TOKEN", None)
+        else:
+            review.os.environ["GITHUB_TOKEN"] = previous
 
 
 def main() -> int:
@@ -268,8 +305,11 @@ def main() -> int:
     test_suggestions_cover_each_heuristic_branch()
     test_confidence_boundaries()
     test_validate_diff_response_rejects_json_payload()
+    test_validate_diff_response_explains_json_without_message()
     test_parse_pr_url_includes_invalid_input()
     test_http_error_includes_github_message()
+    test_http_error_explains_json_without_message()
+    test_github_headers_use_classic_token_scheme()
     print("All PR reviewer checks passed.")
     return 0
 

--- a/claude-review
+++ b/claude-review
@@ -7,14 +7,14 @@ PYTHON_CANDIDATES=("python3" "python" "py -3")
 
 for candidate in "${PYTHON_CANDIDATES[@]}"; do
   read -r -a candidate_cmd <<< "$candidate"
-  if "${candidate_cmd[@]}" -c 'import sys; sys.exit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
+  if "${candidate_cmd[@]}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
     PYTHON_CMD=("${candidate_cmd[@]}")
     break
   fi
 done
 
 if [[ ${#PYTHON_CMD[@]} -eq 0 ]]; then
-  echo "Python 3 is required to run claude-review." >&2
+  echo "Python 3.10 or newer is required to run claude-review." >&2
   exit 1
 fi
 

--- a/claude-review
+++ b/claude-review
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_CMD=()
+PYTHON_CANDIDATES=("python3" "python" "py -3")
+
+for candidate in "${PYTHON_CANDIDATES[@]}"; do
+  read -r -a candidate_cmd <<< "$candidate"
+  if "${candidate_cmd[@]}" --version >/dev/null 2>&1; then
+    PYTHON_CMD=("${candidate_cmd[@]}")
+    break
+  fi
+done
+
+if [[ ${#PYTHON_CMD[@]} -eq 0 ]]; then
+  echo "Python 3 is required to run claude-review." >&2
+  exit 1
+fi
+
+exec "${PYTHON_CMD[@]}" "$SCRIPT_DIR/agents/pr-reviewer/claude_review.py" "$@"

--- a/claude-review
+++ b/claude-review
@@ -7,14 +7,14 @@ PYTHON_CANDIDATES=("python3" "python" "py -3")
 
 for candidate in "${PYTHON_CANDIDATES[@]}"; do
   read -r -a candidate_cmd <<< "$candidate"
-  if "${candidate_cmd[@]}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+  if "${candidate_cmd[@]}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then
     PYTHON_CMD=("${candidate_cmd[@]}")
     break
   fi
 done
 
 if [[ ${#PYTHON_CMD[@]} -eq 0 ]]; then
-  echo "Python 3.10 or newer is required to run claude-review." >&2
+  echo "Python 3.8 or newer is required to run claude-review." >&2
   exit 1
 fi
 

--- a/claude-review
+++ b/claude-review
@@ -7,7 +7,7 @@ PYTHON_CANDIDATES=("python3" "python" "py -3")
 
 for candidate in "${PYTHON_CANDIDATES[@]}"; do
   read -r -a candidate_cmd <<< "$candidate"
-  if "${candidate_cmd[@]}" --version >/dev/null 2>&1; then
+  if "${candidate_cmd[@]}" -c 'import sys; sys.exit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
     PYTHON_CMD=("${candidate_cmd[@]}")
     break
   fi


### PR DESCRIPTION
Closes #4

## Summary
- Adds a Claude Code sub-agent definition at `.claude/agents/pr-reviewer.md`.
- Adds `claude-review --pr <github-pr-url>`, a CLI that fetches a public PR diff and returns structured Markdown.
- Output includes summary, identified risks, improvement suggestions, and confidence score.
- Includes sample outputs for two real PRs: `#2400` and `#2401`.

## Verification
- `python agents\pr-reviewer\claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2400 --output agents\pr-reviewer\examples\pr-2400-review.md`
- `python agents\pr-reviewer\claude_review.py --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401 --output agents\pr-reviewer\examples\pr-2401-review.md`
- `python -m compileall agents\pr-reviewer`
- `C:\Program Files\Git\bin\bash.exe claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2401`
