### PR TITLE
Add git-history changelog generator script

### DIFF
--- a/.claude/skills/generate-changelog/SKILL.md
+++ b/.claude/skills/generate-changelog/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history. Use when the user asks for release notes, a changelog, or categorized changes since the latest tag.
+tools: Bash
+---
+
+# Generate Changelog
+
+1. Confirm the current directory is inside the target git repository.
+2. Run `bash changelog.sh [output_file]`.
+3. Review uncategorized commit subjects and the `Breaking Changes` section.
+4. Report the selected git range and output path.
+
+The script uses the latest reachable tag as the starting point, preserves commit subjects containing delimiters, and groups conventional commits into Breaking Changes, Added, Fixed, Changed, and Removed.
+
+Do not invent release notes that are not supported by git history. If commit messages are ambiguous, leave them in Changed and tell the user what needs manual review.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ You're in the right place.
 
 ---
 
+## Changelog Generator
+
+Generate a structured `CHANGELOG.md` from git history with Added, Fixed, Changed, and Removed sections.
+
+1. Copy `changelog.sh` into any git repository.
+2. Run `bash changelog.sh`.
+3. Review and commit the generated `CHANGELOG.md`.
+
+---
+
 ## Active Bounties
 
 | # | Task | Amount | Status |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ You're in the right place.
 Generate a structured `CHANGELOG.md` from git history with Added, Fixed, Changed, and Removed sections.
 
 1. Copy `changelog.sh` into any git repository.
-2. Run `bash changelog.sh`.
-3. Review and commit the generated `CHANGELOG.md`.
+2. Run `bash changelog.sh [output_file]` (defaults to `CHANGELOG.md`).
+3. Optionally run `chmod +x changelog.sh && ./changelog.sh [output_file]`.
+4. Review and commit the generated changelog.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You're in the right place.
 
 Generate a structured `CHANGELOG.md` from git history with Breaking Changes, Added, Fixed, Changed, and Removed sections.
 
-1. Copy `changelog.sh` into any git repository.
+1. Copy `changelog.sh` and `.claude/skills/generate-changelog/SKILL.md` into any git repository.
 2. Run `bash changelog.sh [output_file]` (defaults to `CHANGELOG.md`).
 3. Optionally run `chmod +x changelog.sh && ./changelog.sh [output_file]`.
 4. Review and commit the generated changelog.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ You're in the right place.
 
 ## Changelog Generator
 
-Generate a structured `CHANGELOG.md` from git history with Added, Fixed, Changed, and Removed sections.
+Generate a structured `CHANGELOG.md` from git history with Breaking Changes, Added, Fixed, Changed, and Removed sections.
 
 1. Copy `changelog.sh` into any git repository.
 2. Run `bash changelog.sh [output_file]` (defaults to `CHANGELOG.md`).
 3. Optionally run `chmod +x changelog.sh && ./changelog.sh [output_file]`.
 4. Review and commit the generated changelog.
+
+Run `bash tests/test_changelog.sh` to verify tag ranges, conventional commit grouping, breaking changes, and subjects containing delimiters.
 
 ---
 

--- a/changelog.sh
+++ b/changelog.sh
@@ -37,7 +37,13 @@ add_entry() {
   esac
 }
 
-while IFS='|' read -r hash subject; do
+contains_word() {
+  local haystack=" $1 "
+  local needle="$2"
+  [[ "$haystack" == *" $needle "* ]]
+}
+
+while IFS=$'\x1f' read -r hash subject; do
   [[ -z "${subject:-}" ]] && continue
 
   lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
@@ -51,48 +57,64 @@ while IFS='|' read -r hash subject; do
     fix|fixed|bug|bugfix|resolve|patch) add_entry fixed "$entry" ;;
     remove|removed|delete|deleted|drop|dropped|deprecate) add_entry removed "$entry" ;;
     *)
-      case "$lower_subject" in
-    *" add "*|*" added "*|*" create "*|*" implement "*) add_entry added "$entry" ;;
-    *" fix "*|*" fixed "*|*" bug "*|*" resolve "*) add_entry fixed "$entry" ;;
-    *" remove "*|*" removed "*|*" delete "*|*" drop "*) add_entry removed "$entry" ;;
-    *) add_entry changed "$entry" ;;
-      esac
+      if contains_word "$lower_subject" add \
+        || contains_word "$lower_subject" added \
+        || contains_word "$lower_subject" create \
+        || contains_word "$lower_subject" implement; then
+        add_entry added "$entry"
+      elif contains_word "$lower_subject" fix \
+        || contains_word "$lower_subject" fixed \
+        || contains_word "$lower_subject" bug \
+        || contains_word "$lower_subject" resolve; then
+        add_entry fixed "$entry"
+      elif contains_word "$lower_subject" remove \
+        || contains_word "$lower_subject" removed \
+        || contains_word "$lower_subject" delete \
+        || contains_word "$lower_subject" drop; then
+        add_entry removed "$entry"
+      else
+        add_entry changed "$entry"
+      fi
       ;;
   esac
