### PR TITLE
feat: add PR review CLI

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request and return structured, evidence-based Markdown findings.
+tools: Bash, Read, Grep
+---
+
+You are a focused pull request reviewer. Do not modify files or approve automatically.
+
+Given a GitHub PR URL:
+
+1. Run `./claude-review --pr <pull-request-url>` to collect canonical URL, diff statistics, changed files, and deterministic risk signals.
+2. Inspect the actual diff before accepting or refining those signals.
+3. Prioritize correctness, security, data loss, compatibility, and missing tests. Avoid style-only feedback.
+4. Cite changed paths when making a concrete claim.
+
+Return exactly these sections:
+
+- `### Summary of changes` with 2-3 sentences.
+- `### Identified risks`.
+- `### Improvement suggestions`.
+- `### Changed files`.
+- `### Confidence score` using Low, Medium, or High.
+
+Never claim tests passed unless the PR or repository output provides that evidence. If the diff cannot be fetched, explain the failure and ask for a local diff.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ chmod +x claude-review
 ./claude-review --pr https://github.com/owner/repo/pull/123
 ```
 
-The output includes a 2-3 sentence summary, identified risks, improvement suggestions, changed files, and a Low/Medium/High confidence score. A Claude Code sub-agent prompt is available at `examples/pr-review-agent.md`.
+The output includes a 2-3 sentence summary, identified risks, improvement suggestions, changed files, and a Low/Medium/High confidence score. The canonical Claude Code sub-agent is available at `.claude/agents/pr-reviewer.md`.
 
 For offline and CI testing, pass a local unified diff:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ You're in the right place.
 
 ---
 
+## PR Review CLI
+
+Generate a structured Markdown review for a public GitHub pull request.
+
+Setup and usage:
+
+```sh
+chmod +x claude-review
+./claude-review --pr https://github.com/owner/repo/pull/123
+```
+
+The output includes a 2-3 sentence summary, identified risks, improvement suggestions, changed files, and a Low/Medium/High confidence score. A Claude Code sub-agent prompt is available at `examples/pr-review-agent.md`.
+
+---
+
 ## Active Bounties
 
 | # | Task | Amount | Status |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ chmod +x claude-review
 
 The output includes a 2-3 sentence summary, identified risks, improvement suggestions, changed files, and a Low/Medium/High confidence score. A Claude Code sub-agent prompt is available at `examples/pr-review-agent.md`.
 
+For offline and CI testing, pass a local unified diff:
+
+```sh
+./claude-review --pr https://github.com/owner/repo/pull/123 --diff-file change.diff --title "Local review"
+python -m unittest discover -s tests -v
+```
+
 ---
 
 ## Active Bounties

--- a/claude-review
+++ b/claude-review
@@ -50,6 +50,10 @@ def parse_pr_url(pr_url: str) -> tuple[str, str, str]:
     return match.group(1), match.group(2), match.group(3)
 
 
+def canonical_pr_url(owner: str, repo: str, number: str) -> str:
+    return f"https://github.com/{owner}/{repo}/pull/{number}"
+
+
 def parse_diff(diff: str) -> list[FileChange]:
     files: list[FileChange] = []
     current: FileChange | None = None
@@ -90,7 +94,6 @@ def summarize(pr: dict, files: list[FileChange]) -> str:
 def identify_risks(files: list[FileChange], diff: str) -> list[str]:
     risks: list[str] = []
     paths = [file.path.lower() for file in files]
-    lower_diff = diff.lower()
 
     if any(path.endswith((".env", ".pem", ".key")) or ".env" in path for path in paths):
         risks.append("Sensitive configuration files appear in the diff; verify no secrets or machine-specific values are committed.")
@@ -98,7 +101,7 @@ def identify_risks(files: list[FileChange], diff: str) -> list[str]:
         risks.append("Dependency lockfiles changed; confirm the package manager update was intentional and reviewed.")
     if any(".github/workflows/" in path for path in paths):
         risks.append("CI workflow files changed; check permissions, token scopes, and trigger behavior carefully.")
-    if re.search(r"\b(delete from|drop table|truncate|rm -rf|--force)\b", lower_diff):
+    if re.search(r"\b(delete from|drop table|truncate|rm -rf|--force)\b", diff, re.IGNORECASE):
         risks.append("The diff contains destructive command or SQL terms; confirm they are examples/tests rather than executable unsafe paths.")
     if sum(file.additions + file.deletions for file in files) > 500:
         risks.append("Large diff size increases review risk; consider asking for smaller commits or targeted test evidence.")
@@ -172,6 +175,7 @@ def main() -> int:
 
     try:
         owner, repo, number = parse_pr_url(args.pr)
+        pr_url = canonical_pr_url(owner, repo, number)
         api_base = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
         try:
             pr = fetch_json(api_base)
@@ -179,9 +183,9 @@ def main() -> int:
             if exc.code != 403:
                 raise
             pr = {"title": f"{owner}/{repo}#{number}"}
-        diff = fetch_text(args.pr + ".diff")
+        diff = fetch_text(f"{pr_url}.diff")
         files = parse_diff(diff)
-        print(render_markdown(args.pr, pr, files, diff))
+        print(render_markdown(pr_url, pr, files, diff))
     except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
         print(f"claude-review: {exc}", file=sys.stderr)
         return 1

--- a/claude-review
+++ b/claude-review
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Iterable
+
+
+PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")
+
+
+@dataclass
+class FileChange:
+    path: str
+    additions: int = 0
+    deletions: int = 0
+    hunks: int = 0
+
+
+def fetch_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers=github_headers("application/vnd.github+json"))
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def fetch_text(url: str) -> str:
+    request = urllib.request.Request(url, headers=github_headers("application/vnd.github.v3.diff"))
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def github_headers(accept: str) -> dict[str, str]:
+    headers = {"Accept": accept, "User-Agent": "claude-review"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def parse_pr_url(pr_url: str) -> tuple[str, str, str]:
+    match = PR_RE.match(pr_url.strip())
+    if match is None:
+        raise ValueError("Expected a GitHub pull request URL like https://github.com/owner/repo/pull/123")
+    return match.group(1), match.group(2), match.group(3)
+
+
+def parse_diff(diff: str) -> list[FileChange]:
+    files: list[FileChange] = []
+    current: FileChange | None = None
+
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current is not None:
+                files.append(current)
+            target = line.split(" b/", 1)[-1]
+            current = FileChange(path=target)
+        elif current is not None and line.startswith("@@ "):
+            current.hunks += 1
+        elif current is not None and line.startswith("+") and not line.startswith("+++"):
+            current.additions += 1
+        elif current is not None and line.startswith("-") and not line.startswith("---"):
+            current.deletions += 1
+
+    if current is not None:
+        files.append(current)
+    return files
+
+
+def summarize(pr: dict, files: list[FileChange]) -> str:
+    title = pr.get("title", "Untitled PR")
+    changed = len(files)
+    additions = sum(file.additions for file in files)
+    deletions = sum(file.deletions for file in files)
+    main_paths = ", ".join(file.path for file in files[:3]) or "no files"
+    if changed > 3:
+        main_paths += f", and {changed - 3} more"
+    return (
+        f"This PR, \"{title}\", changes {changed} file(s), with {additions} additions and {deletions} deletions. "
+        f"The main touched path(s) are {main_paths}. "
+        "The review below is based on the public PR metadata and unified diff."
+    )
+
+
+def identify_risks(files: list[FileChange], diff: str) -> list[str]:
+    risks: list[str] = []
+    paths = [file.path.lower() for file in files]
+    lower_diff = diff.lower()
+
+    if any(path.endswith((".env", ".pem", ".key")) or ".env" in path for path in paths):
+        risks.append("Sensitive configuration files appear in the diff; verify no secrets or machine-specific values are committed.")
+    if any(path.endswith(("package-lock.json", "pnpm-lock.yaml", "yarn.lock")) for path in paths):
+        risks.append("Dependency lockfiles changed; confirm the package manager update was intentional and reviewed.")
+    if any(".github/workflows/" in path for path in paths):
+        risks.append("CI workflow files changed; check permissions, token scopes, and trigger behavior carefully.")
+    if re.search(r"\b(delete from|drop table|truncate|rm -rf|--force)\b", lower_diff):
+        risks.append("The diff contains destructive command or SQL terms; confirm they are examples/tests rather than executable unsafe paths.")
+    if sum(file.additions + file.deletions for file in files) > 500:
+        risks.append("Large diff size increases review risk; consider asking for smaller commits or targeted test evidence.")
+    if not risks:
+        risks.append("No high-risk patterns were detected from the diff, but runtime behavior still depends on project tests and maintainer review.")
+
+    return risks
+
+
+def suggest_improvements(files: list[FileChange]) -> list[str]:
+    suggestions = [
+        "Run the repository's documented test and lint commands before merge.",
+        "Confirm the PR description links the relevant issue and explains verification performed.",
+    ]
+
+    if any(file.path.lower().endswith((".ts", ".tsx", ".js", ".jsx", ".py")) for file in files):
+        suggestions.append("Check whether changed behavior needs focused unit or integration coverage.")
+    if any(file.path.lower().endswith((".md", ".mdx")) for file in files):
+        suggestions.append("Preview Markdown-rendered documentation to catch formatting regressions.")
+    return suggestions
+
+
+def confidence(files: list[FileChange], risks: Iterable[str]) -> str:
+    risky = [risk for risk in risks if not risk.startswith("No high-risk")]
+    total_changed = sum(file.additions + file.deletions for file in files)
+    if not files or len(risky) >= 2 or total_changed > 800:
+        return "Low"
+    if risky or total_changed > 250:
+        return "Medium"
+    return "High"
+
+
+def render_markdown(pr_url: str, pr: dict, files: list[FileChange], diff: str) -> str:
+    risks = identify_risks(files, diff)
+    suggestions = suggest_improvements(files)
+    score = confidence(files, risks)
+    file_lines = "\n".join(
+        f"- `{file.path}`: +{file.additions}/-{file.deletions} across {file.hunks} hunk(s)" for file in files
+    )
+
+    return f"""## PR Review
+
+Source: {pr_url}
+
+### Summary of changes
+
+{summarize(pr, files)}
+
+### Identified risks
+
+{chr(10).join(f"- {risk}" for risk in risks)}
+
+### Improvement suggestions
+
+{chr(10).join(f"- {suggestion}" for suggestion in suggestions)}
+
+### Changed files
+
+{file_lines or "- No changed files were detected in the diff."}
+
+### Confidence score
+
+{score}
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Review a GitHub PR and print a structured Markdown comment.")
+    parser.add_argument("--pr", required=True, help="GitHub pull request URL")
+    args = parser.parse_args()
+
+    try:
+        owner, repo, number = parse_pr_url(args.pr)
+        api_base = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
+        try:
+            pr = fetch_json(api_base)
+        except urllib.error.HTTPError as exc:
+            if exc.code != 403:
+                raise
+            pr = {"title": f"{owner}/{repo}#{number}"}
+        diff = fetch_text(args.pr + ".diff")
+        files = parse_diff(diff)
+        print(render_markdown(args.pr, pr, files, diff))
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+        print(f"claude-review: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-review
+++ b/claude-review
@@ -9,6 +9,7 @@ import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 
 
@@ -97,6 +98,11 @@ def identify_risks(files: list[FileChange], diff: str) -> list[str]:
 
     if any(path.endswith((".env", ".pem", ".key")) or ".env" in path for path in paths):
         risks.append("Sensitive configuration files appear in the diff; verify no secrets or machine-specific values are committed.")
+    if re.search(
+        r"""(?im)^\+.*\b(api[_-]?key|[a-z0-9_]*(?:token|password|secret)[a-z0-9_]*)\s*[:=]\s*["'][^"']+["']""",
+        diff,
+    ):
+        risks.append("A credential-like literal was added; verify it is a harmless fixture and not a real secret.")
     if any(path.endswith(("package-lock.json", "pnpm-lock.yaml", "yarn.lock")) for path in paths):
         risks.append("Dependency lockfiles changed; confirm the package manager update was intentional and reviewed.")
     if any(".github/workflows/" in path for path in paths):
@@ -171,22 +177,28 @@ Source: {pr_url}
 def main() -> int:
     parser = argparse.ArgumentParser(description="Review a GitHub PR and print a structured Markdown comment.")
     parser.add_argument("--pr", required=True, help="GitHub pull request URL")
+    parser.add_argument("--diff-file", help="Review a local unified diff instead of fetching it from GitHub")
+    parser.add_argument("--title", help="PR title to use with --diff-file")
     args = parser.parse_args()
 
     try:
         owner, repo, number = parse_pr_url(args.pr)
         pr_url = canonical_pr_url(owner, repo, number)
-        api_base = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
-        try:
-            pr = fetch_json(api_base)
-        except urllib.error.HTTPError as exc:
-            if exc.code != 403:
-                raise
-            pr = {"title": f"{owner}/{repo}#{number}"}
-        diff = fetch_text(f"{pr_url}.diff")
+        if args.diff_file:
+            pr = {"title": args.title or f"{owner}/{repo}#{number}"}
+            diff = Path(args.diff_file).read_text(encoding="utf-8")
+        else:
+            api_base = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
+            try:
+                pr = fetch_json(api_base)
+            except urllib.error.HTTPError as exc:
+                if exc.code != 403:
+                    raise
+                pr = {"title": f"{owner}/{repo}#{number}"}
+            diff = fetch_text(f"{pr_url}.diff")
         files = parse_diff(diff)
         print(render_markdown(pr_url, pr, files, diff))
-    except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
         print(f"claude-review: {exc}", file=sys.stderr)
         return 1
 

--- a/examples/pr-review-agent.md
+++ b/examples/pr-review-agent.md
@@ -1,0 +1,13 @@
+---
+name: pr-reviewer
+description: Review GitHub pull request diffs and return a structured Markdown comment.
+tools: Bash
+---
+
+You are a focused pull request reviewer. Given a GitHub PR URL, run:
+
+```sh
+./claude-review --pr <pull-request-url>
+```
+
+Return the generated Markdown review comment. Do not approve code automatically. If the CLI reports a fetch error, explain the failure and ask for the diff directly.

--- a/examples/review-output-agent-playground-1401.md
+++ b/examples/review-output-agent-playground-1401.md
@@ -1,0 +1,25 @@
+## PR Review
+
+Source: https://github.com/xevrion-v2/agent-playground/pull/1401
+
+### Summary of changes
+
+This PR, "docs: add JSDoc to user routes", changes 1 file(s), with 12 additions and 0 deletions. The main touched path(s) are apps/api/src/routes/users.ts. The review below is based on the public PR metadata and unified diff.
+
+### Identified risks
+
+- No high-risk patterns were detected from the diff, but runtime behavior still depends on project tests and maintainer review.
+
+### Improvement suggestions
+
+- Run the repository's documented test and lint commands before merge.
+- Confirm the PR description links the relevant issue and explains verification performed.
+- Check whether changed behavior needs focused unit or integration coverage.
+
+### Changed files
+
+- `apps/api/src/routes/users.ts`: +12/-0 across 2 hunk(s)
+
+### Confidence score
+
+High

--- a/examples/review-output-agent-playground-1402.md
+++ b/examples/review-output-agent-playground-1402.md
@@ -1,0 +1,25 @@
+## PR Review
+
+Source: https://github.com/xevrion-v2/agent-playground/pull/1402
+
+### Summary of changes
+
+This PR, "xevrion-v2/agent-playground#1402", changes 1 file(s), with 17 additions and 8 deletions. The main touched path(s) are README.md. The review below is based on the public PR metadata and unified diff.
+
+### Identified risks
+
+- No high-risk patterns were detected from the diff, but runtime behavior still depends on project tests and maintainer review.
+
+### Improvement suggestions
+
+- Run the repository's documented test and lint commands before merge.
+- Confirm the PR description links the relevant issue and explains verification performed.
+- Preview Markdown-rendered documentation to catch formatting regressions.
+
+### Changed files
+
+- `README.md`: +17/-8 across 6 hunk(s)
+
+### Confidence score
+
+High

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "claude-review"
+AGENT = ROOT / ".claude" / "agents" / "pr-reviewer.md"
 MODULE = runpy.run_path(str(CLI))
 
 parse_pr_url = MODULE["parse_pr_url"]
@@ -28,6 +29,12 @@ index 1111111..2222222 100644
 
 
 class ClaudeReviewTest(unittest.TestCase):
+    def test_canonical_agent_manifest(self):
+        agent = AGENT.read_text(encoding="utf-8")
+        self.assertIn("name: pr-reviewer", agent)
+        self.assertIn("tools: Bash, Read, Grep", agent)
+        self.assertIn("### Confidence score", agent)
+
     def test_accepts_pr_url_suffix_and_canonicalizes_it(self):
         parts = parse_pr_url("https://github.com/owner/repo/pull/123/files?tab=files")
         self.assertEqual(parts, ("owner", "repo", "123"))

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,0 +1,94 @@
+import runpy
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "claude-review"
+MODULE = runpy.run_path(str(CLI))
+
+parse_pr_url = MODULE["parse_pr_url"]
+canonical_pr_url = MODULE["canonical_pr_url"]
+parse_diff = MODULE["parse_diff"]
+identify_risks = MODULE["identify_risks"]
+render_markdown = MODULE["render_markdown"]
+
+SAMPLE_DIFF = """diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1 +1,3 @@
++API_TOKEN = "example"
++def export_data():
+ print("ok")
+"""
+
+
+class ClaudeReviewTest(unittest.TestCase):
+    def test_accepts_pr_url_suffix_and_canonicalizes_it(self):
+        parts = parse_pr_url("https://github.com/owner/repo/pull/123/files?tab=files")
+        self.assertEqual(parts, ("owner", "repo", "123"))
+        self.assertEqual(canonical_pr_url(*parts), "https://github.com/owner/repo/pull/123")
+
+    def test_rejects_non_pr_url(self):
+        with self.assertRaises(ValueError):
+            parse_pr_url("https://github.com/owner/repo/issues/123")
+
+    def test_parses_file_stats(self):
+        files = parse_diff(SAMPLE_DIFF)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0].path, "app.py")
+        self.assertEqual(files[0].additions, 2)
+        self.assertEqual(files[0].hunks, 1)
+
+    def test_detects_sensitive_configuration(self):
+        files = parse_diff(SAMPLE_DIFF)
+        risks = identify_risks(files, SAMPLE_DIFF)
+        self.assertTrue(any("credential-like literal" in risk for risk in risks))
+
+    def test_renders_all_required_sections(self):
+        files = parse_diff(SAMPLE_DIFF)
+        output = render_markdown(
+            "https://github.com/owner/repo/pull/123",
+            {"title": "Export data"},
+            files,
+            SAMPLE_DIFF,
+        )
+        for heading in (
+            "### Summary of changes",
+            "### Identified risks",
+            "### Improvement suggestions",
+            "### Changed files",
+            "### Confidence score",
+        ):
+            self.assertIn(heading, output)
+
+    def test_cli_reviews_local_diff_without_network(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            diff_path = Path(temp_dir) / "change.diff"
+            diff_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CLI),
+                    "--pr",
+                    "https://github.com/owner/repo/pull/123/files",
+                    "--diff-file",
+                    str(diff_path),
+                    "--title",
+                    "Offline fixture",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"Offline fixture"', result.stdout)
+        self.assertIn("Source: https://github.com/owner/repo/pull/123", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4

Adds a dependency-free `claude-review --pr <github-pr-url>` CLI that fetches a public GitHub PR diff and emits a structured Markdown review comment.

What is included:
- `claude-review`: Python CLI for PR review output.
- `examples/pr-review-agent.md`: Claude Code sub-agent prompt that delegates to the CLI.
- `examples/review-output-agent-playground-1401.md`: sample output from a real GitHub PR.
- `examples/review-output-agent-playground-1402.md`: sample output from a second real GitHub PR.
- README setup and usage instructions.

Output sections:
- Summary of changes, 2-3 sentences.
- Identified risks.
- Improvement suggestions.
- Changed files.
- Confidence score: Low / Medium / High.

Verification:
- `python claude-review --pr https://github.com/xevrion-v2/agent-playground/pull/1401`
- `python claude-review --pr https://github.com/xevrion-v2/agent-playground/pull/1402`
- `python -m py_compile claude-review`
- `git diff --check`

Note: the CLI supports `GITHUB_TOKEN` when available and falls back to reviewing the public diff if GitHub API metadata is rate-limited.