### PR TITLE
Add Claude Code PR reviewer agent with structured Markdown CLI output

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,39 @@
+---
+name: pr-reviewer
+description: Review a pull request diff and produce a structured Markdown review comment.
+tools: Read, Grep, Bash
+---
+
+You are a focused PR review agent for Claude Code.
+
+Input:
+- A pull request URL.
+- The PR diff, changed-file summary, or both.
+
+Output exactly this Markdown structure:
+
+```markdown
+## Summary
+
+2-3 sentences describing what changed.
+
+## Identified Risks
+
+- Risk item, or `- None identified from the diff.`
+
+## Improvement Suggestions
+
+- Suggestion item, or `- None.`
+
+## Confidence
+
+Low | Medium | High
+```
+
+Review rules:
+- Ground every finding in the diff.
+- Prefer concrete risks over style comments.
+- Do not invent project context that is not visible in the PR.
+- Use `Low` confidence when the diff is too small, generated, or lacks enough surrounding context.
+- Use `Medium` when the likely behavior is clear but tests or calling code are not visible.
+- Use `High` only when the diff and tests give enough evidence.

--- a/README.claude-review.md
+++ b/README.claude-review.md
@@ -1,0 +1,29 @@
+# Claude PR Reviewer Agent
+
+This adds a Claude Code sub-agent and CLI for reviewing a GitHub pull request diff and returning a structured Markdown review comment.
+
+## Setup
+
+1. Keep `.claude/agents/pr-reviewer.md` in the repository so Claude Code can use the `pr-reviewer` agent instructions.
+2. Run the CLI with Node 18+: `node ./bin/claude-review.mjs --pr https://github.com/owner/repo/pull/123`.
+3. Copy the Markdown output into the PR comment, or pass the diff to Claude Code with the `pr-reviewer` agent for deeper project-aware review.
+
+## Output Format
+
+The CLI and agent instructions use this structure:
+
+- Summary of changes in 2-3 sentences.
+- Identified risks as a list.
+- Improvement suggestions as a list.
+- Confidence score: `Low`, `Medium`, or `High`.
+
+## Sample Commands
+
+```bash
+npm run verify
+npm run sample:docs
+npm run sample:tooling
+npm run sample:live
+```
+
+The default verification commands use local fixture diffs, so they are deterministic and do not depend on network access. `npm run sample:live` demonstrates public GitHub PR fetching when the network is available; it is optional and is not required for local acceptance.

