### PR TITLE
Add n8n weekly Claude summary workflow

### DIFF
--- a/workflows/issue-5-weekly-dev-summary/README.md
+++ b/workflows/issue-5-weekly-dev-summary/README.md
@@ -30,4 +30,10 @@ This workflow generates a weekly narrative summary for a GitHub repository with 
 
 ## Validation
 
-The workflow JSON was validated locally with PowerShell JSON parsing. The GitHub API requests are implemented with HTTP Request nodes because n8n Code nodes are for data preparation/transformation, not external HTTP calls. A live n8n execution screenshot still requires real `ANTHROPIC_API_KEY` and Discord webhook values in the target n8n instance.
+The workflow JSON was validated locally with:
+
+```bash
+python workflows/issue-5-weekly-dev-summary/validate_workflow.py
+```
+
+Expected output is documented in `VERIFICATION.md`. The GitHub API requests are implemented with HTTP Request nodes because n8n Code nodes are for data preparation/transformation, not external HTTP calls. A live n8n execution screenshot still requires real `ANTHROPIC_API_KEY` and Discord webhook values in the target n8n instance.

--- a/workflows/issue-5-weekly-dev-summary/README.md
+++ b/workflows/issue-5-weekly-dev-summary/README.md
@@ -24,10 +24,10 @@ This workflow generates a weekly narrative summary for a GitHub repository with 
 ## What it does
 
 - Runs every Friday at 5pm.
-- Fetches commits, recently closed issues, and recently merged PRs from the GitHub API for the last 7 days.
+- Fetches commits, recently closed issues, and recently merged PRs from the GitHub API for the last 7 days using n8n HTTP Request nodes.
 - Sends those events to `claude-sonnet-4-20250514` with a narrative summary prompt.
 - Posts the final summary to Discord.
 
 ## Validation
 
-The workflow JSON was validated locally with PowerShell JSON parsing. A live n8n execution screenshot still requires real `ANTHROPIC_API_KEY` and Discord webhook values in the target n8n instance.
+The workflow JSON was validated locally with PowerShell JSON parsing. The GitHub API requests are implemented with HTTP Request nodes because n8n Code nodes are for data preparation/transformation, not external HTTP calls. A live n8n execution screenshot still requires real `ANTHROPIC_API_KEY` and Discord webhook values in the target n8n instance.

--- a/workflows/issue-5-weekly-dev-summary/README.md
+++ b/workflows/issue-5-weekly-dev-summary/README.md
@@ -1,0 +1,33 @@
+# Weekly GitHub Activity Summary for n8n
+
+This workflow generates a weekly narrative summary for a GitHub repository with Claude and posts it to Discord.
+
+## Setup
+
+1. Import `weekly-github-claude-summary.workflow.json` into n8n.
+2. Set these environment variables on the n8n host: `GITHUB_REPO_OWNER`, `GITHUB_REPO_NAME`, `ANTHROPIC_API_KEY`, `WEEKLY_SUMMARY_DISCORD_WEBHOOK_URL`, and optional `SUMMARY_LANGUAGE` (`EN` or `FR`) plus `GITHUB_TOKEN`.
+3. Open the workflow, confirm the Friday 5pm schedule, and activate it.
+4. Run the workflow manually once from the Schedule Trigger node.
+5. Confirm Discord receives the summary, then leave the workflow active for weekly runs.
+
+## Configuration
+
+| Variable | Required | Example | Purpose |
+| --- | --- | --- | --- |
+| `GITHUB_REPO_OWNER` | Yes | `anthropics` | GitHub owner or organization. |
+| `GITHUB_REPO_NAME` | Yes | `claude-code` | GitHub repository name. |
+| `ANTHROPIC_API_KEY` | Yes | `sk-ant-...` | Claude API key used by the Anthropic Messages API. |
+| `WEEKLY_SUMMARY_DISCORD_WEBHOOK_URL` | Yes | `https://discord.com/api/webhooks/...` | Discord webhook destination. |
+| `SUMMARY_LANGUAGE` | No | `EN` or `FR` | Summary language. Defaults to `EN`. |
+| `GITHUB_TOKEN` | No | `ghp_...` | Raises GitHub API rate limits and enables private repo access. |
+
+## What it does
+
+- Runs every Friday at 5pm.
+- Fetches commits, recently closed issues, and recently merged PRs from the GitHub API for the last 7 days.
+- Sends those events to `claude-sonnet-4-20250514` with a narrative summary prompt.
+- Posts the final summary to Discord.
+
+## Validation
+
+The workflow JSON was validated locally with PowerShell JSON parsing. A live n8n execution screenshot still requires real `ANTHROPIC_API_KEY` and Discord webhook values in the target n8n instance.

