### PR TITLE
Add destructive Bash blocker hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ You're in the right place.
 
 ---
 
+## Destructive Bash Hook
+
+Install a Claude Code `PreToolUse` hook that blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause.
+
+1. Run `python3 hooks/install.py`.
+2. Restart Claude Code.
+
+Blocked attempts are logged to `~/.claude/hooks/blocked.log`.
+
+---
+
 ## Active Bounties
 
 | # | Task | Amount | Status |

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+LOG_PATH = Path(os.environ.get("CLAUDE_BLOCK_LOG", Path.home() / ".claude" / "hooks" / "blocked.log"))
+
+RULES = (
+    (
+        "rm -rf",
+        re.compile(r"(^|[\s;&|()])rm\s+-(?:[A-Za-z]*r[A-Za-z]*f|[A-Za-z]*f[A-Za-z]*r)[A-Za-z]*\b"),
+        "Recursive forced remove commands are blocked.",
+    ),
+    (
+        "rm --recursive --force",
+        re.compile(r"(^|[\s;&|()])rm\b(?=.*\s--recursive\b)(?=.*\s--force\b)", re.DOTALL),
+        "Recursive forced remove commands are blocked.",
+    ),
+    (
+        "DROP TABLE",
+        re.compile(r"\bdrop\s+table\b", re.IGNORECASE),
+        "DROP TABLE is destructive and must be reviewed manually.",
+    ),
+    (
+        "git push --force",
+        re.compile(r"\bgit\s+push\b(?=.*\s--force(?:\b|=)|.*\s-f\b)", re.IGNORECASE | re.DOTALL),
+        "Force-pushing can rewrite shared history.",
+    ),
+    (
+        "TRUNCATE",
+        re.compile(r"\btruncate\b", re.IGNORECASE),
+        "TRUNCATE removes table data and must be reviewed manually.",
+    ),
+)
+
+
+def _project_path(payload: dict) -> str:
+    return (
+        payload.get("cwd")
+        or payload.get("project_dir")
+        or payload.get("projectPath")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+
+
+def _delete_from_without_where(command: str) -> bool:
+    for statement in re.split(r";|\n", command):
+        match = re.search(r"\bdelete\s+from\b", statement, re.IGNORECASE)
+        if not match:
+            continue
+        tail = statement[match.end() :]
+        if not re.search(r"\bwhere\b", tail, re.IGNORECASE):
+            return True
+    return False
+
+
+def blocked_reason(command: str) -> str | None:
+    for label, pattern, reason in RULES:
+        if pattern.search(command):
+            return f"Blocked `{label}`: {reason}"
+
+    if _delete_from_without_where(command):
+        return "Blocked `DELETE FROM` without a WHERE clause: this can delete every row in a table."
+
+    return None
+
+
+def _log_block(payload: dict, command: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": _project_path(payload),
+        "reason": reason,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "")
+    if not command:
+        return 0
+
+    reason = blocked_reason(command)
+    if reason is None:
+        return 0
+
+    _log_block(payload, command, reason)
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -16,7 +16,10 @@ LOG_PATH = Path(os.environ.get("CLAUDE_BLOCK_LOG", Path.home() / ".claude" / "ho
 RULES = (
     (
         "rm -rf",
-        re.compile(r"(^|[\s;&|()])rm\s+-(?:[A-Za-z]*r[A-Za-z]*f|[A-Za-z]*f[A-Za-z]*r)[A-Za-z]*\b"),
+        re.compile(
+            r"(^|[\s;&|()])rm\b(?=[^;&|()]*\s-[A-Za-z]*r)(?=[^;&|()]*\s-[A-Za-z]*f)",
+            re.IGNORECASE,
+        ),
         "Recursive forced remove commands are blocked.",
     ),
     (

--- a/hooks/install.py
+++ b/hooks/install.py
@@ -13,18 +13,13 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_HOOK = REPO_ROOT / "hooks" / "block_destructive_bash.py"
-CLAUDE_DIR = Path.home() / ".claude"
+CLAUDE_DIR = Path(os.environ.get("CLAUDE_HOME", Path.home() / ".claude")).expanduser()
 HOOK_DIR = CLAUDE_DIR / "hooks"
 TARGET_HOOK = HOOK_DIR / "block_destructive_bash.py"
 SETTINGS_PATH = CLAUDE_DIR / "settings.json"
 HOOK_ENTRY = {
     "matcher": "Bash",
-    "hooks": [
-        {
-            "type": "command",
-            "command": 'python3 "$HOME/.claude/hooks/block_destructive_bash.py"',
-        }
-    ],
+    "hooks": [{"type": "command", "command": f'"{sys.executable}" "{TARGET_HOOK}"'}],
 }
 
 
@@ -54,9 +49,11 @@ def main() -> int:
     if HOOK_ENTRY not in pre_tool_use:
         pre_tool_use.append(HOOK_ENTRY)
 
-    with SETTINGS_PATH.open("w", encoding="utf-8") as settings_file:
+    temporary_settings = SETTINGS_PATH.with_suffix(".json.tmp")
+    with temporary_settings.open("w", encoding="utf-8") as settings_file:
         json.dump(settings, settings_file, indent=2)
         settings_file.write("\n")
+    temporary_settings.replace(SETTINGS_PATH)
 
     print(f"Installed hook: {TARGET_HOOK}")
     print(f"Updated settings: {SETTINGS_PATH}")

--- a/hooks/install.py
+++ b/hooks/install.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash guard into ~/.claude/hooks/."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_HOOK = REPO_ROOT / "hooks" / "block_destructive_bash.py"
+CLAUDE_DIR = Path.home() / ".claude"
+HOOK_DIR = CLAUDE_DIR / "hooks"
+TARGET_HOOK = HOOK_DIR / "block_destructive_bash.py"
+SETTINGS_PATH = CLAUDE_DIR / "settings.json"
+HOOK_ENTRY = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": 'python3 "$HOME/.claude/hooks/block_destructive_bash.py"',
+        }
+    ],
+}
+
+
+def load_settings() -> dict:
+    if not SETTINGS_PATH.exists():
+        return {}
+    with SETTINGS_PATH.open("r", encoding="utf-8") as settings_file:
+        return json.load(settings_file)
+
+
+def main() -> int:
+    HOOK_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE_HOOK, TARGET_HOOK)
+    TARGET_HOOK.chmod(TARGET_HOOK.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    settings = load_settings()
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    if HOOK_ENTRY not in pre_tool_use:
+        pre_tool_use.append(HOOK_ENTRY)
+
+    with SETTINGS_PATH.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+    print(f"Installed hook: {TARGET_HOOK}")
+    print(f"Updated settings: {SETTINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/install.py
+++ b/hooks/install.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import stat
+import sys
 from pathlib import Path
 
 
@@ -30,16 +31,23 @@ HOOK_ENTRY = {
 def load_settings() -> dict:
     if not SETTINGS_PATH.exists():
         return {}
-    with SETTINGS_PATH.open("r", encoding="utf-8") as settings_file:
-        return json.load(settings_file)
+    try:
+        with SETTINGS_PATH.open("r", encoding="utf-8") as settings_file:
+            return json.load(settings_file)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RuntimeError(f"Cannot read valid Claude settings from {SETTINGS_PATH}: {exc}") from exc
 
 
 def main() -> int:
     HOOK_DIR.mkdir(parents=True, exist_ok=True)
     shutil.copy2(SOURCE_HOOK, TARGET_HOOK)
-    TARGET_HOOK.chmod(TARGET_HOOK.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    TARGET_HOOK.chmod(TARGET_HOOK.stat().st_mode | stat.S_IXUSR)
 
-    settings = load_settings()
+    try:
+        settings = load_settings()
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
     hooks = settings.setdefault("hooks", {})
     pre_tool_use = hooks.setdefault("PreToolUse", [])
 

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,69 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HOOK = Path(__file__).resolve().parents[1] / "hooks" / "block_destructive_bash.py"
+
+
+def run_hook(command):
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/tmp/example-project",
+    }
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory(prefix="claude-hook-test-") as temp_home:
+        env["CLAUDE_BLOCK_LOG"] = str(Path(temp_home) / "blocked.log")
+        return subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
+
+
+class BlockDestructiveBashTest(unittest.TestCase):
+    def assert_blocked(self, command):
+        result = run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        output = json.loads(result.stdout)
+        decision = output["hookSpecificOutput"]
+        self.assertEqual(decision["hookEventName"], "PreToolUse")
+        self.assertEqual(decision["permissionDecision"], "deny")
+        self.assertTrue(decision["permissionDecisionReason"])
+
+    def test_blocks_destructive_patterns(self):
+        blocked = [
+            "rm -rf dist",
+            "psql -c 'DROP TABLE users'",
+            "git push --force origin main",
+            "mysql -e 'TRUNCATE sessions'",
+            "psql -c 'DELETE FROM users'",
+        ]
+        for command in blocked:
+            with self.subTest(command=command):
+                self.assert_blocked(command)
+
+    def test_allows_normal_bash_commands(self):
+        allowed = [
+            "npm test",
+            "git status --short",
+            "rm dist/app.js",
+            "psql -c 'DELETE FROM users WHERE id = 1'",
+        ]
+        for command in allowed:
+            with self.subTest(command=command):
+                result = run_hook(command)
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -42,8 +42,11 @@ class BlockDestructiveBashTest(unittest.TestCase):
     def test_blocks_destructive_patterns(self):
         blocked = [
             "rm -rf dist",
+            "rm -r -f dist",
+            "rm -f -r dist",
             "psql -c 'DROP TABLE users'",
             "git push --force origin main",
+            "git push -f origin main",
             "mysql -e 'TRUNCATE sessions'",
             "psql -c 'DELETE FROM users'",
         ]

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -19,7 +19,7 @@ def run_hook(command):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory(prefix="claude-hook-test-") as temp_home:
         env["CLAUDE_BLOCK_LOG"] = str(Path(temp_home) / "blocked.log")
-        return subprocess.run(
+        result = subprocess.run(
             [sys.executable, str(HOOK)],
             input=json.dumps(payload),
             text=True,
@@ -27,17 +27,24 @@ def run_hook(command):
             check=False,
             env=env,
         )
+        log_path = Path(env["CLAUDE_BLOCK_LOG"])
+        log_text = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        return result, log_text
 
 
 class BlockDestructiveBashTest(unittest.TestCase):
     def assert_blocked(self, command):
-        result = run_hook(command)
+        result, log_text = run_hook(command)
         self.assertEqual(result.returncode, 0)
         output = json.loads(result.stdout)
         decision = output["hookSpecificOutput"]
         self.assertEqual(decision["hookEventName"], "PreToolUse")
         self.assertEqual(decision["permissionDecision"], "deny")
         self.assertTrue(decision["permissionDecisionReason"])
+        entry = json.loads(log_text)
+        self.assertEqual(entry["attempted_command"], command)
+        self.assertEqual(entry["project_path"], "/tmp/example-project")
+        self.assertIn("timestamp", entry)
 
     def test_blocks_destructive_patterns(self):
         blocked = [
@@ -63,9 +70,35 @@ class BlockDestructiveBashTest(unittest.TestCase):
         ]
         for command in allowed:
             with self.subTest(command=command):
-                result = run_hook(command)
+                result, log_text = run_hook(command)
                 self.assertEqual(result.returncode, 0)
                 self.assertEqual(result.stdout, "")
+                self.assertEqual(log_text, "")
+
+    def test_installer_is_idempotent_and_preserves_settings(self):
+        installer = HOOK.parents[0] / "install.py"
+        with tempfile.TemporaryDirectory(prefix="claude-install-test-") as temp_home:
+            claude_home = Path(temp_home) / ".claude"
+            claude_home.mkdir()
+            settings = claude_home / "settings.json"
+            settings.write_text('{"theme": "dark"}\n', encoding="utf-8")
+            env = os.environ.copy()
+            env["CLAUDE_HOME"] = str(claude_home)
+
+            for _ in range(2):
+                result = subprocess.run(
+                    [sys.executable, str(installer)],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                    env=env,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            installed = json.loads(settings.read_text(encoding="utf-8"))
+            self.assertEqual(installed["theme"], "dark")
+            self.assertEqual(len(installed["hooks"]["PreToolUse"]), 1)
+            self.assertTrue((claude_home / "hooks" / HOOK.name).exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3

Adds a Claude Code `PreToolUse` hook that blocks destructive Bash and SQL commands before they run.

What is included:
- `hooks/block_destructive_bash.py`: reads Claude Code hook JSON from stdin, checks Bash commands, and returns a documented `permissionDecision: deny` response when blocked.
- `hooks/install.py`: installs the hook into `~/.claude/hooks/` and merges a `PreToolUse` Bash matcher into `~/.claude/settings.json`.
- `tests/test_block_destructive_bash.py`: verifies blocked and allowed command behavior.
- README install instructions in two commands.

Blocked patterns:
- `rm -rf` / recursive forced remove variants
- `DROP TABLE`
- `git push --force`
- `TRUNCATE`
- `DELETE FROM` without a `WHERE` clause

Logging:
- Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON with timestamp, attempted command, project path, and reason.

Verification:
- `python tests\test_block_destructive_bash.py`
- Temporary-home install smoke test for `python hooks\install.py`
- `git diff --check`

I referenced the current Claude Code hooks docs for the `PreToolUse` matcher and structured deny output shape.