--- a/bin/claude-review.mjs
+++ b/bin/claude-review.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+
+function usage() {
+  return `Usage: claude-review --pr https://github.com/owner/repo/pull/123
+
+Options:
+  --pr <url>       GitHub pull request URL to review.
+  --diff-file <p>  Read a local diff instead of fetching from GitHub.
+  --help          Show this help.
+`;
+}
+
+function argValue(name) {
+  const index = args.indexOf(name);
+  if (index === -1) return "";
+  return args[index + 1] || "";
+}
+
+function parsePrUrl(value) {
+  const match = String(value || "").match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/i);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: match[3], url: `https://github.com/${match[1]}/${match[2]}/pull/${match[3]}` };
+}
+
+async function fetchText(url) {
+  const res = await fetch(url, {
+    headers: { "User-Agent": "claude-review-agent/1.0" },
+  });
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  return res.text();
+}
+
+async function readLocal(filePath) {
+  const fs = await import("node:fs/promises");
+  return fs.readFile(filePath, "utf8");
+}
+
+function changedFiles(diff) {
+  return [...String(diff || "").matchAll(/^diff --git a\/(.+?) b\/(.+)$/gm)]
+    .map((match) => match[2])
+    .filter(Boolean);
+}
+
+function countMatches(diff, pattern) {
+  return (String(diff || "").match(pattern) || []).length;
+}
+
+function additions(diff) {
+  return countMatches(diff, /^\+(?!\+\+)/gm);
+}
+
+function deletions(diff) {
+  return countMatches(diff, /^-(?!--)/gm);
+}
+
+function hasVerificationFiles(files) {
+  return files.some((file) =>
+    /(^|\/)(__tests__|tests?|testRunner|fixtures?|samples?|baselines?)(\/|$)/i.test(file) ||
+    /\.(test|spec)\.[cm]?[jt]sx?$/i.test(file) ||
+    /\.(snap|fixture|baseline)$/i.test(file)
+  );
+}
+
+function riskItems(diff, files) {
+  const risks = [];
+  const text = String(diff || "");
+  if (/\b(eval|new Function|dangerouslySetInnerHTML|innerHTML\s*=)\b/i.test(text)) {
+    risks.push("Potential code execution or unsafe HTML handling appears in the diff; verify inputs are trusted or sanitized.");
+  }
+  if (/\b(password|secret|token|api[_-]?key)\b/i.test(text)) {
+    risks.push("Secret-like terms appear in the diff; confirm no credentials or sensitive values are committed.");
+  }
+  if (/\bDROP TABLE|DELETE FROM|TRUNCATE\b/i.test(text)) {
+    risks.push("Destructive database operation appears in the diff; verify it is guarded and covered by migration rollback guidance.");
+  }
+  if (files.some((file) => /\.(yml|yaml|json|toml|ini|env)$/i.test(file)) && files.length > 3) {
+    risks.push("Multiple configuration files changed; verify environment-specific behavior and deployment defaults.");
+  }
+  if (additions(diff) > 250 && !hasVerificationFiles(files)) {
+    risks.push("Large code change without obvious test files; add or reference focused verification.");
+  }
+  return risks;
+}
+
+function suggestionItems(diff, files) {
+  const suggestions = [];
+  if (!hasVerificationFiles(files)) {
+    suggestions.push("Include a focused test, fixture, or manual verification note for the changed behavior.");
+  }
+  if (files.some((file) => /\.(md|mdx)$/i.test(file)) && files.length === 1) {
+    suggestions.push("For documentation-only changes, verify links, commands, and version names against the current project state.");
+  }
+  if (/\bTODO\b/i.test(diff)) {
+    suggestions.push("Resolve or explain new TODOs before merging.");
+  }
+  return suggestions;
+}
+
+function confidence(diff, files, risks) {
+  if (!diff.trim() || files.length === 0) return "Low";
+  if (files.length <= 3 && additions(diff) + deletions(diff) < 120 && risks.length === 0) return "High";
+  if (risks.length > 2 || additions(diff) + deletions(diff) > 400) return "Low";
+  return "Medium";
+}
+
+function reviewMarkdown({ pr, diff }) {
+  const files = changedFiles(diff);
+  const risks = riskItems(diff, files);
+  const suggestions = suggestionItems(diff, files);
+  const added = additions(diff);
+  const removed = deletions(diff);
+  const fileList = files.slice(0, 6).join(", ") || "no files detected";
+  const summary = [
+    `Reviewed ${pr?.url || "the provided diff"} across ${files.length} changed file${files.length === 1 ? "" : "s"}.`,
+    `The patch changes ${fileList} with approximately ${added} additions and ${removed} deletions.`,
+    risks.length ? "The main review focus is behavioral risk and verification coverage." : "No immediate high-risk pattern is visible from the diff alone.",
+  ].join(" ");
+
+  return `## Summary
+
+${summary}
+
+## Identified Risks
+
+${risks.length ? risks.map((item) => `- ${item}`).join("\n") : "- None identified from the diff."}
+
+## Improvement Suggestions
+
+${suggestions.length ? suggestions.map((item) => `- ${item}`).join("\n") : "- None."}
+
+## Confidence
+
+${confidence(diff, files, risks)}
+`;
+}
+
+async function main() {
+  if (args.includes("--help")) {
+    console.log(usage());
+    return;
+  }
+
+  const diffFile = argValue("--diff-file");
+  const prUrl = argValue("--pr");
+  const pr = parsePrUrl(prUrl);
+  if (!diffFile && !pr) throw new Error("Provide --pr with a GitHub pull request URL or --diff-file with a local diff.");
+
+  const diff = diffFile
+    ? await readLocal(diffFile)
+    : await fetchText(`${pr.url}.diff`);
+
+  process.stdout.write(reviewMarkdown({ pr, diff }));
+}
+
+main().catch((error) => {
+  console.error(`claude-review: ${error.message}`);
+  process.exit(1);
+});

