### PR TITLE
Add Claude Code destructive command blocker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md — claude-builders-bounty
+
+> 墨子 Harness · 自动生成于 2026-06-08
+
+---
+
+## 项目说明
+
+- **项目名称**: claude-builders-bounty
+- **仓库地址**: https://github.com/claude-builders-bounty/claude-builders-bounty.git
+- **技术栈**: Python + Bash, no external dependencies
+- **目标**: Implement bounty #3, a Claude Code PreToolUse hook that blocks destructive Bash commands
+- **Bounty链接**: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3
+
+---
+
+## 禁止操作
+
+1. **不要 push 到 main/master** — 始终在 feature 分支工作
+2. **不要 force push** — `git push --force` 绝对禁止，`--force-with-lease` 也不行
+3. **不要修改 CI/CD 配置** — `.github/workflows/`、`Makefile`、`Dockerfile` 不碰
+4. **不要装来路不明的包** — 不新增 npm/pip/cargo 依赖，除非 bounty 明确需要
+5. **不要删别人的代码** — 不删除或重构非自己写的代码
+6. **不要加后门/遥测** — 不插任何数据收集、网络请求、环境变量窃取代码
+7. **不要 `sudo`** — 不执行需要提权的命令
+8. **不要 `curl`/`wget` 下载外部脚本** — 所有依赖通过包管理器
+
+---
+
+## 完成定义
+
+**以下四条命令，退出码必须全部为 0，才算完成：**
+
+1. **类型检查** — `bash scripts/type-check.sh`
+2. **测试** — `bash scripts/test.sh`
+3. **Lint** — `bash scripts/lint.sh`
+4. **构建** — `bash scripts/build.sh`
+
+**额外要求**:
+- [ ] 本地手动验证功能正常
+- [ ] PR 描述清晰：改了什么、为什么、怎么测的
+- [ ] 截图/GIF 附在 PR 里（如有 UI 变更）
+- [ ] PROGRESS.md 已更新

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,9 @@
+# PROGRESS.md — claude-builders-bounty
+
+## 2026-06-08
+
+- Claimed bounty #3 with `/opire try`.
+- Initialized 墨子 Harness and tailored it for a dependency-free Python/Bash project.
+- Added `pre-tool-use-blocker/hooks/pre_tool_use_blocker.py` for Claude Code `PreToolUse` Bash protection.
+- Added installer, tests, lint/type/build scripts, and concise README install instructions.
+- Validation passed: `bash setup.sh`, `bash scripts/type-check.sh`, `bash scripts/test.sh`, `bash scripts/lint.sh`, `bash scripts/build.sh`.

--- a/pre-tool-use-blocker/README.md
+++ b/pre-tool-use-blocker/README.md
@@ -1,0 +1,31 @@
+# Claude Code destructive command blocker
+
+A dependency-free Claude Code `PreToolUse` hook that stops dangerous Bash commands before they run.
+
+## Install
+
+```bash
+git clone https://github.com/claude-builders-bounty/claude-builders-bounty.git
+cd claude-builders-bounty/pre-tool-use-blocker && bash scripts/install.sh
+```
+
+Then paste the hook block printed by the installer into your Claude Code settings.
+
+## What it blocks
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+
+Blocked attempts are appended to `~/.claude/hooks/blocked.log` with timestamp, attempted command, and project path.
+
+## Verify
+
+```bash
+bash scripts/type-check.sh
+bash scripts/test.sh
+bash scripts/lint.sh
+bash scripts/build.sh
+```

