### PR TITLE
Add changelog generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Generated from git history for all commits on 2026-06-12.
+
+### Added
+
+- Add changelog generator
+- feat: initial README with bounty board
+
+### Fixed
+
+- None
+
+### Changed
+
+- None
+
+### Removed
+
+- None

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ You're in the right place.
 
 Create a structured `CHANGELOG.md` from commits since the latest git tag:
 
-1. Run `bash changelog.sh` or `python generate_changelog.py`.
+1. Run `bash changelog.sh` or `python3 generate_changelog.py`.
 2. Review `CHANGELOG.md`.
 3. Commit the generated file when it looks right.
+
+Requires Python 3.8 or newer.
 
 The script skips merge commits and sorts commit subjects into `Added`, `Fixed`,
 `Changed`, and `Removed`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,43 @@ You're in the right place.
 
 ---
 
+## Generate a Changelog
+
+Create a structured `CHANGELOG.md` from commits since the latest git tag:
+
+1. Run `bash changelog.sh` or `python generate_changelog.py`.
+2. Review `CHANGELOG.md`.
+3. Commit the generated file when it looks right.
+
+The script skips merge commits and sorts commit subjects into `Added`, `Fixed`,
+`Changed`, and `Removed`.
+
+Example output:
+
+```markdown
+# Changelog
+
+Generated from git history for all commits on 2026-06-12.
+
+### Added
+
+- feat: initial README with bounty board
+
+### Fixed
+
+- None
+
+### Changed
+
+- None
+
+### Removed
+
+- None
+```
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/changelog.sh
+++ b/changelog.sh
@@ -2,8 +2,17 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if command -v python3 >/dev/null 2>&1 && python3 --version >/dev/null 2>&1; then
-  python3 "$script_dir/generate_changelog.py" "$@"
-else
-  python "$script_dir/generate_changelog.py" "$@"
+python_cmd=""
+for candidate in python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c 'import sys; raise SystemExit(sys.version_info < (3, 8))'; then
+    python_cmd="$candidate"
+    break
+  fi
+done
+
+if [ -z "$python_cmd" ]; then
+  echo "Python 3.8 or newer is required to generate the changelog." >&2
+  exit 1
 fi
