### PR TITLE
Add destructive Bash command hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — claude-builders-bounty
+
+> 墨子 Harness · Issue #3
+
+---
+
+## 项目说明
+
+- **项目名称**: claude-builders-bounty
+- **仓库地址**: https://github.com/claude-builders-bounty/claude-builders-bounty.git
+- **技术栈**: Python standard library + shell scripts
+- **目标**: Implement a Claude Code pre-tool-use hook that blocks destructive Bash commands
+- **Bounty链接**: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3
+
+---
+
+## 禁止操作
+
+1. **不要 push 到 main/master** — 始终在 feature 分支工作
+2. **不要 force push** — `git push --force` 绝对禁止，`--force-with-lease` 也不行
+3. **不要修改 CI/CD 配置** — `.github/workflows/`、`Makefile`、`Dockerfile` 不碰
+4. **不要装来路不明的包** — 不新增 npm/pip/cargo 依赖，除非 bounty 明确需要
+5. **不要删别人的代码** — 不删除或重构非自己写的代码
+6. **不要加后门/遥测** — 不插任何数据收集、网络请求、环境变量窃取代码
+7. **不要 `sudo`** — 不执行需要提权的命令
+8. **不要 `curl`/`wget` 下载外部脚本** — 所有依赖通过包管理器
+
+---
+
+## 完成定义
+
+**以下四条命令，退出码必须全部为 0，才算完成：**
+
+1. **类型检查** — `bash scripts/type-check.sh`
+2. **测试** — `bash scripts/test.sh`
+3. **Lint** — `bash scripts/lint.sh`
+4. **构建** — `bash scripts/build.sh`
+
+**额外要求**:
+- [ ] 本地手动验证功能正常
+- [ ] PR 描述清晰：改了什么、为什么、怎么测的
+- [ ] PROGRESS.md 已更新

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,36 @@
+# PROGRESS.md — claude-builders-bounty
+
+> 墨子 Harness · Issue #3
+
+---
+
+## ✅ 已完成
+
+- Initialized Harness files for bounty issue #3
+- Locked the project to Python standard library with no third-party dependencies
+- Added destructive Bash command hook implementation
+- Added local tests for blocked commands, safe commands, and log creation
+- Added four Harness commands: type-check, test, lint, build
+- Ralph verification passed:
+  - `bash scripts/type-check.sh`
+  - `bash scripts/test.sh`
+  - `bash scripts/lint.sh`
+  - `bash scripts/build.sh`
+
+---
+
+## 🔄 进行中
+
+- Open PR for review
+
+---
+
+## 📋 待办
+
+- Respond to reviewer feedback if requested
+
+---
+
+## ⚠️ 已知问题
+
+- None

--- a/README.md
+++ b/README.md
@@ -8,6 +8,30 @@ You're in the right place.
 
 ---
 
+## Destructive Bash Command Hook
+
+This repository includes a Claude Code `pre-tool-use` hook that blocks dangerous Bash commands before they run.
+
+### Install
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/block_destructive_bash.py ~/.claude/hooks/block_destructive_bash.py
+```
+
+Add it to your Claude Code hook configuration as a `PreToolUse` hook for Bash.
+
+### What It Blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` with the timestamp, project path, reason, and attempted command.
+
+---
+
 ## How it works
 
 **To post a bounty**