-done < <(git log --no-merges --date-order --format='%h|%s' ${range})
+done < <(git log --no-merges --date-order --format='%h%x1f%s' ${range})
+
+has_entries=false
+if (( ${#added[@]} > 0 || ${#fixed[@]} > 0 || ${#changed[@]} > 0 || ${#removed[@]} > 0 )); then
+  has_entries=true
+fi
 
 {
   printf '# Changelog\n\n'
   printf '## %s - %s\n\n' "$today" "$range_label"
   printf 'Repository: `%s`\n\n' "$repo_name"
 
-  if (( ${#added[@]} == 0 && ${#fixed[@]} == 0 && ${#changed[@]} == 0 && ${#removed[@]} == 0 )); then
+  if [[ "$has_entries" == false ]]; then
     printf 'No commits found for this range.\n'
-    exit 0
-  fi
+  else
+    if (( ${#added[@]} > 0 )); then
+      printf '### Added\n'
+      printf '%s\n' "${added[@]}"
+      printf '\n'
+    fi
 
-  if (( ${#added[@]} > 0 )); then
-    printf '### Added\n'
-    printf '%s\n' "${added[@]}"
-    printf '\n'
-  fi
+    if (( ${#fixed[@]} > 0 )); then
+      printf '### Fixed\n'
+      printf '%s\n' "${fixed[@]}"
+      printf '\n'
+    fi
 
-  if (( ${#fixed[@]} > 0 )); then
-    printf '### Fixed\n'
-    printf '%s\n' "${fixed[@]}"
-    printf '\n'
-  fi
+    if (( ${#changed[@]} > 0 )); then
+      printf '### Changed\n'
+      printf '%s\n' "${changed[@]}"
+      printf '\n'
+    fi
 
-  if (( ${#changed[@]} > 0 )); then
-    printf '### Changed\n'
-    printf '%s\n' "${changed[@]}"
-    printf '\n'
-  fi
-
-  if (( ${#removed[@]} > 0 )); then
-    printf '### Removed\n'
-    printf '%s\n' "${removed[@]}"
-    printf '\n'
+    if (( ${#removed[@]} > 0 )); then
+      printf '### Removed\n'
+      printf '%s\n' "${removed[@]}"
+      printf '\n'
+    fi
   fi
 } > "$output_file"
 

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+today="$(date +%Y-%m-%d)"
+
+if [[ -n "$latest_tag" ]]; then
+  range="${latest_tag}..HEAD"
+  range_label="Changes since ${latest_tag}"
+else
+  range=""
+  range_label="All commits"
+fi
+
+added=()
+fixed=()
+changed=()
+removed=()
+
+normalize_subject() {
+  local subject="$1"
+  subject="$(printf '%s' "$subject" | sed -E 's/^(feat|fix|docs|chore|refactor|test|style|perf|build|ci)(\([^)]+\))?!?:[[:space:]]*//')"
+  printf '%s' "$subject"
+}
+
+add_entry() {
+  local category="$1"
+  local line="$2"
+
+  case "$category" in
+    added) added+=("$line") ;;
+    fixed) fixed+=("$line") ;;
+    removed) removed+=("$line") ;;
+    *) changed+=("$line") ;;
+  esac
+}
+
+while IFS='|' read -r hash subject; do
+  [[ -z "${subject:-}" ]] && continue
+
+  lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  prefix="${lower_subject%%:*}"
+  prefix="${prefix%%(*}"
+  clean_subject="$(normalize_subject "$subject")"
+  entry="- ${clean_subject} (${hash})"
+
+  case "$prefix" in
+    feat|add|added|create|implement) add_entry added "$entry" ;;
+    fix|fixed|bug|bugfix|resolve|patch) add_entry fixed "$entry" ;;
+    remove|removed|delete|deleted|drop|dropped|deprecate) add_entry removed "$entry" ;;
+    *)
+      case "$lower_subject" in
+    *" add "*|*" added "*|*" create "*|*" implement "*) add_entry added "$entry" ;;
+    *" fix "*|*" fixed "*|*" bug "*|*" resolve "*) add_entry fixed "$entry" ;;
+    *" remove "*|*" removed "*|*" delete "*|*" drop "*) add_entry removed "$entry" ;;
+    *) add_entry changed "$entry" ;;
+      esac
+      ;;
+  esac
+done < <(git log --no-merges --date-order --format='%h|%s' ${range})
+
+{
+  printf '# Changelog\n\n'
+  printf '## %s - %s\n\n' "$today" "$range_label"
+  printf 'Repository: `%s`\n\n' "$repo_name"
+
+  if (( ${#added[@]} == 0 && ${#fixed[@]} == 0 && ${#changed[@]} == 0 && ${#removed[@]} == 0 )); then
+    printf 'No commits found for this range.\n'
+    exit 0
+  fi
+
+  if (( ${#added[@]} > 0 )); then
+    printf '### Added\n'
+    printf '%s\n' "${added[@]}"
+    printf '\n'
+  fi
+
+  if (( ${#fixed[@]} > 0 )); then
+    printf '### Fixed\n'
+    printf '%s\n' "${fixed[@]}"
+    printf '\n'
+  fi
+
+  if (( ${#changed[@]} > 0 )); then
+    printf '### Changed\n'
+    printf '%s\n' "${changed[@]}"
+    printf '\n'
+  fi
+
+  if (( ${#removed[@]} > 0 )); then
+    printf '### Removed\n'
+    printf '%s\n' "${removed[@]}"
+    printf '\n'
+  fi
+} > "$output_file"
+
+printf 'Generated %s from %s.\n' "$output_file" "$range_label"

--- a/changelog.sh
+++ b/changelog.sh
@@ -18,6 +18,8 @@ added=()
 fixed=()
 changed=()
 removed=()
+breaking=()
+breaking_subject_re='^[[:alpha:]]+(\([^)]+\))?!:'
 
 normalize_subject() {
   local subject="$1"
@@ -30,6 +32,7 @@ add_entry() {
   local line="$2"
 
   case "$category" in
+    breaking) breaking+=("$line") ;;
     added) added+=("$line") ;;
     fixed) fixed+=("$line") ;;
     removed) removed+=("$line") ;;
@@ -43,7 +46,8 @@ contains_word() {
   [[ "$haystack" == *" $needle "* ]]
 }
 
-while IFS=$'\x1f' read -r hash subject; do
+while IFS= read -r -d $'\x1e' record; do
+  IFS=$'\x1f' read -r hash subject body <<< "$record"
   [[ -z "${subject:-}" ]] && continue
 
   lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
@@ -52,11 +56,15 @@ while IFS=$'\x1f' read -r hash subject; do
   clean_subject="$(normalize_subject "$subject")"
   entry="- ${clean_subject} (${hash})"
 
-  case "$prefix" in
-    feat|add|added|create|implement) add_entry added "$entry" ;;
-    fix|fixed|bug|bugfix|resolve|patch) add_entry fixed "$entry" ;;
-    remove|removed|delete|deleted|drop|dropped|deprecate) add_entry removed "$entry" ;;
-    *)
+  if [[ "$subject" =~ $breaking_subject_re ]] \
+    || printf '%s\n' "${body:-}" | grep -Eiq '^BREAKING[ -]CHANGE:'; then
+    add_entry breaking "$entry"
+  else
+    case "$prefix" in
+      feat|add|added|create|implement) add_entry added "$entry" ;;
+      fix|fixed|bug|bugfix|resolve|patch) add_entry fixed "$entry" ;;
+      remove|removed|delete|deleted|drop|dropped|deprecate) add_entry removed "$entry" ;;
+      *)
       if contains_word "$lower_subject" add \
         || contains_word "$lower_subject" added \
         || contains_word "$lower_subject" create \
@@ -76,11 +84,12 @@ while IFS=$'\x1f' read -r hash subject; do
         add_entry changed "$entry"
       fi
       ;;
-  esac
-done < <(git log --no-merges --date-order --format='%h%x1f%s' ${range})
+    esac
+  fi
+done < <(git log --no-merges --date-order --format='%h%x1f%s%x1f%b%x1e' ${range})
 
 has_entries=false
-if (( ${#added[@]} > 0 || ${#fixed[@]} > 0 || ${#changed[@]} > 0 || ${#removed[@]} > 0 )); then
+if (( ${#breaking[@]} > 0 || ${#added[@]} > 0 || ${#fixed[@]} > 0 || ${#changed[@]} > 0 || ${#removed[@]} > 0 )); then
   has_entries=true
 fi
 
@@ -92,6 +101,12 @@ fi
   if [[ "$has_entries" == false ]]; then
     printf 'No commits found for this range.\n'
   else
+    if (( ${#breaking[@]} > 0 )); then
+      printf '### Breaking Changes\n'
+      printf '%s\n' "${breaking[@]}"
+      printf '\n'
+    fi
+
     if (( ${#added[@]} > 0 )); then
       printf '### Added\n'
       printf '%s\n' "${added[@]}"

--- a/examples/changelog-sample.md
+++ b/examples/changelog-sample.md
@@ -1,0 +1,51 @@
+# Changelog
+
+## 2026-06-10 - All commits
+
+Repository: `raycast-multi-translate`
+
+### Added
+- add DeepL translation provider (10a7b9f)
+- support open in web dicts (70fb0aa)
+- source language select (080900e)
+- make config types from a single source of truth (#5) (ef3fb5c)
+- add license (f184ac6)
+- better item selection (549aba5)
+- add a few more actions (331c665)
+- render svg as data url (#3) (0dd074c)
+- add esno to the deps (2728a1f)
+- support spelling check (c638b07)
+- hide from lang when all are the same (ea69e7b)
+- update logo (236986e)
+- add option to disable text selection grab (fd89eef)
+- translate back (948e86c)
+- passive selection grab (dbb16e0)
+- make changes (3447cf8)
+- fork from https://github.com/raycast/extensions/tree/main/extensions/google-translate (3a2ddd6)
+
+### Fixed
+- ensure long text does not overflow searchbar (#13) (f6f5773)
+- from lang (6fc60e7)
+- svg foreground color (faa5a3a)
+- auto clean cache on start up (56bb74f)
+- react hooks can not in condition segment (#2) (7d2f601)
+
+### Changed
+- update deps (cdb6de1)
+- extract spellcheck item logic (#6) (0109dcf)
+- styling (66ac5bb)
+- update readme (3c1c26d)
+- refactor (5863e88)
+- update lint rules (7c062a8)
+- use native spellcheck cli (#4) (b4e3608)
+- restructure (98d1381)
+- layout (9bf21da)
+- clean up (c017c4c)
+- clean up deps (0300ee3)
+- lint (c74b847)
+- update readme (a4da3e3)
+- update (c92bb43)
+- cleanup (7d9776a)
+- readme (5514ccd)
+- trimming (c962a00)
+- deps and lint (679bbff)

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+git -C "$fixture" init -q
+git -C "$fixture" config user.email test@example.com
+git -C "$fixture" config user.name Test
+
+printf 'base\n' > "$fixture/file.txt"
+git -C "$fixture" add file.txt
+git -C "$fixture" commit -qm "chore: initial"
+git -C "$fixture" tag v1.0.0
+
+printf 'feature\n' >> "$fixture/file.txt"
+git -C "$fixture" commit -qam "feat: add export | preserve delimiter"
+printf 'fix\n' >> "$fixture/file.txt"
+git -C "$fixture" commit -qam "fix: handle empty config"
+printf 'breaking\n' >> "$fixture/file.txt"
+git -C "$fixture" commit -qam "feat!: require Node 20"
+
+(cd "$fixture" && bash "$root/changelog.sh" TEST_CHANGELOG.md >/dev/null)
+
+grep -q 'Changes since v1.0.0' "$fixture/TEST_CHANGELOG.md"
+grep -q '### Breaking Changes' "$fixture/TEST_CHANGELOG.md"
+grep -q 'require Node 20' "$fixture/TEST_CHANGELOG.md"
+grep -q '### Added' "$fixture/TEST_CHANGELOG.md"
+grep -q 'add export | preserve delimiter' "$fixture/TEST_CHANGELOG.md"
+grep -q '### Fixed' "$fixture/TEST_CHANGELOG.md"
+grep -q 'handle empty config' "$fixture/TEST_CHANGELOG.md"
+! grep -q 'initial' "$fixture/TEST_CHANGELOG.md"
+
+printf 'changelog regression tests passed\n'

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -5,6 +5,9 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fixture="$(mktemp -d)"
 trap 'rm -rf "$fixture"' EXIT
 
+grep -q '^name: generate-changelog$' "$root/.claude/skills/generate-changelog/SKILL.md"
+grep -q '^tools: Bash$' "$root/.claude/skills/generate-changelog/SKILL.md"
+
 git -C "$fixture" init -q
 git -C "$fixture" config user.email test@example.com
 git -C "$fixture" config user.name Test


### PR DESCRIPTION
Closes #1

Adds a standalone `changelog.sh` generator that builds a structured `CHANGELOG.md` from git history.

What it does:
- Finds the latest git tag and uses `latest_tag..HEAD`, or all commits when no tag exists.
- Categorizes commits into Added, Fixed, Changed, and Removed using conventional commit prefixes, scoped prefixes, and common subject keywords.
- Writes a dated Markdown changelog with commit hashes.
- Includes setup instructions in the README in three steps.
- Includes `examples/changelog-sample.md` generated from the real `antfu/raycast-multi-translate` repo.

Verification:
- Ran `C:\Program Files\Git\bin\bash.exe changelog.sh TEST_CHANGELOG.md` in this repo.
- Created a temporary local tag and verified the script only included commits after that tag.
- Ran the script against `raycast-multi-translate` and saved the generated sample output.
- Ran `git diff --check`.

Note: On this Windows machine, the default `bash` points to a broken WSL install, so I used Git Bash explicitly for verification. On normal Unix/macOS/Linux shells, `bash changelog.sh` is the intended command.