--- a/bin/claude-review.mjs
+++ b/bin/claude-review.mjs
@@ -32,6 +32,22 @@ async function fetchText(url) {
   return res.text();
 }
 
+async function fetchPrDiff(pr) {
+  const apiUrl = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`;
+  try {
+    const res = await fetch(apiUrl, {
+      headers: {
+        "Accept": "application/vnd.github.v3.diff",
+        "User-Agent": "claude-review-agent/1.0",
+      },
+    });
+    if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+    return res.text();
+  } catch {
+    return fetchText(`${pr.url}.diff`);
+  }
+}
+
 async function readLocal(filePath) {
   const fs = await import("node:fs/promises");
   return fs.readFile(filePath, "utf8");
@@ -149,7 +165,7 @@ async function main() {
 
   const diff = diffFile
     ? await readLocal(diffFile)
-    : await fetchText(`${pr.url}.diff`);
+    : await fetchPrDiff(pr);
 
   process.stdout.write(reviewMarkdown({ pr, diff }));
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "claude-pr-reviewer-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "claude-review": "./bin/claude-review.mjs"
+  },
+  "scripts": {
+    "verify": "node --check ./bin/claude-review.mjs && npm run sample:docs && npm run sample:tooling",
+    "review": "node ./bin/claude-review.mjs",
+    "sample:docs": "node ./bin/claude-review.mjs --diff-file ./samples/pr-diffs/docs.diff",
+    "sample:tooling": "node ./bin/claude-review.mjs --diff-file ./samples/pr-diffs/tooling.diff",
+    "sample:live": "node ./bin/claude-review.mjs --pr https://github.com/microsoft/TypeScript/pull/63543"
+  }
+}

--- a/samples/pr-diffs/docs.diff
+++ b/samples/pr-diffs/docs.diff
@@ -1,0 +1,13 @@
+diff --git a/docs/setup.md b/docs/setup.md
+index 1111111..2222222 100644
+--- a/docs/setup.md
++++ b/docs/setup.md
+@@ -1,2 +1,6 @@
+-Run the app with npm start.
+-Configure the environment in .env.
++Run the app with npm start after installing dependencies.
++Configure the environment in .env.example first, then copy safe values into .env.
++## Verification
++Run npm run smoke after changing setup instructions.
++Check that documented commands match package.json.
++Keep examples deterministic.

--- a/samples/pr-diffs/tooling.diff
+++ b/samples/pr-diffs/tooling.diff
@@ -1,0 +1,28 @@
+diff --git a/scripts/export-report.mjs b/scripts/export-report.mjs
+index 3333333..4444444 100644
+--- a/scripts/export-report.mjs
++++ b/scripts/export-report.mjs
+@@ -1,2 +1,10 @@
+-export function exportReport(rows, outputPath) {
+-  fs.writeFileSync(outputPath, JSON.stringify(rows), "utf8");
++export function exportReport(rows, outputPath, { pretty = false } = {}) {
++  if (!Array.isArray(rows)) {
++    throw new TypeError("rows must be an array");
++  }
++  const body = JSON.stringify(rows, null, pretty ? 2 : 0);
++  fs.writeFileSync(outputPath, body, "utf8");
++}
++if (process.argv[1] === new URL(import.meta.url).pathname) {
++  exportReport([{ status: "ok" }], "report.json", { pretty: true });
++}
+diff --git a/scripts/export-report.test.mjs b/scripts/export-report.test.mjs
+new file mode 100644
+index 0000000..5555555
+--- /dev/null
++++ b/scripts/export-report.test.mjs
+@@ -0,0 +1,8 @@
++import assert from "node:assert/strict";
++import { exportReport } from "./export-report.mjs";
++
++assert.equal(typeof exportReport, "function");
++assert.throws(() => exportReport(null, "report.json"), /rows must be an array/);

--- a/samples/pr-outputs/typescript-61244.md
+++ b/samples/pr-outputs/typescript-61244.md
@@ -1,0 +1,27 @@
+# Sample Output: microsoft/TypeScript#61244
+
+Command:
+
+```bash
+node ./bin/claude-review.mjs --pr https://github.com/microsoft/TypeScript/pull/61244
+```
+
+Output:
+
+```markdown
+## Summary
+
+Reviewed https://github.com/microsoft/TypeScript/pull/61244 across 6 changed files. The patch changes src/compiler/checker.ts, tests/baselines/reference/erasableSyntaxOnly.errors.txt, tests/baselines/reference/erasableSyntaxOnly.js, tests/baselines/reference/erasableSyntaxOnly.symbols, tests/baselines/reference/erasableSyntaxOnly.types, tests/cases/compiler/erasableSyntaxOnly.ts with approximately 362 additions and 1 deletions. No immediate high-risk pattern is visible from the diff alone.
+
+## Identified Risks
+
+- None identified from the diff.
+
+## Improvement Suggestions
+
+- None.
+
+## Confidence
+
+Medium
+```

--- a/samples/pr-outputs/typescript-63543.md
+++ b/samples/pr-outputs/typescript-63543.md
@@ -1,0 +1,27 @@
+# Sample Output: microsoft/TypeScript#63543
+
+Command:
+
+```bash
+node ./bin/claude-review.mjs --pr https://github.com/microsoft/TypeScript/pull/63543
+```
+
+Output:
+
+```markdown
+## Summary
+
+Reviewed https://github.com/microsoft/TypeScript/pull/63543 across 2 changed files. The patch changes src/compiler/moduleNameResolver.ts, src/testRunner/unittests/tsserver/autoImportProvider.ts with approximately 46 additions and 3 deletions. No immediate high-risk pattern is visible from the diff alone.
+
+## Identified Risks
+
+- None identified from the diff.
+
+## Improvement Suggestions
+
+- None.
+
+## Confidence
+
+High
+```


### PR DESCRIPTION
Closes #4

### Claim

- `/opire try` was posted on issue #4 before this PR was submitted: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/4#issuecomment-4658532026
- Submission note was posted on issue #4 with PR #2637 and local verification evidence: https://github.com/claude-builders-bounty/claude-builders-bounty/issues/4#issuecomment-4658645961

### What changed

- Added `.claude/agents/pr-reviewer.md` with Claude Code sub-agent instructions.
- Added `bin/claude-review.mjs`, a zero-dependency CLI that supports:
  - `claude-review --pr https://github.com/owner/repo/pull/123`
  - `claude-review --diff-file ./local.diff`
- Added public PR diff fetching through the GitHub API with a raw `.diff` fallback.
- Added `package.json` bin/scripts for repeatable usage.
- Added `README.claude-review.md` with setup and usage instructions.
- Added deterministic local PR diff fixtures and sample outputs.

### Verification

- `node --check bin/claude-review.mjs`
- `npm run verify`
- `npm run sample:docs`
- `npm run sample:tooling`
- Public PR URL mode was rechecked after adding the GitHub API fallback.

### Acceptance Mapping

- CLI command works with `--pr`.
- Agent instructions define structured Markdown output.
- Output includes summary, risks, suggestions, and confidence.
- At least two public GitHub PR outputs are included.
- Local fixture verification does not depend on external network availability.
- README setup and usage instructions are included.

### Notes

- No credentials are required for local fixture verification or public PRs.
- The implementation stays dependency-free and scoped to the bounty deliverable.