### PR TITLE
feat: safe bash hook to intercept destructive commands (#3)

### DIFF
--- a/safe-bash-hook/README.md
+++ b/safe-bash-hook/README.md
@@ -1,0 +1,30 @@
+# Claude Code Safeguard Hook
+
+A lightweight, robust `pre-tool-use` hook for Claude Code that prevents the execution of destructive bash and SQL commands. 
+
+This hook automatically intercepts:
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force` (and `-f`)
+- `TRUNCATE`
+- `DELETE FROM` (without a `WHERE` clause)
+
+If Claude attempts to use any of these, the action is blocked, logged to `~/.claude/hooks/blocked.log`, and Claude is immediately notified with an explanation so it can alter its approach safely.
+
+## Installation (1 command!)
+
+Run the following command to download, install, and enable the hook for Claude Code:
+
+```bash
+mkdir -p ~/.claude/hooks && curl -sL https://raw.githubusercontent.com/claude-builders-bounty/claude-builders-bounty/main/safe-bash-hook/pre-tool-use.py -o ~/.claude/hooks/pre-tool-use && chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+## How it Works
+
+Claude Code passes tool invocations to any executable named `pre-tool-use` in the `~/.claude/hooks/` directory. This script parses the JSON payload from `stdin` to analyze the `Bash` command payload.
+
+If a destructive pattern is found:
+1. It logs the timestamp, exact command, and project directory to `~/.claude/hooks/blocked.log`.
+2. It prints an error message explicitly telling Claude to rethink its approach.
+3. It exits with code `1`, causing Claude Code to block execution and feed the error message back to the LLM.
+4. If the command is completely safe, it exits with code `0`, and Claude Code proceeds seamlessly!

--- a/safe-bash-hook/pre-tool-use.py
+++ b/safe-bash-hook/pre-tool-use.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import sys
+import json
+import os
+import re
+from datetime import datetime
+
+def block_command(command, reason):
+    """Logs the blocked command and exits with a non-zero status."""
+    log_dir = os.path.expanduser("~/.claude/hooks")
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, "blocked.log")
+    
+    timestamp = datetime.now().isoformat()
+    project_path = os.getcwd()
+    
+    with open(log_file, "a") as f:
+        f.write(f"[{timestamp}] command=\"{command}\" project=\"{project_path}\"\n")
+    
+    # Print the error message which will be sent to Claude as the system response
+    print(f"🚫 BLOCKING ACTION: The command was intercepted and blocked by the pre-tool-use security hook.")
+    print(f"Reason: {reason}")
+    print(f"Blocked Command: {command}")
+    print(f"\nPlease formulate a safer alternative or ask the user for explicit permission.")
+    sys.exit(1)
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(0)
+        
+    tool_name = sys.argv[1].lower()
+    
+    # We only care about shell/bash tools
+    if tool_name not in ["bash", "run_command", "terminal"]:
+        sys.exit(0)
+        
+    try:
+        input_data = sys.stdin.read()
+        if not input_data.strip():
+            sys.exit(0)
+            
+        payload = json.loads(input_data)
+    except Exception:
+        sys.exit(0)
+        
+    # Depending on the exact tool interface, the command could be in 'command', 'CommandLine', etc.
+    command = payload.get("command") or payload.get("CommandLine") or payload.get("script")
+    if not command:
+        sys.exit(0)
+        
+    # Check against blocked patterns
+    # Using regex for case-insensitivity and to handle multiple spaces
+    
+    cmd_upper = command.upper()
+    
+    if re.search(r'rm\s+-rf', command):
+        block_command(command, "Contains destructive 'rm -rf' pattern.")
+        
+    if "DROP TABLE" in cmd_upper:
+        block_command(command, "Contains destructive 'DROP TABLE' statement.")
+        
+    if re.search(r'git\s+push\s+--force', command) or re.search(r'git\s+push\s+-f\b', command):
+        block_command(command, "Contains dangerous 'git push --force' pattern.")
+        
+    if "TRUNCATE" in cmd_upper:
+        block_command(command, "Contains destructive 'TRUNCATE' statement.")
+        
+    if "DELETE FROM" in cmd_upper and "WHERE" not in cmd_upper:
+        block_command(command, "Contains 'DELETE FROM' without a safety 'WHERE' clause.")
+        
+    # If no patterns match, exit cleanly
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Python-based `pre-tool-use` hook to intercept and block destructive bash commands.

## Changes

- `hooks/pre-tool-use.py`: implements regex filtering for destructive command patterns (`rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without `WHERE`)
- `hooks/blocked.log`: added log appending functionality for intercepted commands
- `README.md`: added installation and configuration guide

## Testing

- Manual: verified `rm -rf /` exits with code 1 and logs to `~/.claude/hooks/blocked.log`
- Manual: verified safe commands execute with code 0

Closes #3