--- a/dist/block_destructive_bash.py
+++ b/dist/block_destructive_bash.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Block destructive Bash commands before Claude Code runs them."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+BLOCKED_PATTERNS = [
+    ("rm -rf", re.compile(r"(^|[;&|`$()\s])rm\s+[^\n;]*-(?:[^\n;\s]*r[^\n;\s]*f|[^\n;\s]*f[^\n;\s]*r)(?:\s|$)")),
+    ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE)),
+    ("git push --force", re.compile(r"\bgit\s+push\b[^\n;]*\s--force(?:\s|=|$)")),
+    ("TRUNCATE", re.compile(r"\bTRUNCATE\b", re.IGNORECASE)),
+    ("DELETE FROM without WHERE", re.compile(r"\bDELETE\s+FROM\b(?:(?!\bWHERE\b).)*(?:;|$)", re.IGNORECASE | re.DOTALL)),
+]
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    """Claude changes shapes; look in the common places first."""
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd", "script"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+
+    for key in ("command", "cmd", "script"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+
+    return ""
+
+
+def first_block_reason(command: str) -> str | None:
+    for label, pattern in BLOCKED_PATTERNS:
+        if pattern.search(command):
+            return label
+    return None
+
+
+def write_block_log(command: str, project_path: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    clean_command = command.replace("\n", "\\n")
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(f"{timestamp}\t{project_path}\t{reason}\t{clean_command}\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as error:
+        print(f"Could not parse Claude Code hook input: {error}", file=sys.stderr)
+        return 0
+
+    command = extract_command(payload)
+    if not command:
+        return 0
+
+    reason = first_block_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = str(payload.get("cwd") or payload.get("project_path") or os.getcwd())
+    write_block_log(command, project_path, reason)
+    print(
+        f"Blocked destructive Bash command ({reason}). "
+        "Review the command and use a safer, explicit alternative.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Block destructive Bash commands before Claude Code runs them."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+BLOCKED_PATTERNS = [
+    ("rm -rf", re.compile(r"(^|[;&|`$()\s])rm\s+[^\n;]*-(?:[^\n;\s]*r[^\n;\s]*f|[^\n;\s]*f[^\n;\s]*r)(?:\s|$)")),
+    ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE)),
+    ("git push --force", re.compile(r"\bgit\s+push\b[^\n;]*\s--force(?:\s|=|$)")),
+    ("TRUNCATE", re.compile(r"\bTRUNCATE\b", re.IGNORECASE)),
+    ("DELETE FROM without WHERE", re.compile(r"\bDELETE\s+FROM\b(?:(?!\bWHERE\b).)*(?:;|$)", re.IGNORECASE | re.DOTALL)),
+]
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    """Claude changes shapes; look in the common places first."""
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd", "script"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+
+    for key in ("command", "cmd", "script"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+
+    return ""
+
+
+def first_block_reason(command: str) -> str | None:
+    for label, pattern in BLOCKED_PATTERNS:
+        if pattern.search(command):
+            return label
+    return None
+
+
+def write_block_log(command: str, project_path: str, reason: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    clean_command = command.replace("\n", "\\n")
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(f"{timestamp}\t{project_path}\t{reason}\t{clean_command}\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as error:
+        print(f"Could not parse Claude Code hook input: {error}", file=sys.stderr)
+        return 0
+
+    command = extract_command(payload)
+    if not command:
+        return 0
+
+    reason = first_block_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = str(payload.get("cwd") or payload.get("project_path") or os.getcwd())
+    write_block_log(command, project_path, reason)
+    print(
+        f"Blocked destructive Bash command ({reason}). "
+        "Review the command and use a safer, explicit alternative.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p dist
+cp hooks/block_destructive_bash.py dist/block_destructive_bash.py
+chmod +x dist/block_destructive_bash.py

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m py_compile hooks/block_destructive_bash.py tests/test_block_destructive_bash.py

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 tests/test_block_destructive_bash.py

--- a/scripts/type-check.sh
+++ b/scripts/type-check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m py_compile hooks/block_destructive_bash.py tests/test_block_destructive_bash.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '🔍 Checking Python environment...\n'
+python3 --version
+printf '✅ No third-party dependencies required.\n'

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block_destructive_bash.py"
+
+spec = importlib.util.spec_from_file_location("block_destructive_bash", HOOK)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def run_hook(payload, home):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_pattern_detection():
+    blocked = [
+        "rm -rf /tmp/demo",
+        "DROP TABLE users;",
+        "git push origin main --force",
+        "TRUNCATE audit_log;",
+        "DELETE FROM users;",
+    ]
+    for command in blocked:
+        if module.first_block_reason(command) is None:
+            raise AssertionError(f"should block: {command}")
+
+    allowed = [
+        "rm -r /tmp/demo",
+        "git push origin feature/safe",
+        "DELETE FROM users WHERE id = 1;",
+        "echo 'DROP by later migration note'",
+    ]
+    for command in allowed:
+        if module.first_block_reason(command) is not None:
+            raise AssertionError(f"should allow: {command}")
+
+
+def test_hook_blocks_and_logs():
+    with tempfile.TemporaryDirectory() as temp_home:
+        result = run_hook(
+            {"tool_input": {"command": "rm -rf build"}, "cwd": "/repo"},
+            Path(temp_home),
+        )
+        assert_equal(result.returncode, 2, "blocked return code")
+        if "Blocked destructive Bash command" not in result.stderr:
+            raise AssertionError(result.stderr)
+        log_path = Path(temp_home) / ".claude" / "hooks" / "blocked.log"
+        log_text = log_path.read_text(encoding="utf-8")
+        if "/repo\trm -rf" not in log_text:
+            raise AssertionError(log_text)
+
+
+def test_hook_allows_normal_commands():
+    with tempfile.TemporaryDirectory() as temp_home:
+        result = run_hook(
+            {"tool_input": {"command": "git status --short"}, "cwd": "/repo"},
+            Path(temp_home),
+        )
+        assert_equal(result.returncode, 0, "allowed return code")
+        log_path = Path(temp_home) / ".claude" / "hooks" / "blocked.log"
+        if log_path.exists():
+            raise AssertionError("normal commands must not be logged")
+
+
+def main():
+    test_pattern_detection()
+    test_hook_blocks_and_logs()
+    test_hook_allows_normal_commands()
+    print("All tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a Claude Code pre-tool-use hook that blocks destructive Bash commands.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, project path, reason, and command.
- Adds README installation instructions and local Harness verification scripts.

## Blocks
- `rm -rf`
- `DROP TABLE`
- `git push --force`
- `TRUNCATE`
- `DELETE FROM` without `WHERE`

## Testing
- `bash scripts/type-check.sh`
- `bash scripts/test.sh`
- `bash scripts/lint.sh`
- `bash scripts/build.sh`