### PR TITLE
Add destructive Bash guard hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -8,7 +8,8 @@ Claude Code `PreToolUse` hook that blocks destructive Bash commands before they 
 bash hooks/install.sh
 ```
 
-Add this hook to your Claude Code settings for the `PreToolUse` event and the `Bash` tool:
+Add this hook to your Claude Code settings for the `PreToolUse` event and the `Bash` tool.
+Replace `/home/you` with your absolute home directory:
 
 ```json
 {
@@ -19,7 +20,7 @@ Add this hook to your Claude Code settings for the `PreToolUse` event and the `B
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/destructive_bash_guard.py"
+            "command": "/home/you/.claude/hooks/destructive_bash_guard.py"
           }
         ]
       }

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,46 @@
+# Destructive Bash Guard
+
+Claude Code `PreToolUse` hook that blocks destructive Bash commands before they run.
+
+## Install
+
+```bash
+bash hooks/install.sh
+```
+
+Add this hook to your Claude Code settings for the `PreToolUse` event and the `Bash` tool:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/destructive_bash_guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook reads Claude Code hook JSON from stdin, inspects `tool_input.command`,
+and exits with code `2` when it blocks a command. Claude Code receives the stderr
+message explaining why the command was blocked.
+
+## Blocked Patterns
+
+- `rm -rf`: recursive force deletion can permanently remove project files.
+- `DROP TABLE`: schema deletion can destroy database data.
+- `git push --force` and `git push --force-with-lease`: force pushes can overwrite shared history.
+- `TRUNCATE`: table truncation erases rows immediately.
+- `DELETE FROM` without a `WHERE` clause: unrestricted deletes can erase every row.
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON with
+timestamp, attempted command, project path, and matched rule.
+
+Normal Bash commands and non-Bash tools exit `0` and continue unchanged.

--- a/hooks/destructive_bash_guard.py
+++ b/hooks/destructive_bash_guard.py
@@ -26,7 +26,7 @@ BLOCK_RULES: Tuple[Tuple[str, re.Pattern[str], str], ...] = (
     ),
     (
         "force push",
-        re.compile(r"(?is)\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?|-f)(?:\s|$)"),
+        re.compile(r"(?is)\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?(?:=\S+)?|-f)(?:\s|$)"),
         "git push --force can overwrite shared history.",
     ),
     (

--- a/hooks/destructive_bash_guard.py
+++ b/hooks/destructive_bash_guard.py
@@ -9,14 +9,14 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
 
 BLOCK_RULES: Tuple[Tuple[str, re.Pattern[str], str], ...] = (
     (
         "recursive force delete",
-        re.compile(r"(?is)(?:^|[;&|]\s*)rm\s+(?=[^;&|]*-[^\s;&|]*r)(?=[^;&|]*-[^\s;&|]*f)\S*(?:\s|$)"),
+        re.compile(r"(?is)(?:^|[;&|]{1,2}\s*)rm\s+(?=[^;&|]*-[^\s;&|]*r)(?=[^;&|]*-[^\s;&|]*f)\S*(?:\s|$)"),
         "rm -rf can permanently delete files.",
     ),
     (
@@ -34,20 +34,19 @@ BLOCK_RULES: Tuple[Tuple[str, re.Pattern[str], str], ...] = (
         re.compile(r"(?is)\btruncate(?:\s+table)?\b"),
         "TRUNCATE can erase table contents immediately.",
     ),
-    (
-        "delete without where",
-        re.compile(r"(?is)\bdelete\s+from\b(?:(?!;|\bwhere\b).)*(?:;|$)"),
-        "DELETE FROM without a WHERE clause can erase every row.",
-    ),
 )
+
+DELETE_FROM_RE = re.compile(r"(?is)\bdelete\s+from\b")
+WHERE_RE = re.compile(r"(?is)\bwhere\b")
 
 
 def load_payload() -> Dict[str, Any]:
     try:
         return json.load(sys.stdin)
     except json.JSONDecodeError as exc:
-        print(f"Destructive command guard could not parse hook JSON: {exc}", file=sys.stderr)
-        raise SystemExit(0)
+        log_parse_failure(str(exc))
+        print(f"Blocked because the PreToolUse hook JSON could not be parsed: {exc}", file=sys.stderr)
+        raise SystemExit(2)
 
 
 def bash_command(payload: Dict[str, Any]) -> Optional[str]:
@@ -66,7 +65,17 @@ def first_violation(command: str) -> Optional[Tuple[str, str]]:
     for rule_name, pattern, reason in BLOCK_RULES:
         if pattern.search(command):
             return rule_name, reason
+    if has_delete_without_where(command):
+        return "delete without where", "DELETE FROM without a WHERE clause can erase every row."
     return None
+
+
+def has_delete_without_where(command: str) -> bool:
+    for match in DELETE_FROM_RE.finditer(command):
+        statement = command[match.start() :].split(";", 1)[0]
+        if not WHERE_RE.search(statement):
+            return True
+    return False
 
 
 def project_path(payload: Dict[str, Any]) -> str:
@@ -85,6 +94,20 @@ def log_block(payload: Dict[str, Any], command: str, rule_name: str) -> None:
         "project_path": project_path(payload),
         "rule": rule_name,
         "command": command,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def log_parse_failure(error: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+    record = {
+        "timestamp": timestamp,
+        "project_path": os.getcwd(),
+        "rule": "invalid hook json",
+        "command": "",
+        "error": error,
     }
     with LOG_PATH.open("a", encoding="utf-8") as log_file:
         log_file.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/hooks/destructive_bash_guard.py
+++ b/hooks/destructive_bash_guard.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+BLOCK_RULES: Tuple[Tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "recursive force delete",
+        re.compile(r"(?is)(?:^|[;&|]\s*)rm\s+(?=[^;&|]*-[^\s;&|]*r)(?=[^;&|]*-[^\s;&|]*f)\S*(?:\s|$)"),
+        "rm -rf can permanently delete files.",
+    ),
+    (
+        "drop table",
+        re.compile(r"(?is)\bdrop\s+table\b"),
+        "DROP TABLE can remove database schema and data.",
+    ),
+    (
+        "force push",
+        re.compile(r"(?is)\bgit\s+push\b[^\n;&|]*(?:--force(?:-with-lease)?|-f)(?:\s|$)"),
+        "git push --force can overwrite shared history.",
+    ),
+    (
+        "truncate",
+        re.compile(r"(?is)\btruncate(?:\s+table)?\b"),
+        "TRUNCATE can erase table contents immediately.",
+    ),
+    (
+        "delete without where",
+        re.compile(r"(?is)\bdelete\s+from\b(?:(?!;|\bwhere\b).)*(?:;|$)"),
+        "DELETE FROM without a WHERE clause can erase every row.",
+    ),
+)
+
+
+def load_payload() -> Dict[str, Any]:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"Destructive command guard could not parse hook JSON: {exc}", file=sys.stderr)
+        raise SystemExit(0)
+
+
+def bash_command(payload: Dict[str, Any]) -> Optional[str]:
+    if payload.get("tool_name") != "Bash":
+        return None
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+
+    command = tool_input.get("command")
+    return command if isinstance(command, str) else None
+
+
+def first_violation(command: str) -> Optional[Tuple[str, str]]:
+    for rule_name, pattern, reason in BLOCK_RULES:
+        if pattern.search(command):
+            return rule_name, reason
+    return None
+
+
+def project_path(payload: Dict[str, Any]) -> str:
+    for key in ("cwd", "workspace_path", "project_path"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return os.getcwd()
+
+
+def log_block(payload: Dict[str, Any], command: str, rule_name: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+    record = {
+        "timestamp": timestamp,
+        "project_path": project_path(payload),
+        "rule": rule_name,
+        "command": command,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    payload = load_payload()
+    command = bash_command(payload)
+    if command is None:
+        return 0
+
+    violation = first_violation(command)
+    if violation is None:
+        return 0
+
+    rule_name, reason = violation
+    log_block(payload, command, rule_name)
+    print(
+        "Blocked destructive Bash command before execution.\n"
+        f"Reason: {reason}\n"
+        "Use a narrower, reversible command or ask the user for explicit approval.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="${HOME}/.claude/hooks"
+mkdir -p "$hook_dir"
+cp "$(dirname "$0")/destructive_bash_guard.py" "$hook_dir/destructive_bash_guard.py"
+chmod +x "$hook_dir/destructive_bash_guard.py"
+
+echo "Installed destructive_bash_guard.py to $hook_dir"
+echo "Add it to your Claude Code PreToolUse hooks for the Bash tool."

--- a/hooks/test_destructive_bash_guard.py
+++ b/hooks/test_destructive_bash_guard.py
@@ -51,6 +51,7 @@ def main() -> int:
             "npm test || rm -rf build",
             "psql -c 'DROP TABLE users'",
             "git push --force origin main",
+            "git push --force-with-lease=main origin main",
             "sqlite3 app.db 'TRUNCATE sessions'",
             "sqlite3 app.db 'DELETE FROM users;'",
         ):
@@ -66,7 +67,7 @@ def main() -> int:
 
         log_path = tmp_home / ".claude" / "hooks" / "blocked.log"
         entries = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
-        assert len(entries) == 7
+        assert len(entries) == 8
         assert all("timestamp" in entry and "project_path" in entry and "command" in entry for entry in entries)
 
         invalid_json = subprocess.run(

--- a/hooks/test_destructive_bash_guard.py
+++ b/hooks/test_destructive_bash_guard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -25,7 +26,7 @@ def run_hook(command: str, tmp_home: Path) -> subprocess.CompletedProcess[str]:
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"HOME": str(tmp_home), "USERPROFILE": str(tmp_home)},
+        env={**os.environ, "HOME": str(tmp_home), "USERPROFILE": str(tmp_home)},
         check=False,
     )
 
@@ -46,6 +47,8 @@ def main() -> int:
         tmp_home = Path(home)
         for command in (
             "rm -rf build",
+            "npm test && rm -rf build",
+            "npm test || rm -rf build",
             "psql -c 'DROP TABLE users'",
             "git push --force origin main",
             "sqlite3 app.db 'TRUNCATE sessions'",
@@ -63,8 +66,20 @@ def main() -> int:
 
         log_path = tmp_home / ".claude" / "hooks" / "blocked.log"
         entries = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
-        assert len(entries) == 5
+        assert len(entries) == 7
         assert all("timestamp" in entry and "project_path" in entry and "command" in entry for entry in entries)
+
+        invalid_json = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input="{",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, "HOME": str(tmp_home), "USERPROFILE": str(tmp_home)},
+            check=False,
+        )
+        assert invalid_json.returncode == 2
+        assert "could not be parsed" in invalid_json.stderr
 
     print("destructive_bash_guard smoke tests passed")
     return 0

--- a/hooks/test_destructive_bash_guard.py
+++ b/hooks/test_destructive_bash_guard.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Smoke tests for destructive_bash_guard.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "destructive_bash_guard.py"
+
+
+def run_hook(command: str, tmp_home: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(ROOT),
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={"HOME": str(tmp_home), "USERPROFILE": str(tmp_home)},
+        check=False,
+    )
+
+
+def assert_blocked(command: str, tmp_home: Path) -> None:
+    result = run_hook(command, tmp_home)
+    assert result.returncode == 2, (command, result.returncode, result.stderr)
+    assert "Blocked destructive Bash command" in result.stderr
+
+
+def assert_allowed(command: str, tmp_home: Path) -> None:
+    result = run_hook(command, tmp_home)
+    assert result.returncode == 0, (command, result.returncode, result.stderr)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as home:
+        tmp_home = Path(home)
+        for command in (
+            "rm -rf build",
+            "psql -c 'DROP TABLE users'",
+            "git push --force origin main",
+            "sqlite3 app.db 'TRUNCATE sessions'",
+            "sqlite3 app.db 'DELETE FROM users;'",
+        ):
+            assert_blocked(command, tmp_home)
+
+        for command in (
+            "rm -r build",
+            "git push origin main",
+            "sqlite3 app.db 'DELETE FROM users WHERE id = 1;'",
+            "npm test",
+        ):
+            assert_allowed(command, tmp_home)
+
+        log_path = tmp_home / ".claude" / "hooks" / "blocked.log"
+        entries = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+        assert len(entries) == 5
+        assert all("timestamp" in entry and "project_path" in entry and "command" in entry for entry in entries)
+
+    print("destructive_bash_guard smoke tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a Claude Code `PreToolUse` hook that inspects Bash commands from hook JSON and blocks destructive patterns before execution.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, command, project path, and matched rule.
- Includes a two-command-or-fewer install path, README usage docs, and smoke tests for blocked and allowed commands.

## Blocked Patterns
- `rm -rf`
- `DROP TABLE`
- `git push --force` and `git push --force-with-lease`
- `TRUNCATE`
- `DELETE FROM` without a `WHERE` clause

## Verification
- `python hooks/test_destructive_bash_guard.py`
- `python -m py_compile hooks/destructive_bash_guard.py hooks/test_destructive_bash_guard.py`
- `git diff --check HEAD~1 HEAD`

Closes #3