### PR TITLE
Add destructive bash blocker hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/hooks/block_destructive_bash.py",
+            "args": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ You're in the right place.
 
 ---
 
+## Destructive Bash Blocker Hook
+
+This repository includes a Claude Code `PreToolUse` hook that blocks dangerous Bash commands before execution.
+
+### Install
+
+1. `chmod +x install.sh`
+2. `./install.sh`
+
+The installer copies `hooks/block_destructive_bash.py` to `~/.claude/hooks/` and registers it in `~/.claude/settings.json`.
+
+### Blocked Patterns
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force` and `git push --force-with-lease`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log` as JSON with timestamp, attempted command, project path, and reason. Safe Bash commands produce no output and continue normally.
+
+---
+
 ## Community
 
 - 🐦 X: [@ClaudeBounty](https://x.com/ClaudeBounty)

--- a/hooks/block_destructive_bash.py
+++ b/hooks/block_destructive_bash.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+RM_RF_RE = re.compile(r"(?<![\w-])rm\s+-(?:[^\s;|&]*r[^\s;|&]*f|[^\s;|&]*f[^\s;|&]*r)\b", re.IGNORECASE)
+GIT_FORCE_PUSH_RE = re.compile(
+    r"(?<![\w-])git\s+push\b(?=[^;&|]*(?:--force(?:-with-lease)?\b|-f\b))",
+    re.IGNORECASE,
+)
+DROP_TABLE_RE = re.compile(r"\bdrop\s+table\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\btruncate(?:\s+table)?\b", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bwhere\b", re.IGNORECASE)
+
+
+def find_block_reason(command: str) -> str | None:
+    checks = (
+        (RM_RF_RE, "rm -rf can recursively delete files and directories."),
+        (GIT_FORCE_PUSH_RE, "git push --force can overwrite remote history."),
+        (DROP_TABLE_RE, "DROP TABLE can permanently remove database tables."),
+        (TRUNCATE_RE, "TRUNCATE can permanently remove table data."),
+    )
+    for pattern, reason in checks:
+        if pattern.search(command):
+            return reason
+
+    delete_match = DELETE_FROM_RE.search(command)
+    if delete_match:
+        statement_tail = command[delete_match.end() :]
+        statement_tail = re.split(r";|&&|\|\||\n", statement_tail, maxsplit=1)[0]
+        if not WHERE_RE.search(statement_tail):
+            return "DELETE FROM without a WHERE clause can remove every row in a table."
+
+    return None
+
+
+def log_blocked_attempt(command: str, project_path: str, reason: str) -> None:
+    log_path = Path(os.environ.get("CLAUDE_HOOK_LOG", "~/.claude/hooks/blocked.log")).expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "attempted_command": command,
+        "project_path": project_path,
+        "reason": reason,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Blocked destructive Bash command: {reason}",
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    if not command:
+        return 0
+
+    reason = find_block_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = str(
+        payload.get("cwd")
+        or payload.get("project_path")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+    log_blocked_attempt(command, project_path, reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="${CLAUDE_HOME:-$HOME/.claude}"
+HOOK_DIR="$CLAUDE_DIR/hooks"
+HOOK_TARGET="$HOOK_DIR/block_destructive_bash.py"
+SETTINGS_FILE="$CLAUDE_DIR/settings.json"
+
+mkdir -p "$HOOK_DIR"
+cp "$ROOT/hooks/block_destructive_bash.py" "$HOOK_TARGET"
+chmod +x "$HOOK_TARGET"
+
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+  PYTHON_BIN=(python3)
+elif command -v python >/dev/null 2>&1 && python -c "import sys" >/dev/null 2>&1; then
+  PYTHON_BIN=(python)
+elif command -v py >/dev/null 2>&1 && py -3 -c "import sys" >/dev/null 2>&1; then
+  PYTHON_BIN=(py -3)
+else
+  echo "error: Python 3 is required to install the hook" >&2
+  exit 1
+fi
+
+"${PYTHON_BIN[@]}" - "$SETTINGS_FILE" "$HOOK_TARGET" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_file = Path(sys.argv[1]).expanduser()
+hook_target = Path(sys.argv[2]).expanduser()
+settings_file.parent.mkdir(parents=True, exist_ok=True)
+
+if settings_file.exists():
+    try:
+        settings = json.loads(settings_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        raise SystemExit(f"Refusing to edit invalid JSON: {settings_file}")
+else:
+    settings = {}
+
+entry = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": str(hook_target),
+            "args": [],
+        }
+    ],
+}
+
+pre_tool_use = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+already_installed = any(
+    group.get("matcher") == "Bash"
+    and any(hook.get("command") == str(hook_target) for hook in group.get("hooks", []))
+    for group in pre_tool_use
+)
+if not already_installed:
+    pre_tool_use.append(entry)
+
+settings_file.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+print(f"Installed {hook_target}")
+print(f"Updated {settings_file}")
+PY

--- a/tests/test_block_destructive_bash.py
+++ b/tests/test_block_destructive_bash.py
@@ -1,0 +1,87 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "block_destructive_bash.py"
+
+
+def run_hook(command: str, *, tool_name: str = "Bash"):
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "blocked.log"
+        payload = {
+            "session_id": "test",
+            "cwd": "/tmp/example-project",
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": {"command": command},
+            "tool_use_id": "toolu_test",
+        }
+        env = os.environ.copy()
+        env["CLAUDE_HOOK_LOG"] = str(log_path)
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=False,
+        )
+        log_text = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        return result, log_text
+
+
+class BlockDestructiveBashTests(unittest.TestCase):
+    def assert_blocked(self, command: str, expected_reason: str):
+        result, log_text = run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("permissionDecision", result.stdout)
+        self.assertIn("deny", result.stdout)
+        self.assertIn(expected_reason, result.stdout)
+        log_entry = json.loads(log_text)
+        self.assertEqual(log_entry["attempted_command"], command)
+        self.assertEqual(log_entry["project_path"], "/tmp/example-project")
+        self.assertIn("timestamp", log_entry)
+
+    def assert_allowed(self, command: str):
+        result, log_text = run_hook(command)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(log_text, "")
+
+    def test_blocks_rm_rf(self):
+        self.assert_blocked("rm -rf build/", "rm -rf")
+
+    def test_blocks_drop_table(self):
+        self.assert_blocked('psql -c "DROP TABLE users"', "DROP TABLE")
+
+    def test_blocks_git_force_push(self):
+        self.assert_blocked("git push --force origin main", "git push --force")
+
+    def test_blocks_truncate(self):
+        self.assert_blocked('mysql -e "TRUNCATE TABLE sessions"', "TRUNCATE")
+
+    def test_blocks_delete_without_where(self):
+        self.assert_blocked('psql -c "DELETE FROM users"', "DELETE FROM without a WHERE")
+
+    def test_allows_delete_with_where(self):
+        self.assert_allowed('psql -c "DELETE FROM users WHERE id = 1"')
+
+    def test_allows_normal_bash(self):
+        self.assert_allowed("npm test && git status")
+
+    def test_ignores_non_bash_tool(self):
+        result, log_text = run_hook("rm -rf build", tool_name="Read")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(log_text, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a Claude Code `PreToolUse` hook that blocks destructive Bash commands before execution.
- Blocks `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` statements without `WHERE`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
- Adds a 2-command installer and project `.claude/settings.json` example.

## Verification

- `python -m unittest discover -s tests -v`
- Installed into a temporary `CLAUDE_HOME` with `C:\Program Files\Git\bin\bash.exe install.sh`.

All 8 hook behavior tests pass.

/claim #3

Closes #3
