### PR TITLE
Add pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/pre-tool-use-hook/README.md
+++ b/pre-tool-use-hook/README.md
@@ -39,3 +39,9 @@ Safe commands still proceed normally, for example:
 ```bash
 echo "hello"
 ```
+
+## Test
+
+```bash
+python -m unittest discover -s pre-tool-use-hook/tests
+```

--- a/pre-tool-use-hook/README.md
+++ b/pre-tool-use-hook/README.md
@@ -1,0 +1,41 @@
+# Pre-Tool-Use Bash Safety Hook
+
+This bounty submission adds a Claude Code `PreToolUse` hook that blocks a short list of destructive Bash commands before they run.
+
+## What it blocks
+
+- `rm -rf`
+- `git push --force`
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+
+## What it does when it blocks
+
+- Returns a Claude Code `PreToolUse` denial with a clear reason
+- Writes the blocked command to `~/.claude/hooks/blocked.log`
+- Records the current working directory and UTC timestamp
+
+## Install
+
+Run one command from the repo root:
+
+```bash
+python pre-tool-use-hook/install_hook.py
+```
+
+That command copies the hook into `~/.claude/hooks/` and updates `~/.claude/settings.json` so Bash calls are checked automatically.
+
+## Verify
+
+After install, a command like this should be blocked:
+
+```bash
+rm -rf ./build
+```
+
+Safe commands still proceed normally, for example:
+
+```bash
+echo "hello"
+```

--- a/pre-tool-use-hook/block_dangerous_bash.py
+++ b/pre-tool-use-hook/block_dangerous_bash.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,7 +35,15 @@ def _has_rm_rf(command: str) -> bool:
 
 
 def _has_git_push_force(command: str) -> bool:
-    return bool(re.search(r"\bgit\s+push\b.*(--force\b|-f\b)", command))
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = command.split()
+
+    if len(tokens) < 2 or tokens[0] != "git" or tokens[1] != "push":
+        return False
+
+    return "--force" in tokens or "-f" in tokens
 
 
 def _has_drop_table(command: str) -> bool:

