### PR TITLE
Add Claude PR review agent

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: pr-reviewer
+description: Review a GitHub pull request diff and draft a structured Markdown comment.
+tools: Bash, Read
+---
+
+You are a focused pull request reviewer. Given a GitHub PR URL, run:
+
+```bash
+agents/pr-reviewer/bin/claude-review --pr <PR_URL>
+```
+
+Read the generated Markdown, then add any repository-specific validation,
+missing-test, or acceptance-criteria observations that are evident from the
+current workspace. Keep the final comment structured as:
+
+- Summary of changes
+- Identified risks
+- Improvement suggestions
+- Confidence score: Low / Medium / High
+
+Do not approve a PR solely from the generated heuristic output. If the diff
+touches authentication, payments, secrets, CI permissions, database migrations,
+or package metadata, call out the exact area and request targeted validation.

--- a/agents/pr-reviewer/README.md
+++ b/agents/pr-reviewer/README.md
@@ -1,0 +1,25 @@
+# Claude PR Review Agent
+
+`claude-review` reads a GitHub pull request diff and returns a structured
+Markdown review comment with a summary, risk list, improvement suggestions, and
+confidence score.
+
+## Setup
+
+1. Add `agents/pr-reviewer/bin` to your `PATH`.
+2. Run `claude-review --pr https://github.com/owner/repo/pull/123`.
+3. Paste the generated Markdown into the PR after adding any project-specific test notes.
+
+## Claude Code Sub-Agent
+
+The companion sub-agent definition lives at `.claude/agents/pr-reviewer.md`.
+Use it when you want Claude Code to run the CLI, inspect the output, and add
+repository-specific context before posting a review.
+
+## Local Diff Mode
+
+For offline testing or CI:
+
+```bash
+claude-review --diff-file path/to/change.diff
+```

--- a/agents/pr-reviewer/bin/claude-review
+++ b/agents/pr-reviewer/bin/claude-review
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$script_dir/../claude_review.py" "$@"