+
+"$python_cmd" "$script_dir/generate_changelog.py" "$@"

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if command -v python3 >/dev/null 2>&1 && python3 --version >/dev/null 2>&1; then
+  python3 "$script_dir/generate_changelog.py" "$@"
+else
+  python "$script_dir/generate_changelog.py" "$@"
+fi

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate CHANGELOG.md from git history."""
+
+from __future__ import annotations
+
+import datetime as dt
+import subprocess
+import sys
+from pathlib import Path
+
+
+def git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def latest_tag() -> str | None:
+    result = git("describe", "--tags", "--abbrev=0", check=False)
+    tag = result.stdout.strip()
+    return tag or None
+
+
+def commit_subjects(commit_range: str) -> list[str]:
+    result = git("log", "--no-merges", "--pretty=format:%s", commit_range)
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def categorize(subject: str) -> str:
+    lowered = subject.lower()
+    added_markers = ("feat:", "add:", "added:")
+    fixed_markers = ("fix:", "bug:", "bugfix:")
+    removed_markers = ("remove:", "removed:", "delete:", "deleted:")
+
+    if lowered.startswith(added_markers) or lowered.startswith(("add ", "adds ", "added ", "implement ", "implements ")) or any(marker in lowered for marker in (" add ", " adds ", " added ", " implement ", " implements ")):
+        return "Added"
+    if lowered.startswith(fixed_markers) or lowered.startswith(("fix ", "fixes ", "fixed ", "bug ")) or any(marker in lowered for marker in (" fix ", " fixes ", " fixed ", " bug ")):
+        return "Fixed"
+    if lowered.startswith(removed_markers) or lowered.startswith(("remove ", "removes ", "removed ", "delete ", "deletes ")) or any(marker in lowered for marker in (" remove ", " removes ", " removed ", " delete ", " deletes ")):
+        return "Removed"
+    return "Changed"
+
+
+def section(title: str, entries: list[str]) -> str:
+    lines = [f"### {title}", ""]
+    if entries:
+        lines.extend(f"- {entry}" for entry in entries)
+    else:
+        lines.append("- None")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    inside_work_tree = git("rev-parse", "--is-inside-work-tree", check=False)
+    if inside_work_tree.returncode != 0:
+        print("generate_changelog.py must be run inside a git repository.", file=sys.stderr)
+        return 1
+
+    output_path = Path(sys.argv[1] if len(sys.argv) > 1 else "CHANGELOG.md")
+    tag = latest_tag()
+    commit_range = f"{tag}..HEAD" if tag else "HEAD"
+    range_label = f"since {tag}" if tag else "for all commits"
+
+    buckets: dict[str, list[str]] = {
+        "Added": [],
+        "Fixed": [],
+        "Changed": [],
+        "Removed": [],
+    }
+
+    subjects = commit_subjects(commit_range)
+    for subject in subjects:
+        buckets[categorize(subject)].append(subject)
+
+    today = dt.datetime.now(dt.UTC).strftime("%Y-%m-%d")
+    changelog = [
+        "# Changelog",
+        "",
+        f"Generated from git history {range_label} on {today}.",
+        "",
+        section("Added", buckets["Added"]),
+        section("Fixed", buckets["Fixed"]),
+        section("Changed", buckets["Changed"]),
+        section("Removed", buckets["Removed"]),
+    ]
+    output_path.write_text("\n".join(changelog), encoding="utf-8")
+    print(f"Wrote {output_path} with {len(subjects)} commit(s) {range_label}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -7,9 +7,10 @@ import datetime as dt
 import subprocess
 import sys
 from pathlib import Path
+from typing import Dict, List, Optional
 
 
-def git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["git", *args],
         check=check,
@@ -19,33 +20,41 @@ def git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     )
 
 
-def latest_tag() -> str | None:
+def latest_tag() -> Optional[str]:
     result = git("describe", "--tags", "--abbrev=0", check=False)
     tag = result.stdout.strip()
     return tag or None
 
 
-def commit_subjects(commit_range: str) -> list[str]:
+def commit_subjects(commit_range: str) -> List[str]:
     result = git("log", "--no-merges", "--pretty=format:%s", commit_range)
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
 def categorize(subject: str) -> str:
     lowered = subject.lower()
-    added_markers = ("feat:", "add:", "added:")
-    fixed_markers = ("fix:", "bug:", "bugfix:")
-    removed_markers = ("remove:", "removed:", "delete:", "deleted:")
+    added_prefixes = ("feat:", "add:", "added:", "add ", "adds ", "added ", "implement ", "implements ")
+    fixed_prefixes = ("fix:", "bug:", "bugfix:", "fix ", "fixes ", "fixed ", "bug ")
+    removed_prefixes = ("remove:", "removed:", "delete:", "deleted:", "remove ", "removes ", "removed ", "delete ", "deletes ")
 
-    if lowered.startswith(added_markers) or lowered.startswith(("add ", "adds ", "added ", "implement ", "implements ")) or any(marker in lowered for marker in (" add ", " adds ", " added ", " implement ", " implements ")):
+    if starts_with_any(lowered, added_prefixes) or contains_any(lowered, (" add ", " adds ", " added ", " implement ", " implements ")):
         return "Added"
-    if lowered.startswith(fixed_markers) or lowered.startswith(("fix ", "fixes ", "fixed ", "bug ")) or any(marker in lowered for marker in (" fix ", " fixes ", " fixed ", " bug ")):
+    if starts_with_any(lowered, fixed_prefixes) or contains_any(lowered, (" fix ", " fixes ", " fixed ", " bug ")):
         return "Fixed"
-    if lowered.startswith(removed_markers) or lowered.startswith(("remove ", "removes ", "removed ", "delete ", "deletes ")) or any(marker in lowered for marker in (" remove ", " removes ", " removed ", " delete ", " deletes ")):
+    if starts_with_any(lowered, removed_prefixes) or contains_any(lowered, (" remove ", " removes ", " removed ", " delete ", " deletes ")):
         return "Removed"
     return "Changed"
 
 
-def section(title: str, entries: list[str]) -> str:
+def starts_with_any(value: str, prefixes: tuple) -> bool:
+    return value.startswith(prefixes)
+
+
+def contains_any(value: str, markers: tuple) -> bool:
+    return any(marker in value for marker in markers)
+
+
+def section(title: str, entries: List[str]) -> str:
     lines = [f"### {title}", ""]
     if entries:
         lines.extend(f"- {entry}" for entry in entries)
@@ -66,7 +75,7 @@ def main() -> int:
     commit_range = f"{tag}..HEAD" if tag else "HEAD"
     range_label = f"since {tag}" if tag else "for all commits"
 
-    buckets: dict[str, list[str]] = {
+    buckets: Dict[str, List[str]] = {
         "Added": [],
         "Fixed": [],
         "Changed": [],
@@ -77,7 +86,7 @@ def main() -> int:
     for subject in subjects:
         buckets[categorize(subject)].append(subject)
 
-    today = dt.datetime.now(dt.UTC).strftime("%Y-%m-%d")
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     changelog = [
         "# Changelog",
         "",


### PR DESCRIPTION
## Summary
- Adds `generate_changelog.py` to build a structured `CHANGELOG.md` from git commit history.
- Adds `changelog.sh` as the `bash changelog.sh` entry point.
- Documents setup in three steps and includes generated sample output.

## Verification
- `python generate_changelog.py CHANGELOG.verify.md`
- `bash changelog.sh CHANGELOG.verify-bash.md`
- Compared both generated files and confirmed they match.

Closes #1