### PR TITLE
[BOUNTY ] HOOK: Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/README-bounty3.md
+++ b/README-bounty3.md
@@ -1,0 +1,19 @@
+# Pre-Tool-Use Hook
+
+Blocks destructive commands before execution in Claude Code.
+
+## Install
+`ash
+mkdir -p ~/.claude/hooks
+cp pre-tool-use.py ~/.claude/hooks/pre-tool-use
+chmod +x ~/.claude/hooks/pre-tool-use
+`
+
+## Blocks
+- rm -rf, rm -fr, rm --recursive
+- DROP TABLE, DROP DATABASE, TRUNCATE TABLE
+- git push --force, git push -f
+- DELETE FROM without WHERE
+- shutdown, dd, mkfs, chmod 777
+
+All blocked attempts logged to ~/.claude/hooks/blocked.log

--- a/pre-tool-use.py
+++ b/pre-tool-use.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""pre-tool-use hook for Claude Code"""
+import os, sys, json, datetime
+BLOCKED = [
+    "rm -rf", "rm -fr", "rm --recursive",
+    "DROP TABLE", "DROP DATABASE", "TRUNCATE TABLE",
+    "git push --force", "git push -f",
+    "DELETE FROM",
+    "shutdown now", "shutdown -h",
+    "dd if=", "mkfs.",
+    "chmod 777",
+    "wget.*sh",
+]
+LOG = os.path.expanduser("~/.claude/hooks/blocked.log")
+def blocked(cmd):
+    cl = cmd.lower()
+    for p in BLOCKED:
+        if p.lower() in cl:
+            return True
+    if "delete from" in cl and "where" not in cl:
+        return True
+    return False
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+    except Exception:
+        return
+    cmd = data.get("command", "")
+    if not blocked(cmd):
+        print(json.dumps({"blocked": False}))
+        return
+    os.makedirs(os.path.dirname(LOG), exist_ok=True)
+    ts = datetime.datetime.now().isoformat()
+    with open(LOG, "a") as f:
+        f.write(f"[{ts}] [{os.getcwd()}] {cmd}\n")
+    print(json.dumps({"blocked": True, "message": "BLOCKED: " + cmd}))
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Bounty #3 Submission

Solution: pre-tool-use.py - Python hook that blocks destructive bash commands in Claude Code.

Blocks:
- rm -rf, rm -fr
- DROP TABLE, DROP DATABASE, TRUNCATE TABLE
- git push --force, git push -f
- DELETE FROM without WHERE clause
- shutdown, dd, mkfs, chmod 777

Features:
- Follows Claude Code hooks format
- Logs all blocked attempts with timestamp and project path
- Does not interfere with normal commands
- README with 2-command installation