--- a/workflows/issue-5-weekly-dev-summary/VERIFICATION.md
+++ b/workflows/issue-5-weekly-dev-summary/VERIFICATION.md
@@ -1,0 +1,27 @@
+# Verification
+
+This submission is designed to be importable into n8n and independently checkable without external credentials.
+
+## Local validation
+
+Run from the repository root:
+
+```bash
+python workflows/issue-5-weekly-dev-summary/validate_workflow.py
+```
+
+Expected output:
+
+```text
+workflow validation passed
+nodes=9
+connections=8
+delivery=discord
+model=claude-sonnet-4-20250514
+```
+
+The validator checks the exported workflow shape, Friday 5pm schedule, GitHub commits/issues/pulls fetches, Claude Messages API model, Discord webhook delivery, EN/FR language configuration, and five-step README constraint.
+
+## Live execution boundary
+
+The workflow needs real `ANTHROPIC_API_KEY` and `WEEKLY_SUMMARY_DISCORD_WEBHOOK_URL` values to produce a live n8n execution screenshot. I did not fabricate that artifact from this environment.

--- a/workflows/issue-5-weekly-dev-summary/validate_workflow.py
+++ b/workflows/issue-5-weekly-dev-summary/validate_workflow.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate the issue #5 n8n workflow export without external services."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+WORKFLOW_PATH = ROOT / "weekly-github-claude-summary.workflow.json"
+README_PATH = ROOT / "README.md"
+
+
+def fail(message: str) -> None:
+    print(f"workflow validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def node_by_name(workflow: dict, name: str) -> dict:
+    for node in workflow.get("nodes", []):
+        if node.get("name") == name:
+            return node
+    fail(f"missing node: {name}")
+
+
+def main() -> None:
+    workflow = json.loads(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    readme = README_PATH.read_text(encoding="utf-8")
+    workflow_text = json.dumps(workflow, sort_keys=True)
+
+    require(workflow.get("name"), "workflow name is required")
+    require(isinstance(workflow.get("nodes"), list), "nodes must be a list")
+    require(isinstance(workflow.get("connections"), dict), "connections must be an object")
+
+    required_nodes = {
+        "Weekly Friday 5pm": "n8n-nodes-base.scheduleTrigger",
+        "Prepare Config": "n8n-nodes-base.code",
+        "Get Commits": "n8n-nodes-base.httpRequest",
+        "Get Closed Issues": "n8n-nodes-base.httpRequest",
+        "Get Closed Pulls": "n8n-nodes-base.httpRequest",
+        "Build Claude Prompt": "n8n-nodes-base.code",
+        "Generate Claude Summary": "n8n-nodes-base.httpRequest",
+        "Prepare Discord Message": "n8n-nodes-base.code",
+        "Send Discord Summary": "n8n-nodes-base.httpRequest",
+    }
+
+    for name, expected_type in required_nodes.items():
+        node = node_by_name(workflow, name)
+        require(node.get("type") == expected_type, f"{name} type should be {expected_type}")
+
+    schedule = node_by_name(workflow, "Weekly Friday 5pm")["parameters"]["rule"]["interval"][0]
+    require(schedule.get("field") == "weeks", "trigger must run weekly")
+    require(schedule.get("triggerAtDay") == [5], "trigger must run on Friday")
+    require(schedule.get("triggerAtHour") == 17, "trigger must run at 17:00")
+    require(schedule.get("triggerAtMinute") == 0, "trigger minute must be 0")
+
+    require("claude-sonnet-4-20250514" in workflow_text, "Claude Sonnet 4 model is missing")
+    require("https://api.anthropic.com/v1/messages" in workflow_text, "Claude Messages API URL is missing")
+    require("ANTHROPIC_API_KEY" in workflow_text, "Anthropic API key env var is missing")
+    require("GITHUB_REPO_OWNER" in workflow_text, "GitHub owner env var is missing")
+    require("GITHUB_REPO_NAME" in workflow_text, "GitHub repo env var is missing")
+    require("SUMMARY_LANGUAGE" in workflow_text, "language env var is missing")
+    require("WEEKLY_SUMMARY_DISCORD_WEBHOOK_URL" in workflow_text, "Discord webhook env var is missing")
+    require("/commits?" in workflow_text, "commits API fetch is missing")
+    require("/issues?state=closed" in workflow_text, "closed issues API fetch is missing")
+    require("/pulls?state=closed" in workflow_text, "closed pulls API fetch is missing")
+    require("mergedPulls" in workflow_text, "merged PR filtering/output is missing")
+
+    connections = workflow["connections"]
+    expected_edges = [
+        ("Weekly Friday 5pm", "Prepare Config"),
+        ("Prepare Config", "Get Commits"),
+        ("Get Commits", "Get Closed Issues"),
+        ("Get Closed Issues", "Get Closed Pulls"),
+        ("Get Closed Pulls", "Build Claude Prompt"),
+        ("Build Claude Prompt", "Generate Claude Summary"),
+        ("Generate Claude Summary", "Prepare Discord Message"),
+        ("Prepare Discord Message", "Send Discord Summary"),
+    ]
+    for source, target in expected_edges:
+        serialized = json.dumps(connections.get(source, {}))
+        require(f'"node": "{target}"' in serialized, f"missing connection {source} -> {target}")
+
+    setup_steps = re.findall(r"(?m)^\d+\.\s+", readme)
+    require(len(setup_steps) <= 5, "README setup instructions must be 5 steps or fewer")
+
+    print("workflow validation passed")
+    print(f"nodes={len(workflow['nodes'])}")
+    print(f"connections={len(workflow['connections'])}")
+    print("delivery=discord")
+    print("model=claude-sonnet-4-20250514")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json
+++ b/workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json
@@ -1,0 +1,173 @@
+{
+  "name": "Weekly GitHub Activity Summary with Claude",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "weeks",
+              "triggerAtDay": [
+                5
+              ],
+              "triggerAtHour": 17,
+              "triggerAtMinute": 0
+            }
+          ]
+        }
+      },
+      "id": "8feec9df-0a5a-4c43-91e0-867b8d7c0c00",
+      "name": "Weekly Friday 5pm",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        240,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const owner = $env.GITHUB_REPO_OWNER || 'claude-builders-bounty';\nconst repo = $env.GITHUB_REPO_NAME || 'claude-builders-bounty';\nconst language = (($env.SUMMARY_LANGUAGE || 'EN').toUpperCase() === 'FR') ? 'FR' : 'EN';\nconst token = $env.GITHUB_TOKEN || '';\nconst now = new Date();\nconst until = now.toISOString();\nconst sinceDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);\nconst since = sinceDate.toISOString();\n\nconst headers = {\n  Accept: 'application/vnd.github+json',\n  'X-GitHub-Api-Version': '2022-11-28',\n  'User-Agent': 'n8n-weekly-claude-summary'\n};\nif (token) headers.Authorization = `Bearer ${token}`;\n\nasync function getJson(url) {\n  const response = await fetch(url, { headers });\n  if (!response.ok) {\n    const text = await response.text();\n    throw new Error(`GitHub API failed ${response.status} for ${url}: ${text}`);\n  }\n  return response.json();\n}\n\nconst base = `https://api.github.com/repos/${owner}/${repo}`;\nconst commitsUrl = `${base}/commits?since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}&per_page=100`;\nconst issuesUrl = `${base}/issues?state=closed&since=${encodeURIComponent(since)}&per_page=100`;\nconst pullsUrl = `${base}/pulls?state=closed&sort=updated&direction=desc&per_page=100`;\n\nconst [commits, closedIssues, closedPulls] = await Promise.all([\n  getJson(commitsUrl),\n  getJson(issuesUrl),\n  getJson(pullsUrl)\n]);\n\nconst mergedPulls = closedPulls.filter((pr) => pr.merged_at && new Date(pr.merged_at) >= sinceDate);\nconst plainIssues = closedIssues.filter((issue) => !issue.pull_request && issue.closed_at && new Date(issue.closed_at) >= sinceDate);\n\nfunction compactCommit(commit) {\n  return {\n    sha: commit.sha.slice(0, 7),\n    author: commit.commit.author?.name || commit.author?.login || 'unknown',\n    date: commit.commit.author?.date,\n    message: commit.commit.message.split('\\n')[0],\n    url: commit.html_url\n  };\n}\n\nfunction compactIssue(issue) {\n  return {\n    number: issue.number,\n    title: issue.title,\n    author: issue.user?.login || 'unknown',\n    closedAt: issue.closed_at,\n    url: issue.html_url\n  };\n}\n\nfunction compactPull(pr) {\n  return {\n    number: pr.number,\n    title: pr.title,\n    author: pr.user?.login || 'unknown',\n    mergedAt: pr.merged_at,\n    url: pr.html_url\n  };\n}\n\nconst activity = {\n  repository: `${owner}/${repo}`,\n  period: { since, until },\n  language,\n  commits: commits.map(compactCommit),\n  closedIssues: plainIssues.map(compactIssue),\n  mergedPulls: mergedPulls.map(compactPull)\n};\n\nconst languageInstruction = language === 'FR'\n  ? 'Write the summary in French.'\n  : 'Write the summary in English.';\n\nconst prompt = `You are preparing a weekly engineering update for ${activity.repository}. ${languageInstruction}\\n\\nUse this JSON activity data to write a concise narrative summary with: 1) headline, 2) shipped highlights, 3) issue and PR outcomes, 4) notable contributors, 5) next-week watch items. Avoid inventing details.\\n\\n${JSON.stringify(activity, null, 2)}`;\n\nreturn [{ json: { ...activity, prompt } }];"
+      },
+      "id": "3d19f355-5a30-48a7-b3dd-5a85cf3b07f2",
+      "name": "Fetch GitHub Activity",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        480,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{$env.ANTHROPIC_API_KEY}}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 1200,\n  \"temperature\": 0.3,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": $json.prompt\n    }\n  ]\n}"
+      },
+      "id": "4de7f03a-23c7-4f8a-8a12-763866a4c987",
+      "name": "Generate Claude Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        720,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const content = $json.content || [];\nconst firstText = content.find((part) => part.type === 'text')?.text || 'No summary returned by Claude.';\nconst repository = $('Fetch GitHub Activity').first().json.repository;\nconst since = $('Fetch GitHub Activity').first().json.period.since.slice(0, 10);\nconst until = $('Fetch GitHub Activity').first().json.period.until.slice(0, 10);\nconst message = `**Weekly GitHub Summary: ${repository}**\\n_${since} to ${until}_\\n\\n${firstText}`;\nreturn [{ json: { repository, since, until, message } }];"
+      },
+      "id": "7a725dd6-3a12-4f59-a218-b04832f73d42",
+      "name": "Prepare Discord Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        960,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{$env.WEEKLY_SUMMARY_DISCORD_WEBHOOK_URL}}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"content\": $json.message\n}"
+      },
+      "id": "86221d1c-c7fa-41a4-bab2-8fd930d57406",
+      "name": "Send Discord Summary",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1200,
+        300
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Weekly Friday 5pm": {
+      "main": [
+        [
+          {
+            "node": "Fetch GitHub Activity",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch GitHub Activity": {
+      "main": [
+        [
+          {
+            "node": "Generate Claude Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Claude Summary": {
+      "main": [
+        [
+          {
+            "node": "Prepare Discord Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Discord Message": {
+      "main": [
+        [
+          {
+            "node": "Send Discord Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "5b9442f1-0416-4fdf-8364-59ae4d2a10ea",
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "id": "weekly-github-claude-summary",
+  "tags": [
+    {
+      "name": "github"
+    },
+    {
+      "name": "claude"
+    },
+    {
+      "name": "discord"
+    }
+  ]
+}

--- a/workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json
+++ b/workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json
@@ -21,21 +21,127 @@
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.2,
       "position": [
-        240,
-        300
+        200,
+        320
       ]
     },
     {
       "parameters": {
-        "jsCode": "const owner = $env.GITHUB_REPO_OWNER || 'claude-builders-bounty';\nconst repo = $env.GITHUB_REPO_NAME || 'claude-builders-bounty';\nconst language = (($env.SUMMARY_LANGUAGE || 'EN').toUpperCase() === 'FR') ? 'FR' : 'EN';\nconst token = $env.GITHUB_TOKEN || '';\nconst now = new Date();\nconst until = now.toISOString();\nconst sinceDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);\nconst since = sinceDate.toISOString();\n\nconst headers = {\n  Accept: 'application/vnd.github+json',\n  'X-GitHub-Api-Version': '2022-11-28',\n  'User-Agent': 'n8n-weekly-claude-summary'\n};\nif (token) headers.Authorization = `Bearer ${token}`;\n\nasync function getJson(url) {\n  const response = await fetch(url, { headers });\n  if (!response.ok) {\n    const text = await response.text();\n    throw new Error(`GitHub API failed ${response.status} for ${url}: ${text}`);\n  }\n  return response.json();\n}\n\nconst base = `https://api.github.com/repos/${owner}/${repo}`;\nconst commitsUrl = `${base}/commits?since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}&per_page=100`;\nconst issuesUrl = `${base}/issues?state=closed&since=${encodeURIComponent(since)}&per_page=100`;\nconst pullsUrl = `${base}/pulls?state=closed&sort=updated&direction=desc&per_page=100`;\n\nconst [commits, closedIssues, closedPulls] = await Promise.all([\n  getJson(commitsUrl),\n  getJson(issuesUrl),\n  getJson(pullsUrl)\n]);\n\nconst mergedPulls = closedPulls.filter((pr) => pr.merged_at && new Date(pr.merged_at) >= sinceDate);\nconst plainIssues = closedIssues.filter((issue) => !issue.pull_request && issue.closed_at && new Date(issue.closed_at) >= sinceDate);\n\nfunction compactCommit(commit) {\n  return {\n    sha: commit.sha.slice(0, 7),\n    author: commit.commit.author?.name || commit.author?.login || 'unknown',\n    date: commit.commit.author?.date,\n    message: commit.commit.message.split('\\n')[0],\n    url: commit.html_url\n  };\n}\n\nfunction compactIssue(issue) {\n  return {\n    number: issue.number,\n    title: issue.title,\n    author: issue.user?.login || 'unknown',\n    closedAt: issue.closed_at,\n    url: issue.html_url\n  };\n}\n\nfunction compactPull(pr) {\n  return {\n    number: pr.number,\n    title: pr.title,\n    author: pr.user?.login || 'unknown',\n    mergedAt: pr.merged_at,\n    url: pr.html_url\n  };\n}\n\nconst activity = {\n  repository: `${owner}/${repo}`,\n  period: { since, until },\n  language,\n  commits: commits.map(compactCommit),\n  closedIssues: plainIssues.map(compactIssue),\n  mergedPulls: mergedPulls.map(compactPull)\n};\n\nconst languageInstruction = language === 'FR'\n  ? 'Write the summary in French.'\n  : 'Write the summary in English.';\n\nconst prompt = `You are preparing a weekly engineering update for ${activity.repository}. ${languageInstruction}\\n\\nUse this JSON activity data to write a concise narrative summary with: 1) headline, 2) shipped highlights, 3) issue and PR outcomes, 4) notable contributors, 5) next-week watch items. Avoid inventing details.\\n\\n${JSON.stringify(activity, null, 2)}`;\n\nreturn [{ json: { ...activity, prompt } }];"
+        "jsCode": "const owner = $env.GITHUB_REPO_OWNER || 'claude-builders-bounty';\nconst repo = $env.GITHUB_REPO_NAME || 'claude-builders-bounty';\nconst language = (($env.SUMMARY_LANGUAGE || 'EN').toUpperCase() === 'FR') ? 'FR' : 'EN';\nconst now = new Date();\nconst until = now.toISOString();\nconst sinceDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);\nconst since = sinceDate.toISOString();\nconst base = `https://api.github.com/repos/${owner}/${repo}`;\nreturn [{\n  json: {\n    owner,\n    repo,\n    repository: `${owner}/${repo}`,\n    language,\n    since,\n    until,\n    commitsUrl: `${base}/commits?since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}&per_page=100`,\n    issuesUrl: `${base}/issues?state=closed&since=${encodeURIComponent(since)}&per_page=100`,\n    pullsUrl: `${base}/pulls?state=closed&sort=updated&direction=desc&per_page=100`\n  }\n}];"
       },
-      "id": "3d19f355-5a30-48a7-b3dd-5a85cf3b07f2",
-      "name": "Fetch GitHub Activity",
+      "id": "cad02d2a-3b51-4a7b-9f3c-34c8eaf7c70a",
+      "name": "Prepare Config",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        480,
-        300
+        440,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$json.commitsUrl}}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "X-GitHub-Api-Version",
+              "value": "2022-11-28"
+            },
+            {
+              "name": "User-Agent",
+              "value": "n8n-weekly-claude-summary"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "97303380-384e-46f3-a157-58d90e6da98d",
+      "name": "Get Commits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        680,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$('Prepare Config').first().json.issuesUrl}}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "X-GitHub-Api-Version",
+              "value": "2022-11-28"
+            },
+            {
+              "name": "User-Agent",
+              "value": "n8n-weekly-claude-summary"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "70633d90-0722-41bc-8462-ccba360bb8ab",
+      "name": "Get Closed Issues",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$('Prepare Config').first().json.pullsUrl}}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            },
+            {
+              "name": "X-GitHub-Api-Version",
+              "value": "2022-11-28"
+            },
+            {
+              "name": "User-Agent",
+              "value": "n8n-weekly-claude-summary"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "014b75de-10aa-41e7-9bb8-4f4f7df9197d",
+      "name": "Get Closed Pulls",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1160,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $('Prepare Config').first().json;\nconst sinceDate = new Date(config.since);\n\nfunction nodeItems(nodeName) {\n  const values = $(nodeName).all().map((item) => item.json);\n  if (values.length === 1 && Array.isArray(values[0])) {\n    return values[0];\n  }\n  return values;\n}\n\nfunction compactCommit(commit) {\n  return {\n    sha: (commit.sha || '').slice(0, 7),\n    author: commit.commit?.author?.name || commit.author?.login || 'unknown',\n    date: commit.commit?.author?.date,\n    message: (commit.commit?.message || '').split('\\n')[0],\n    url: commit.html_url\n  };\n}\n\nfunction compactIssue(issue) {\n  return {\n    number: issue.number,\n    title: issue.title,\n    author: issue.user?.login || 'unknown',\n    closedAt: issue.closed_at,\n    url: issue.html_url\n  };\n}\n\nfunction compactPull(pr) {\n  return {\n    number: pr.number,\n    title: pr.title,\n    author: pr.user?.login || 'unknown',\n    mergedAt: pr.merged_at,\n    url: pr.html_url\n  };\n}\n\nconst commits = nodeItems('Get Commits').map(compactCommit);\nconst closedIssues = nodeItems('Get Closed Issues')\n  .filter((issue) => !issue.pull_request && issue.closed_at && new Date(issue.closed_at) >= sinceDate)\n  .map(compactIssue);\nconst mergedPulls = nodeItems('Get Closed Pulls')\n  .filter((pr) => pr.merged_at && new Date(pr.merged_at) >= sinceDate)\n  .map(compactPull);\n\nconst activity = {\n  repository: config.repository,\n  period: { since: config.since, until: config.until },\n  language: config.language,\n  commits,\n  closedIssues,\n  mergedPulls\n};\n\nconst languageInstruction = config.language === 'FR'\n  ? 'Write the summary in French.'\n  : 'Write the summary in English.';\n\nconst prompt = `You are preparing a weekly engineering update for ${activity.repository}. ${languageInstruction}\\n\\nUse this JSON activity data to write a concise narrative summary with: 1) headline, 2) shipped highlights, 3) issue and PR outcomes, 4) notable contributors, 5) next-week watch items. Avoid inventing details.\\n\\n${JSON.stringify(activity, null, 2)}`;\n\nreturn [{ json: { ...activity, prompt } }];"
+      },
+      "id": "1bde99e1-3269-4bd4-b8ce-bcb47c41d59b",
+      "name": "Build Claude Prompt",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1400,
+        320
       ]
     },
     {
@@ -68,21 +174,21 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        720,
-        300
+        1640,
+        320
       ]
     },
     {
       "parameters": {
-        "jsCode": "const content = $json.content || [];\nconst firstText = content.find((part) => part.type === 'text')?.text || 'No summary returned by Claude.';\nconst repository = $('Fetch GitHub Activity').first().json.repository;\nconst since = $('Fetch GitHub Activity').first().json.period.since.slice(0, 10);\nconst until = $('Fetch GitHub Activity').first().json.period.until.slice(0, 10);\nconst message = `**Weekly GitHub Summary: ${repository}**\\n_${since} to ${until}_\\n\\n${firstText}`;\nreturn [{ json: { repository, since, until, message } }];"
+        "jsCode": "const content = $json.content || [];\nconst firstText = content.find((part) => part.type === 'text')?.text || 'No summary returned by Claude.';\nconst activity = $('Build Claude Prompt').first().json;\nconst message = `**Weekly GitHub Summary: ${activity.repository}**\\n_${activity.period.since.slice(0, 10)} to ${activity.period.until.slice(0, 10)}_\\n\\n${firstText}`;\nreturn [{ json: { repository: activity.repository, message } }];"
       },
       "id": "7a725dd6-3a12-4f59-a218-b04832f73d42",
       "name": "Prepare Discord Message",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        960,
-        300
+        1880,
+        320
       ]
     },
     {
@@ -98,8 +204,8 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1200,
-        300
+        2120,
+        320
       ]
     }
   ],
@@ -109,14 +215,58 @@
       "main": [
         [
           {
-            "node": "Fetch GitHub Activity",
+            "node": "Prepare Config",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Fetch GitHub Activity": {
+    "Prepare Config": {
+      "main": [
+        [
+          {
+            "node": "Get Commits",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Commits": {
+      "main": [
+        [
+          {
+            "node": "Get Closed Issues",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Closed Issues": {
+      "main": [
+        [
+          {
+            "node": "Get Closed Pulls",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Closed Pulls": {
+      "main": [
+        [
+          {
+            "node": "Build Claude Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Claude Prompt": {
       "main": [
         [
           {
@@ -154,7 +304,7 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "5b9442f1-0416-4fdf-8364-59ae4d2a10ea",
+  "versionId": "a913412a-a096-4011-9962-c84e5596fd3c",
   "meta": {
     "templateCredsSetupCompleted": true
   },

--- a/workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json
+++ b/workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json
@@ -55,6 +55,10 @@
             {
               "name": "User-Agent",
               "value": "n8n-weekly-claude-summary"
+            },
+            {
+              "name": "Authorization",
+              "value": "={{$env.GITHUB_TOKEN ? 'Bearer ' + $env.GITHUB_TOKEN : ''}}"
             }
           ]
         },
@@ -86,6 +90,10 @@
             {
               "name": "User-Agent",
               "value": "n8n-weekly-claude-summary"
+            },
+            {
+              "name": "Authorization",
+              "value": "={{$env.GITHUB_TOKEN ? 'Bearer ' + $env.GITHUB_TOKEN : ''}}"
             }
           ]
         },
@@ -117,6 +125,10 @@
             {
               "name": "User-Agent",
               "value": "n8n-weekly-claude-summary"
+            },
+            {
+              "name": "Authorization",
+              "value": "={{$env.GITHUB_TOKEN ? 'Bearer ' + $env.GITHUB_TOKEN : ''}}"
             }
           ]
         },


### PR DESCRIPTION
/claim #5

Closes #5

## Summary
- Adds an importable n8n workflow for the weekly GitHub activity summary bounty.
- Fetches commits, closed issues, and merged PRs from the GitHub API for the prior 7 days.
- Sends the activity payload to Claude using `claude-sonnet-4-20250514`.
- Posts the generated summary to Discord with configurable repository and language values.
- Adds a 5-step setup README with required environment variables.

## Validation
- Parsed `workflows/issue-5-weekly-dev-summary/weekly-github-claude-summary.workflow.json` locally with PowerShell `ConvertFrom-Json`.

## Note
A live n8n execution screenshot still requires real `ANTHROPIC_API_KEY` and `WEEKLY_SUMMARY_DISCORD_WEBHOOK_URL` values in the target n8n instance. I did not fabricate that artifact from this environment.