--- a/agents/pr-reviewer/claude_review.py
+++ b/agents/pr-reviewer/claude_review.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Generate a structured Markdown review for a GitHub pull request diff."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+PR_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$")
+RISK_PATTERNS = [
+    ("Shell execution", re.compile(r"\b(subprocess\.[^(]+\(.*shell\s*=\s*True|os\.system\(|exec\(|eval\()")),
+    ("Destructive command", re.compile(r"\brm\s+-[^\n]*r[^\n]*f\b")),
+    ("Credential handling", re.compile(r"\b(secret|token|password|api[_-]?key)\b", re.I)),
+    ("Permissive CORS", re.compile(r"Access-Control-Allow-Origin['\"]?\s*[:=]\s*['\"]\*")),
+    ("Database mutation", re.compile(r"\b(delete\s+from|update\s+\w+\s+set)\b(?![^;\n]*\bwhere\b)", re.I)),
+]
+
+
+@dataclass
+class FileChange:
+    path: str
+    additions: int = 0
+    deletions: int = 0
+    risky_lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ReviewAnalysis:
+    files: list[FileChange]
+    total_additions: int
+    total_deletions: int
+    risks: list[str]
+    suggestions: list[str]
+    confidence: str
+
+
+def pr_to_diff_url(pr_url: str) -> str:
+    match = PR_RE.match(pr_url)
+    if not match:
+        raise ValueError("expected a GitHub pull request URL, for example https://github.com/owner/repo/pull/123")
+    owner, repo, number = match.groups()
+    return f"https://github.com/{owner}/{repo}/pull/{number}.diff"
+
+
+def fetch_pr_diff(pr_url: str) -> str:
+    request = urllib.request.Request(
+        pr_to_diff_url(pr_url),
+        headers={"User-Agent": "claude-review-agent"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"GitHub returned HTTP {exc.code} while fetching PR diff") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"could not fetch PR diff: {exc.reason}") from exc
+
+
+def parse_diff(diff_text: str) -> list[FileChange]:
+    files: list[FileChange] = []
+    current: FileChange | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            match = re.match(r"diff --git a/(.*?) b/(.*)", line)
+            path = match.group(2) if match else line.rsplit(" ", 1)[-1].removeprefix("b/")
+            current = FileChange(path=path)
+            files.append(current)
+            continue
+
+        if current is None:
+            continue
+
+        if line.startswith("+") and not line.startswith("+++"):
+            current.additions += 1
+            added = line[1:]
+            for label, pattern in RISK_PATTERNS:
+                if pattern.search(added):
+                    current.risky_lines.append(f"{label}: `{added.strip()[:140]}`")
+        elif line.startswith("-") and not line.startswith("---"):
+            current.deletions += 1
+
+    return files
+
+
+def analyze_diff(diff_text: str) -> ReviewAnalysis:
+    files = parse_diff(diff_text)
+    total_additions = sum(file.additions for file in files)
+    total_deletions = sum(file.deletions for file in files)
+    risks: list[str] = []
+    suggestions: list[str] = []
+
+    if not files:
+        risks.append("The diff appears to be empty or could not be parsed.")
+        suggestions.append("Confirm the PR branch contains committed changes before review.")
+
+    for file in files:
+        lowered = file.path.lower()
+        if file.risky_lines:
+            risks.extend(f"{file.path}: {line}" for line in file.risky_lines[:3])
+        if any(part in lowered for part in ("auth", "security", "permission", "payment", "secret")):
+            risks.append(f"{file.path}: touches a security-sensitive area and needs focused regression coverage.")
+        if lowered.endswith(("package-lock.json", "pnpm-lock.yaml", "yarn.lock", "package.json")):
+            risks.append(f"{file.path}: dependency or package metadata changed; verify install and supply-chain impact.")
+        if ".github/workflows/" in lowered:
+            risks.append(f"{file.path}: CI workflow changed; verify permissions and trigger scope are minimal.")
+        if "migration" in lowered or lowered.endswith(".sql"):
+            risks.append(f"{file.path}: database schema or migration logic changed; verify rollback and idempotency.")
+
+    if total_additions + total_deletions > 800:
+        risks.append("Large diff size increases review risk; split or add focused test evidence if possible.")
+    elif not risks:
+        risks.append("No obvious high-risk patterns were detected in the added lines.")
+
+    if not any("test" in file.path.lower() for file in files):
+        suggestions.append("Add or reference targeted tests for the changed behavior.")
+    if any(file.risky_lines for file in files):
+        suggestions.append("Document why flagged risky lines are safe, or replace them with narrower helpers.")
+    if any(".github/workflows/" in file.path.lower() for file in files):
+        suggestions.append("Pin workflow permissions and include a dry-run or workflow-dispatch validation note.")
+    if any(file.path.lower().endswith((".md", ".mdx", ".rst")) for file in files):
+        suggestions.append("Preview the rendered documentation to catch broken links, formatting, or stale examples.")
+    if not suggestions:
+        suggestions.append("Include exact validation commands in the PR description for reviewer reproducibility.")
+
+    confidence = "High"
+    if total_additions + total_deletions > 800 or any(file.risky_lines for file in files):
+        confidence = "Medium"
+    if not files or total_additions + total_deletions > 2000:
+        confidence = "Low"
+
+    return ReviewAnalysis(files, total_additions, total_deletions, risks, suggestions, confidence)
+
+
+def render_markdown(analysis: ReviewAnalysis, pr_url: str | None = None) -> str:
+    changed = ", ".join(file.path for file in analysis.files[:5])
+    if len(analysis.files) > 5:
+        changed += f", and {len(analysis.files) - 5} more"
+    changed = changed or "no parsed files"
+
+    lines = [
+        "## PR Review",
+        "",
+        "### Summary of changes",
+        "",
+        (
+            f"This PR changes {len(analysis.files)} file(s): {changed}. "
+            f"The parsed diff contains {analysis.total_additions} additions and "
+            f"{analysis.total_deletions} deletions."
+        ),
+        (
+            "The review below is generated from the pull request diff and should be "
+            "combined with project-specific test results before merge."
+        ),
+        "",
+        "### Identified risks",
+        "",
+    ]
+    lines.extend(f"- {risk}" for risk in analysis.risks)
+    lines.extend(["", "### Improvement suggestions", ""])
+    lines.extend(f"- {suggestion}" for suggestion in analysis.suggestions)
+    lines.extend(["", f"### Confidence score: {analysis.confidence}"])
+    if pr_url:
+        lines.extend(["", f"_Reviewed PR: {pr_url}_"])
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a structured Markdown PR review comment.")
+    parser.add_argument("--pr", help="GitHub pull request URL to fetch and review")
+    parser.add_argument("--diff-file", help="Local unified diff file to review, useful for tests")
+    args = parser.parse_args(argv)
+
+    if bool(args.pr) == bool(args.diff_file):
+        parser.error("provide exactly one of --pr or --diff-file")
+
+    try:
+        if args.pr:
+            diff_text = fetch_pr_diff(args.pr)
+            pr_url = args.pr
+        else:
+            diff_text = Path(args.diff_file).read_text(encoding="utf-8")
+            pr_url = None
+        print(render_markdown(analyze_diff(diff_text), pr_url=pr_url))
+    except Exception as exc:  # noqa: BLE001 - CLI error boundary
+        print(f"claude-review: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/pr-reviewer/samples/claude-builders-pr-2710.md
+++ b/agents/pr-reviewer/samples/claude-builders-pr-2710.md
@@ -1,0 +1,19 @@
+## PR Review
+
+### Summary of changes
+
+This PR changes 3 file(s): README.md, SKILL.md, changelog.sh. The parsed diff contains 295 additions and 31 deletions.
+The review below is generated from the pull request diff and should be combined with project-specific test results before merge.
+
+### Identified risks
+
+- No obvious high-risk patterns were detected in the added lines.
+
+### Improvement suggestions
+
+- Add or reference targeted tests for the changed behavior.
+- Preview the rendered documentation to catch broken links, formatting, or stale examples.
+
+### Confidence score: High
+
+_Reviewed PR: https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2710_

--- a/agents/pr-reviewer/samples/claude-builders-pr-2738.md
+++ b/agents/pr-reviewer/samples/claude-builders-pr-2738.md
@@ -1,0 +1,20 @@
+## PR Review
+
+### Summary of changes
+
+This PR changes 4 file(s): skills/generate-changelog/README.md, skills/generate-changelog/changelog.sh, skills/generate-changelog/sample-output.md, tests/test_changelog.sh. The parsed diff contains 213 additions and 0 deletions.
+The review below is generated from the pull request diff and should be combined with project-specific test results before merge.
+
+### Identified risks
+
+- skills/generate-changelog/changelog.sh: Destructive command: `trap 'rm -rf "$tmp_dir"' EXIT`
+- tests/test_changelog.sh: Destructive command: `trap 'rm -rf "$tmp_repo"' EXIT`
+
+### Improvement suggestions
+
+- Document why flagged risky lines are safe, or replace them with narrower helpers.
+- Preview the rendered documentation to catch broken links, formatting, or stale examples.
+
+### Confidence score: Medium
+
+_Reviewed PR: https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2738_

--- a/tests/test_claude_review.py
+++ b/tests/test_claude_review.py
@@ -1,0 +1,64 @@
+import textwrap
+import unittest
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module():
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "agents" / "pr-reviewer" / "claude_review.py"
+    spec = importlib.util.spec_from_file_location("claude_review", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+claude_review = load_module()
+
+
+class ClaudeReviewTest(unittest.TestCase):
+    def test_parses_and_categorizes_risks(self):
+        diff = textwrap.dedent(
+            """\
+            diff --git a/app/auth.py b/app/auth.py
+            index 1111111..2222222 100644
+            --- a/app/auth.py
+            +++ b/app/auth.py
+            @@ -1,2 +1,3 @@
+             def run(value):
+            +    eval(value)
+                 return True
+            diff --git a/tests/test_auth.py b/tests/test_auth.py
+            index 3333333..4444444 100644
+            --- a/tests/test_auth.py
+            +++ b/tests/test_auth.py
+            @@ -0,0 +1,2 @@
+            +def test_run():
+            +    assert True
+            """
+        )
+
+        analysis = claude_review.analyze_diff(diff)
+        rendered = claude_review.render_markdown(analysis, pr_url="https://github.com/o/r/pull/1")
+
+        self.assertEqual(len(analysis.files), 2)
+        self.assertIn("Shell execution", "\n".join(analysis.risks))
+        self.assertIn("security-sensitive", "\n".join(analysis.risks))
+        self.assertIn("Confidence score: Medium", rendered)
+        self.assertIn("https://github.com/o/r/pull/1", rendered)
+
+    def test_pr_url_validation(self):
+        self.assertEqual(
+            claude_review.pr_to_diff_url("https://github.com/owner/repo/pull/123"),
+            "https://github.com/owner/repo/pull/123.diff",
+        )
+        with self.assertRaises(ValueError):
+            claude_review.pr_to_diff_url("https://example.com/not-a-pr")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `claude-review` CLI that fetches a GitHub PR diff and emits a structured Markdown review
- include a Claude Code sub-agent definition for review workflow usage
- add sample outputs from two real GitHub PRs and unit coverage for URL parsing/risk analysis

## Sample outputs
- `agents/pr-reviewer/samples/claude-builders-pr-2738.md`
- `agents/pr-reviewer/samples/claude-builders-pr-2710.md`

## Validation
- `python3 -m unittest tests/test_claude_review.py -v`
- `agents/pr-reviewer/bin/claude-review --pr https://github.com/claude-builders-bounty/claude-builders-bounty/pull/2738 >/tmp/claude-review-smoke.md && test -s /tmp/claude-review-smoke.md`
- `python3 -m py_compile agents/pr-reviewer/claude_review.py tests/test_claude_review.py`
- `git diff --check`

Refs #4
Opire claim step: `/opire try` posted on #4 before opening this PR.