### PR TITLE
Add changelog generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ You're in the right place.
 
 ---
 
+## Generate a Changelog
+
+This repo includes `changelog.sh`, a small Bash utility that generates a structured `CHANGELOG.md` from git history.
+
+Setup in 3 steps:
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `chmod +x changelog.sh` once.
+3. Run `./changelog.sh` or `./changelog.sh path/to/CHANGELOG.md`.
+
+The script finds commits since the latest git tag, categorizes them into `Added`, `Fixed`, `Changed`, and `Removed`, then writes a formatted changelog. If the repository has no tags, it uses all commits.
+
+See `examples/sample-output.md` for output generated from this repository.
+
+---
+
 ## How it works
 
 **To post a bounty**

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: changelog.sh must be run inside a git repository." >&2
+  exit 1
+fi
+
+last_tag=""
+if last_tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+  commit_range="${last_tag}..HEAD"
+  since_label="since ${last_tag}"
+else
+  commit_range="HEAD"
+  since_label="for all commits"
+fi
+
+repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+generated_at="$(date -u +%Y-%m-%d)"
+
+mapfile -t commits < <(git log --no-merges --pretty=format:'%s%x09%h' "$commit_range")
+
+declare -a added=()
+declare -a fixed=()
+declare -a changed=()
+declare -a removed=()
+
+clean_subject() {
+  local subject="$1"
+  subject="${subject#[[:space:]]}"
+  subject="${subject%[[:space:]]}"
+  subject="$(printf '%s' "$subject" | sed -E 's/^[a-zA-Z]+(\([^)]+\))?!?:[[:space:]]*//')"
+  printf '%s' "$subject"
+}
+
+append_item() {
+  local category="$1"
+  local subject="$2"
+  local sha="$3"
+  local item="$(clean_subject "$subject") (${sha})"
+
+  case "$category" in
+    added) added+=("$item") ;;
+    fixed) fixed+=("$item") ;;
+    changed) changed+=("$item") ;;
+    removed) removed+=("$item") ;;
+  esac
+}
+
+categorize() {
+  local subject_lower
+  subject_lower="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+
+  case "$subject_lower" in
+    feat:*|feat\(*|add:*|add\(*|added:*|new:*|*" add "*|add\ *) printf 'added' ;;
+    fix:*|fix\(*|bugfix:*|hotfix:*|*fix*|*bug*|*repair*) printf 'fixed' ;;
+    remove:*|remove\(*|removed:*|delete:*|delete\(*|drop:*|drop\(*|*remove*|*delete*) printf 'removed' ;;
+    refactor:*|refactor\(*|change:*|change\(*|changed:*|update:*|update\(*|perf:*|perf\(*|docs:*|docs\(*|style:*|style\(*|test:*|test\(*|chore:*|chore\(*) printf 'changed' ;;
+    *) printf 'changed' ;;
+  esac
+}
+
+for commit in "${commits[@]}"; do
+  subject="${commit%$'\t'*}"
+  sha="${commit##*$'\t'}"
+  append_item "$(categorize "$subject")" "$subject" "$sha"
+done
+
+write_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+
+  printf '### %s\n' "$title"
+  if [ "${#items[@]}" -eq 0 ]; then
+    printf -- '- No changes.\n\n'
+    return
+  fi
+
+  local item
+  for item in "${items[@]}"; do
+    printf -- '- %s\n' "$item"
+  done
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  printf 'Generated for `%s` %s on %s.\n\n' "$repo_name" "$since_label" "$generated_at"
+  printf '## Unreleased\n\n'
+  write_section 'Added' "${added[@]}"
+  write_section 'Fixed' "${fixed[@]}"
+  write_section 'Changed' "${changed[@]}"
+  write_section 'Removed' "${removed[@]}"
+} > "$output_file"
+
+echo "Wrote ${output_file} with ${#commits[@]} commit(s) from ${commit_range}."

--- a/examples/sample-output.md
+++ b/examples/sample-output.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Generated for `claude-builders-bounty` for all commits on 2026-06-09.
+
+## Unreleased
+
+### Added
+- initial README with bounty board (1aeae2a)
+
+### Fixed
+- No changes.
+
+### Changed
+- Initial commit (a80a580)
+
+### Removed
+- No changes.


### PR DESCRIPTION
## Summary
- Add `changelog.sh` to generate a structured `CHANGELOG.md` from git history.
- Categorize commits into `Added`, `Fixed`, `Changed`, and `Removed`.
- Document setup in 3 steps and include sample output generated from this repository.

## Validation
- Ran `bash -n changelog.sh`.
- Ran the script in this repository to generate `examples/sample-output.md`.
- Tested on a temporary real git repository with tag `v1.0.0` and commits for `feat`, `fix`, `docs`, and `remove`; verified only post-tag commits were included and all categories were present.

Closes #1