--- a/pre-tool-use-hook/block_dangerous_bash.py
+++ b/pre-tool-use-hook/block_dangerous_bash.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks dangerous Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+
+BLOCK_REASONS = {
+    "rm": "Blocked `rm -rf` because recursive force deletes are destructive.",
+    "git_push": "Blocked `git push --force` because force-pushing can overwrite shared history.",
+    "drop_table": "Blocked `DROP TABLE` because it would destroy database data.",
+    "truncate": "Blocked `TRUNCATE` because it would clear table data.",
+    "delete_from": "Blocked `DELETE FROM` without a `WHERE` clause because it would delete every row.",
+}
+
+
+def _normalize(command: str) -> str:
+    return re.sub(r"\s+", " ", command).strip().lower()
+
+
+def _has_rm_rf(command: str) -> bool:
+    return bool(
+        re.search(r"\brm\b\s+(-[^\s]*r[^\s]*f[^\s]*|-f[^\s]*r[^\s]*|-r[^\s]*f[^\s]*)", command)
+        or "rm -rf" in command
+        or "rm -fr" in command
+    )
+
+
+def _has_git_push_force(command: str) -> bool:
+    return bool(re.search(r"\bgit\s+push\b.*(--force\b|-f\b)", command))
+
+
+def _has_drop_table(command: str) -> bool:
+    return "drop table" in command
+
+
+def _has_truncate(command: str) -> bool:
+    return bool(re.search(r"\btruncate\b", command))
+
+
+def _has_delete_without_where(command: str) -> bool:
+    match = re.search(r"\bdelete\s+from\b", command)
+    if not match:
+        return False
+    tail = command[match.end() :]
+    return not re.search(r"\bwhere\b", tail)
+
+
+def _blocked_reason(command: str) -> tuple[str | None, str | None]:
+    normalized = _normalize(command)
+    if _has_rm_rf(normalized):
+        return "rm", BLOCK_REASONS["rm"]
+    if _has_git_push_force(normalized):
+        return "git_push", BLOCK_REASONS["git_push"]
+    if _has_drop_table(normalized):
+        return "drop_table", BLOCK_REASONS["drop_table"]
+    if _has_truncate(normalized):
+        return "truncate", BLOCK_REASONS["truncate"]
+    if _has_delete_without_where(normalized):
+        return "delete_from", BLOCK_REASONS["delete_from"]
+    return None, None
+
+
+def _log_block(command: str, cwd: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        line = f"{timestamp}\t{cwd}\t{command}\t{reason}\n"
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+    except OSError:
+        # Logging should never prevent the hook from blocking a dangerous command.
+        pass
+
+
+def _emit_block(reason: str) -> None:
+    payload: Dict[str, Any] = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    json.dump(payload, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    if not command.strip():
+        return 0
+
+    block_key, reason = _blocked_reason(command)
+    if not reason:
+        return 0
+
+    cwd = str(payload.get("cwd") or os.getcwd())
+    _log_block(command=command, cwd=cwd, reason=reason)
+    _emit_block(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pre-tool-use-hook/install_hook.py
+++ b/pre-tool-use-hook/install_hook.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Install the dangerous Bash blocker into the user's Claude Code config."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def _settings_path() -> Path:
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _hooks_dir() -> Path:
+    return Path.home() / ".claude" / "hooks"
+
+
+def _hook_target() -> Path:
+    return _hooks_dir() / "block_dangerous_bash.py"
+
+
+def _load_settings(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Existing settings file is not valid JSON: {path}") from exc
+
+
+def _write_settings(path: Path, settings: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(settings, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _ensure_hook(settings: dict, python_exe: str, hook_path: Path) -> dict:
+    hooks = settings.setdefault("hooks", {})
+    pre = hooks.setdefault("PreToolUse", [])
+
+    matcher = None
+    for entry in pre:
+        if entry.get("matcher") == "Bash":
+            matcher = entry
+            break
+
+    hook_entry = {
+        "type": "command",
+        "command": python_exe,
+        "args": [str(hook_path)],
+        "timeout": 10,
+    }
+
+    if matcher is None:
+        pre.append({"matcher": "Bash", "hooks": [hook_entry]})
+        return settings
+
+    existing_hooks = matcher.setdefault("hooks", [])
+    filtered = []
+    for item in existing_hooks:
+        if item.get("type") == "command" and item.get("command") == python_exe and item.get("args") == [str(hook_path)]:
+            continue
+        filtered.append(item)
+    filtered.append(hook_entry)
+    matcher["hooks"] = filtered
+    return settings
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent
+    source_hook = repo_root / "block_dangerous_bash.py"
+    if not source_hook.exists():
+        raise SystemExit(f"Missing hook source: {source_hook}")
+
+    hooks_dir = _hooks_dir()
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    target_hook = _hook_target()
+    shutil.copy2(source_hook, target_hook)
+
+    settings = _load_settings(_settings_path())
+    settings = _ensure_hook(settings, sys.executable, target_hook)
+    _write_settings(_settings_path(), settings)
+
+    print(f"Installed hook to {target_hook}")
+    print(f"Updated settings at {_settings_path()}")
+    print("Installation complete. Claude Code will now block the specified dangerous Bash commands.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pre-tool-use-hook/tests/test_block_dangerous_bash.py
+++ b/pre-tool-use-hook/tests/test_block_dangerous_bash.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import os
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "block_dangerous_bash.py"
+
+
+def run_hook(command: str, home: Path | None = None) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": "C:/tmp/project",
+        "tool_input": {"command": command},
+    }
+    env = os.environ.copy()
+    if home is not None:
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+class HookTests(unittest.TestCase):
+    def test_blocks_rm_rf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            proc = run_hook("rm -rf ./build", home=home)
+            self.assertEqual(proc.returncode, 0)
+            data = json.loads(proc.stdout)
+            self.assertEqual(data["hookSpecificOutput"]["permissionDecision"], "deny")
+            log_file = home / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log_file.exists())
+            self.assertIn("rm -rf ./build", log_file.read_text(encoding="utf-8"))
+
+    def test_blocks_force_push_but_not_force_with_lease(self) -> None:
+        blocked = run_hook("git push --force origin main")
+        self.assertEqual(blocked.returncode, 0)
+        self.assertEqual(
+            json.loads(blocked.stdout)["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+
+        allowed = run_hook("git push --force-with-lease origin main")
+        self.assertEqual(allowed.returncode, 0)
+        self.assertEqual(allowed.stdout.strip(), "")
+
+    def test_allows_safe_command(self) -> None:
+        proc = run_hook("echo safe")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Claude Builders Bounty pre-tool-use hook PR

Issue: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3

Claim command:

```text
/opire try
```

Title:

```text
Add pre-tool-use hook that blocks destructive bash commands
```

Body:

```text
/claim #3

Closes #3

## Summary

- Adds a Claude Code `PreToolUse` hook in Python that blocks destructive Bash commands before they run
- Covers `rm -rf`, `git push --force`, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause
- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
- Includes a one-command installer that copies the hook into `~/.claude/hooks/` and updates `~/.claude/settings.json`
- Includes a small test suite that exercises blocked and allowed commands

## Verification

- Ran `python pre-tool-use-hook/install_hook.py` in a temporary home directory
- Confirmed the installer writes a Claude settings entry for `PreToolUse` on `Bash`
- Confirmed the hook returns a PreToolUse denial for `rm -rf ./build`
- Confirmed safe commands like `echo "safe command"` pass through unchanged
- Confirmed blocked attempts are logged to `~/.claude/hooks/blocked.log`
- Ran `python -m unittest discover -s pre-tool-use-hook/tests`

## Install

```bash
python pre-tool-use-hook/install_hook.py
```
```

Files to include in the PR:

```text
pre-tool-use-hook/block_dangerous_bash.py
pre-tool-use-hook/install_hook.py
pre-tool-use-hook/README.md
pre-tool-use-hook/tests/test_block_dangerous_bash.py
```