--- a/pre-tool-use-blocker/hooks/pre_tool_use_blocker.py
+++ b/pre-tool-use-blocker/hooks/pre_tool_use_blocker.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+BLOCKED_LOG = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+BLOCK_RULES = [
+    ("rm -rf", re.compile(r"(?:^|[;&|()\s])rm\s+(?:-[^\s]*r[^\s]*f|-f[^\s]*r|-[^\s]*R[^\s]*f|-f[^\s]*R)\b", re.IGNORECASE)),
+    ("DROP TABLE", re.compile(r"\bdrop\s+table\b", re.IGNORECASE)),
+    ("git push --force", re.compile(r"\bgit\s+push\b[^\n;&|]*\s--force(?:\s|=|$)", re.IGNORECASE)),
+    ("TRUNCATE", re.compile(r"\btruncate\b", re.IGNORECASE)),
+    ("DELETE FROM without WHERE", re.compile(r"\bdelete\s+from\b(?:(?!\bwhere\b).)*(?:;|$)", re.IGNORECASE | re.DOTALL)),
+]
+
+
+def _read_event() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"PreToolUse blocker could not parse hook input as JSON: {exc}", file=sys.stderr)
+        return {}
+
+
+def _extract_command(event: dict) -> str:
+    tool_input = event.get("tool_input") or event.get("input") or {}
+    if not isinstance(tool_input, dict):
+        return ""
+
+    for key in ("command", "cmd", "script"):
+        value = tool_input.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _project_path(event: dict) -> str:
+    cwd = event.get("cwd") or event.get("project_path") or event.get("workspace")
+    if isinstance(cwd, str) and cwd:
+        return cwd
+    return os.getcwd()
+
+
+def _blocked_reason(command: str) -> str | None:
+    for label, pattern in BLOCK_RULES:
+        if pattern.search(command):
+            return label
+    return None
+
+
+def _log_block(reason: str, command: str, project_path: str) -> None:
+    BLOCKED_LOG.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    safe_command = command.replace("\n", "\\n")
+    with BLOCKED_LOG.open("a", encoding="utf-8") as log_file:
+        log_file.write(f"{timestamp}\t{project_path}\t{reason}\t{safe_command}\n")
+
+
+def main() -> int:
+    event = _read_event()
+    tool_name = str(event.get("tool_name") or event.get("tool") or "")
+
+    if tool_name and tool_name not in {"Bash", "bash"}:
+        return 0
+
+    command = _extract_command(event)
+    if not command:
+        return 0
+
+    reason = _blocked_reason(command)
+    if not reason:
+        return 0
+
+    project_path = _project_path(event)
+    _log_block(reason, command, project_path)
+    print(
+        "Blocked dangerous bash command before execution. "
+        f"Matched rule: {reason}. Review the command and choose a safer alternative.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pre-tool-use-blocker/scripts/build.sh
+++ b/pre-tool-use-blocker/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bash -n scripts/install.sh
+python3 -m py_compile hooks/pre_tool_use_blocker.py

--- a/pre-tool-use-blocker/scripts/install.sh
+++ b/pre-tool-use-blocker/scripts/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOK_DIR="${HOME}/.claude/hooks"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+mkdir -p "${HOOK_DIR}"
+cp "${REPO_ROOT}/hooks/pre_tool_use_blocker.py" "${HOOK_DIR}/pre_tool_use_blocker.py"
+chmod +x "${HOOK_DIR}/pre_tool_use_blocker.py"
+
+cat <<'MSG'
+Installed ~/.claude/hooks/pre_tool_use_blocker.py
+
+Add this hook to your Claude Code settings:
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "python3 ~/.claude/hooks/pre_tool_use_blocker.py" }
+        ]
+      }
+    ]
+  }
+}
+MSG

--- a/pre-tool-use-blocker/scripts/lint.sh
+++ b/pre-tool-use-blocker/scripts/lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m py_compile hooks/pre_tool_use_blocker.py tests/test_pre_tool_use_blocker.py
+bash -n scripts/*.sh

--- a/pre-tool-use-blocker/scripts/test.sh
+++ b/pre-tool-use-blocker/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 tests/test_pre_tool_use_blocker.py

--- a/pre-tool-use-blocker/scripts/type-check.sh
+++ b/pre-tool-use-blocker/scripts/type-check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m py_compile hooks/pre_tool_use_blocker.py tests/test_pre_tool_use_blocker.py

--- a/pre-tool-use-blocker/tests/test_pre_tool_use_blocker.py
+++ b/pre-tool-use-blocker/tests/test_pre_tool_use_blocker.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "pre_tool_use_blocker.py"
+
+
+def run_hook(command: str, home: str, tool_name: str = "Bash") -> subprocess.CompletedProcess[str]:
+    event = {
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+        "cwd": "/tmp/demo-project",
+    }
+    env = os.environ.copy()
+    env["HOME"] = home
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(event),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+    )
+
+
+def main() -> int:
+    blocked = [
+        "rm -rf dist",
+        "psql -c 'DROP TABLE users'",
+        "git push --force origin main",
+        "TRUNCATE audit_log;",
+        "DELETE FROM users;",
+    ]
+    allowed = [
+        "rm -r dist",
+        "git push --force-with-lease origin feature",
+        "DELETE FROM users WHERE id = 1;",
+        "echo hello",
+    ]
+
+    with TemporaryDirectory() as home:
+        for command in blocked:
+            result = run_hook(command, home)
+            assert result.returncode == 2, (command, result.returncode, result.stderr)
+            assert "Blocked dangerous bash command" in result.stderr
+
+        for command in allowed:
+            result = run_hook(command, home)
+            assert result.returncode == 0, (command, result.returncode, result.stderr)
+
+        result = run_hook("rm -rf dist", home, tool_name="Read")
+        assert result.returncode == 0
+
+        log_path = Path(home) / ".claude" / "hooks" / "blocked.log"
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "/tmp/demo-project" in log_text
+        assert "rm -rf dist" in log_text
+
+    print("pre-tool-use blocker tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../pre-tool-use-blocker"
+bash scripts/build.sh

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../pre-tool-use-blocker"
+bash scripts/lint.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../pre-tool-use-blocker"
+bash scripts/test.sh

--- a/scripts/type-check.sh
+++ b/scripts/type-check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../pre-tool-use-blocker"
+bash scripts/type-check.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔍 检查环境..."
+python3 --version
+bash --version | head -1
+
+echo "📦 无外部依赖，跳过安装"
+echo "✅ 环境准备完成"


### PR DESCRIPTION
Closes #3.\n\n## What changed\n- Added a dependency-free Claude Code PreToolUse hook under `pre-tool-use-blocker/`.\n- Blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` statements without `WHERE`.\n- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, and project path.\n- Added a two-command install README plus local type-check/test/lint/build scripts.\n\n## Validation\n- `bash setup.sh`\n- `bash scripts/type-check.sh`\n- `bash scripts/test.sh`\n- `bash scripts/lint.sh`\n- `bash scripts/build.sh`