### PR TITLE
Add changelog generator skill

### DIFF
--- a/skills/generate-changelog/README.md
+++ b/skills/generate-changelog/README.md
@@ -1,0 +1,28 @@
+# Generate Changelog
+
+Create a structured `CHANGELOG.md` from the current repository's git history.
+
+## Setup
+
+1. Copy `changelog.sh` into the root of any git repository.
+2. Run `bash changelog.sh`.
+3. Review the generated `CHANGELOG.md` before committing it.
+
+## Behavior
+
+The script finds the most recent git tag and includes commits from that tag to
+`HEAD`. If no tag exists, it includes the full history. Commit subjects are
+grouped into `Added`, `Fixed`, `Changed`, and `Removed` using common commit
+prefixes such as `feat:`, `fix:`, `remove:`, and `docs:`.
+
+Use `--stdout` to preview without writing a file:
+
+```bash
+bash changelog.sh --stdout
+```
+
+Use `--output` to choose a custom path:
+
+```bash
+bash changelog.sh --output docs/CHANGELOG.md
+```

--- a/skills/generate-changelog/changelog.sh
+++ b/skills/generate-changelog/changelog.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bash changelog.sh [--output CHANGELOG.md] [--stdout]
+
+Generates a Keep a Changelog-style CHANGELOG.md from commits since the most
+recent git tag. If the repository has no tags, all commits are included.
+USAGE
+}
+
+output_file="CHANGELOG.md"
+write_stdout=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      output_file="${2:-}"
+      if [[ -z "$output_file" ]]; then
+        echo "error: --output requires a path" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --stdout)
+      write_stdout=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: changelog.sh must be run inside a git repository" >&2
+  exit 1
+fi
+
+last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$last_tag" ]]; then
+  range="${last_tag}..HEAD"
+  range_label="since ${last_tag}"
+else
+  range="HEAD"
+  range_label="from initial commit"
+fi
+
+commit_lines="$(git log --reverse --pretty=format:'%s%x1f%h' "$range")"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+touch "$tmp_dir/added" "$tmp_dir/fixed" "$tmp_dir/changed" "$tmp_dir/removed"
+
+categorize_subject() {
+  local subject="$1"
+  local normalized
+  normalized="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  case "$normalized" in
+    feat:*|feat\(*|add:*|added:*|create:*|implement:*)
+      echo "added"
+      ;;
+    fix:*|fix\(*|bug:*|bugfix:*|hotfix:*|repair:*)
+      echo "fixed"
+      ;;
+    remove:*|removed:*|delete:*|deleted:*|drop:*|dropped:*|deprecate:*)
+      echo "removed"
+      ;;
+    *)
+      echo "changed"
+      ;;
+  esac
+}
+
+if [[ -n "$commit_lines" ]]; then
+  while IFS=$'\x1f' read -r subject hash; do
+    [[ -z "$subject" ]] && continue
+    category="$(categorize_subject "$subject")"
+    printf -- '- %s (%s)\n' "$subject" "$hash" >> "$tmp_dir/$category"
+  done <<< "$commit_lines"
+fi
+
+render_section() {
+  local title="$1"
+  local file="$2"
+
+  printf '### %s\n\n' "$title"
+  if [[ -s "$file" ]]; then
+    cat "$file"
+  else
+    printf -- '- No changes.\n'
+  fi
+  printf '\n'
+}
+
+{
+  printf '# Changelog\n\n'
+  printf '## Unreleased - %s\n\n' "$(date -u +%Y-%m-%d)"
+  printf '_Generated from git history %s._\n\n' "$range_label"
+  render_section "Added" "$tmp_dir/added"
+  render_section "Fixed" "$tmp_dir/fixed"
+  render_section "Changed" "$tmp_dir/changed"
+  render_section "Removed" "$tmp_dir/removed"
+} > "$tmp_dir/CHANGELOG.md"
+
+if [[ "$write_stdout" -eq 1 ]]; then
+  cat "$tmp_dir/CHANGELOG.md"
+else
+  cp "$tmp_dir/CHANGELOG.md" "$output_file"
+  echo "Wrote $output_file"
+fi

--- a/skills/generate-changelog/sample-output.md
+++ b/skills/generate-changelog/sample-output.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## Unreleased - 2026-06-13
+
+_Generated from git history since v1.0.0._
+
+### Added
+
+- feat: add webhook retry queue (a1b2c3d)
+
+### Fixed
+
+- fix: handle empty API responses (b2c3d4e)
+
+### Changed
+
+- docs: clarify setup steps (c3d4e5f)
+
+### Removed
+
+- remove: drop legacy config loader (d4e5f6a)

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+script="$repo_root/skills/generate-changelog/changelog.sh"
+
+tmp_repo="$(mktemp -d)"
+trap 'rm -rf "$tmp_repo"' EXIT
+
+git -C "$tmp_repo" init -q
+git -C "$tmp_repo" config user.email "test@example.com"
+git -C "$tmp_repo" config user.name "Test User"
+
+printf 'one\n' > "$tmp_repo/file.txt"
+git -C "$tmp_repo" add file.txt
+git -C "$tmp_repo" commit -q -m "chore: initial release"
+git -C "$tmp_repo" tag v1.0.0
+
+printf 'two\n' >> "$tmp_repo/file.txt"
+git -C "$tmp_repo" commit -am "feat: add webhook retry queue" -q
+
+printf 'three\n' >> "$tmp_repo/file.txt"
+git -C "$tmp_repo" commit -am "fix: handle empty API responses" -q
+
+printf 'four\n' >> "$tmp_repo/file.txt"
+git -C "$tmp_repo" commit -am "docs: clarify setup steps" -q
+
+printf 'five\n' >> "$tmp_repo/file.txt"
+git -C "$tmp_repo" commit -am "remove: drop legacy config loader" -q
+
+(cd "$tmp_repo" && bash "$script" --output CHANGELOG.md)
+
+grep -q "Generated from git history since v1.0.0" "$tmp_repo/CHANGELOG.md"
+grep -q "### Added" "$tmp_repo/CHANGELOG.md"
+grep -q "feat: add webhook retry queue" "$tmp_repo/CHANGELOG.md"
+grep -q "### Fixed" "$tmp_repo/CHANGELOG.md"
+grep -q "fix: handle empty API responses" "$tmp_repo/CHANGELOG.md"
+grep -q "### Changed" "$tmp_repo/CHANGELOG.md"
+grep -q "docs: clarify setup steps" "$tmp_repo/CHANGELOG.md"
+grep -q "### Removed" "$tmp_repo/CHANGELOG.md"
+grep -q "remove: drop legacy config loader" "$tmp_repo/CHANGELOG.md"
+
+echo "test_changelog.sh passed"


### PR DESCRIPTION
## Summary
- add a portable Bash changelog generator under `skills/generate-changelog/`
- categorize commits since the latest git tag into Added, Fixed, Changed, and Removed
- include three-step setup docs, sample output, and a shell regression test

## Validation
- `bash tests/test_changelog.sh`
- `bash -n skills/generate-changelog/changelog.sh tests/test_changelog.sh`
- `git diff --check`

Refs #1
Opire claim step: `/opire try` posted on #1 before opening this PR.