### PR TITLE
[BOUNTY 0] Add CHANGELOG generator — Python script + shell wrapper + sample output

### DIFF
--- a/solutions/changelog-generator/README.md
+++ b/solutions/changelog-generator/README.md
@@ -1,0 +1,64 @@
+# Changelog Generator
+
+> Automatically generate a structured `CHANGELOG.md` from your project's git history.
+
+## Quick Start (3 steps)
+
+```bash
+# 1. Download the generator
+curl -O https://raw.githubusercontent.com/Super-yueyue/changelog-generator/main/generate_changelog.py
+
+# 2. Generate your changelog
+python3 generate_changelog.py
+
+# 3. Review the output
+cat CHANGELOG.md
+```
+
+## Features
+
+- **Auto-categorizes** commits into: `Added` / `Fixed` / `Changed` / `Removed` / `Deprecated` / `Security` / `Performance` / `Documentation`
+- **Smart parsing** — understands Conventional Commits (`feat:`, `fix(scope):`, etc.) and falls back to keyword matching
+- **Git tag aware** — generates changelog since the last tag by default
+- **Commit links** — includes clickable commit hashes when a repo URL is detected
+- **Keep a Changelog** format — follows the [popular convention](https://keepachangelog.com)
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--repo PATH` | Path to git repository (default: `.`) |
+| `--output FILE` | Output file (default: `CHANGELOG.md`) |
+| `--since REF` | Start from a specific tag/branch (default: last tag) |
+| `--version X.Y.Z` | Version number for this release |
+| `--repo-url URL` | Repository URL (auto-detected from git remote) |
+
+## Example Output
+
+```markdown
+# Changelog
+
+## [1.2.0] - 2026-06-14
+
+### Added
+- New user dashboard with real-time analytics (`a1b2c3d`)
+- Dark mode support for all pages (`e4f5g6h`)
+
+### Fixed
+- Resolved race condition in payment processing (`i7j8k9l`)
+- Fixed broken image uploads on Safari (`m0n1o2p`)
+
+### Changed
+- Upgraded dependencies to latest versions (`q3r4s5t`)
+- Refactored API client for better error handling (`u6v7w8x`)
+
+### Removed
+- Deprecated v1 API endpoints (`y9z0a1b`)
+```
+
+## How It Works
+
+1. Finds the most recent git tag (or uses all commits if no tags exist)
+2. Runs `git log` to collect commits since that tag
+3. Categorizes each commit by analyzing its subject line
+4. Writes a formatted `CHANGELOG.md` to the specified output path

--- a/solutions/changelog-generator/SAMPLE_CHANGELOG.md
+++ b/solutions/changelog-generator/SAMPLE_CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+## [Unreleased] - 2026-06-14
+
+> Auto-generated from [git history](https://github.com/brandonkindred/Khala-Agentic-AI-Teams)
+
+
+### Added
+
+- Add issue-dependency indicator to the coding team github issues picker (#787) ([`03fad1f`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/03fad1f))
+- Add code review panel: run reviewer agents on a github pr (#795) ([`d56c75f`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/d56c75f))
+- Add cognitivecontext facade (cognition step 8) (#835) ([`2ffacfc`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/2ffacfc))
+- Add live code-review progress, current-activity reporting, and stall detection (#847) ([`ecdca02`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/ecdca02))
+- Add code review guide for task-changed files and prevent input truncation ([`7fb5b0c`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/7fb5b0c))
+- Address review feedback: translate to english, fix script bugs, add detail ([`144e9a8`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/144e9a8))
+
+### Fixed
+
+- Fix coding-team tech lead review deadlock; route rejections back to the engineer (#776) ([`1317d0d`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/1317d0d))
+- Fix coding-team re-implementation/re-planning loop (#778) ([`5d38a9f`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/5d38a9f))
+- Fix rule-probe exit synthesis so stop-loss no longer pre-empts the targeted exit (#790) ([`4e8aeaf`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/4e8aeaf))
+- Drop arbitrary 1-3 word cap from naming convention rules (#865) ([`34e5e56`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/34e5e56))
+
+### Changed
+
+- Harden crypto -usd canonicalization against compound/empty suffixes (#773) ([`24801c0`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/24801c0))
+- [cognition][step 7] tools layer (#766) ([`25b7d56`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/25b7d56))
+- Coding team: active repo-inspection tools (list_files / read_file) for the senior swe agent (#780) ([`51adae7`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/51adae7))
+- Coding team: stop truncating llm inputs (#784) ([`680638a`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/680638a))
+- Coding team: human-in-the-loop decision gate (spec-023) (#782) ([`b38c0f0`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/b38c0f0))
+- Consolidate background-heartbeat scaffolding into a shared helper (#785) ([`915c653`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/915c653))
+- Stop truncating senior swe repo-context briefing (#792) ([`b9912f9`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/b9912f9))
+- Replace synthetic-data rule validation with deterministic math in strategy lab (#797) ([`df704d8`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/df704d8))
+- Exponential backoff for 429 rate limits (300s first retry) (#789) ([`dff1612`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/dff1612))
+- Knowledge-graph layer for agent cognition (neo4j + graphiti) (#805) ([`7268675`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/7268675))
+- Make max_position_pct a pre-entry sizing bound for all engine sizing kinds (#814) ([`9561dda`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/9561dda))
+- Strategy lab: harden refinement agent against unparseable llm output (#809) ([`2c48ed1`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/2c48ed1))
+- Coding team: surface agent thinking tokens in the ui (#811) ([`d79e18b`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/d79e18b))
+- Consolidate per-trade loss into max_position_pct; decouple stop_loss (#817) ([`8639c83`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/8639c83))
+- Move env-var reference detail out of claude.md into docs/env_vars.md (#829) ([`2fd02a9`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/2fd02a9))
+- Dedupe defensive-parsing notes in docs/env_vars.md (#832) ([`b034960`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/b034960))
+- Agent cognition graph sync: re-ingest rollup summaries per version (#820) ([`bd0c3bf`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/bd0c3bf))
+- Extract barpredicate ir into a dedicated module with snapshot tests (#821) ([`09d1603`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/09d1603))
+- Strategy lab: forward the strands transport timeout instead of dropping it (#834) ([`dd2cf13`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/dd2cf13))
+- Code review page: inline pr expansion + persisted per-pr review history (#831) ([`a7eed05`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/a7eed05))
+- Collapse duplicate json extractors onto shared string-aware helper (#838) ([`a6c2129`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/a6c2129))
+- Slim claude.md to core guidance with pointers to detailed docs (#844) ([`9e93a08`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/9e93a08))
+- Llm client: proof-of-change thinking-downgrade retry for empty responses (#839) ([`40949f1`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/40949f1))
+- Cognition step 10: invoke gate — idempotent inject-on-invoke / writeback-on-return at the boundary (#841) ([`99478ae`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/99478ae))
+- [cognition][step 11] ledger hygiene: gc terminal runs in the central scheduler (#853) ([`65832b2`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/65832b2))
+- Code review: bounded per-file chunking with always-on map-reduce coordinator (#852) ([`60d4618`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/60d4618))
+- Cognition step 12: operator hitl api — memory inspect, author tagging, gateway gating (#854) ([`17af193`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/17af193))
+- [cognition][step 13] seed rule packs install on first provision + config/env docs (#856) ([`8c39bbe`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/8c39bbe))
+- Findings-only synthesis pass for the merged review summary (stage 2) (#855) ([`5d2819b`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/5d2819b))
+- Restore structured block fields on replay of blocked runs (#857) ([`348e8f5`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/348e8f5))
+- [cognition][step 14] generator wiring: stamp + consume the cognition core (agentic team) (#858) ([`1a63f4c`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/1a63f4c))
+- Merge branch 'main' into docs/code-review-guide ([`b0876ce`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/b0876ce))
+- Merge branch 'main' into docs/code-review-guide ([`df12191`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/df12191))
+
+### Removed
+
+- Remove genuine string truncation from strategy lab llm prompts (#793) ([`878b9ab`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/878b9ab))
+- Strategy lab: remove expected-trade-count anomaly gate (#819) ([`10c171e`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/10c171e))
+- Remove spec-unaware diversification warning from backtest anomaly gate (#828) ([`16eaf74`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/16eaf74))
+- Remove issue-number refs and phase-history narration from claude.md (#840) ([`fe315fc`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/fe315fc))
+- Remove max-drawdown constraint; stop llm reviewer vetoing on sizing/risk math (#869) ([`94fafe9`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/94fafe9))
+
+### Documentation
+
+- Add agent architecture document (#781) ([`a21d905`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/a21d905))
+- De-duplicate claude.md sections covered by linked readmes (#836) ([`42a5d86`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/42a5d86))
+- Relocate strategy_lab_* knob reference to strategy lab readme (#837) ([`34a1172`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/34a1172))
+
+### CI/CD
+
+- Run shared_neo4j + agent_cognition suites under the 90% coverage gate (#815) ([`55bf135`](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/commit/55bf135))

--- a/solutions/changelog-generator/changelog.sh
+++ b/solutions/changelog-generator/changelog.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# changelog.sh — Wrapper script for generate_changelog.py
+# Usage: bash changelog.sh [--version X.Y.Z] [--repo /path/to/repo]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/generate_changelog.py" "$@"

--- a/solutions/changelog-generator/generate_changelog.py
+++ b/solutions/changelog-generator/generate_changelog.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+generate_changelog.py — Auto-generate CHANGELOG.md from git history
+Usage: python3 generate_changelog.py [--repo PATH] [--output CHANGELOG.md] [--since TAG]
+
+Generates a structured CHANGELOG.md by categorizing commits since the last git tag.
+Categories: Added, Fixed, Changed, Removed, Deprecated, Security, Performance
+"""
+
+import subprocess
+import re
+import os
+import sys
+from datetime import datetime
+from typing import List, Dict
+
+
+def run_git(cmd: List[str], cwd: str = ".") -> str:
+    """Run a git command and return stdout, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git"] + cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=cwd,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""
+
+
+def get_last_tag(cwd: str = ".") -> str:
+    """Get the most recent git tag, or 'HEAD' if none exist."""
+    tag = run_git(["describe", "--tags", "--abbrev=0"], cwd=cwd)
+    return tag if tag else None
+
+
+def get_commits_since(since: str, cwd: str = ".") -> List[Dict[str, str]]:
+    """Get all commits since a given ref, with hash, subject, body."""
+    if since:
+        log_range = f"{since}..HEAD"
+    else:
+        log_range = "--all"
+
+    raw = run_git(
+        ["log", log_range, "--pretty=format:%H||%s||%an||%ai", "--reverse"],
+        cwd=cwd,
+    )
+    if not raw:
+        return []
+
+    commits = []
+    for line in raw.split("\n"):
+        parts = line.split("||", 3)
+        if len(parts) >= 3:
+            commits.append({
+                "hash": parts[0][:7],
+                "subject": parts[1],
+                "author": parts[2],
+                "date": parts[3] if len(parts) > 3 else "",
+            })
+    return commits
+
+
+def categorize_commit(subject: str) -> str:
+    """Categorize a commit by its subject line using Conventional Commits prefixes."""
+    s = subject.lower().strip()
+
+    # Commit type patterns — ordered by priority
+    patterns = [
+        (r"^feat(\(.+?\))?!?:", "Added"),
+        (r"^fix(\(.+?\))?!?:", "Fixed"),
+        (r"^perf(\(.+?\))?!?:", "Performance"),
+        (r"^security", "Security"),
+        (r"^refactor(\(.+?\))?!?:", "Changed"),
+        (r"^style(\(.+?\))?!?:", "Changed"),
+        (r"^revert", "Removed"),
+        (r"^remove", "Removed"),
+        (r"^deprecate", "Deprecated"),
+        (r"^chore(\(.+?\))?!?:", "Changed"),
+        (r"^docs(\(.+?\))?!?:", "Documentation"),
+        (r"^test(\(.+?\))?!?:", "Testing"),
+        (r"^ci(\(.+?\))?!?:", "CI/CD"),
+        (r"^build(\(.+?\))?!?:", "Build"),
+        # Fallback keyword matching
+        (r"\b(?:add|new|create|implement|introduce)\b", "Added"),
+        (r"\b(?:fix|bug|patch|hotfix|correct|resolve)\b", "Fixed"),
+        (r"\b(?:remove|delete|drop|deprecate|phase.out)\b", "Removed"),
+        (r"\b(?:refactor|rewrite|redesign|restructure)\b", "Changed"),
+        (r"\b(?:upgrade|update|bump|migrate)\b", "Changed"),
+    ]
+
+    for pattern, category in patterns:
+        if re.search(pattern, s):
+            return category
+
+    # Commits that don't match any known pattern → "Changed"
+    return "Changed"
+
+
+def format_changelog(
+    commits: List[Dict[str, str]],
+    version: str = None,
+    repo_url: str = None,
+) -> str:
+    """Format commits into a CHANGELOG.md following Keep a Changelog convention."""
+    if not commits:
+        return "# Changelog\n\nNo commits found since the last tag.\n"
+
+    # Categorize
+    categories: Dict[str, List[Dict]] = {}
+    for c in commits:
+        cat = categorize_commit(c["subject"])
+        categories.setdefault(cat, []).append(c)
+
+    # Build header
+    today = datetime.now().strftime("%Y-%m-%d")
+    header = f"# Changelog\n\n"
+    if version:
+        header += f"## [{version}] - {today}\n"
+    else:
+        header += f"## [Unreleased] - {today}\n"
+    if repo_url:
+        header += f"\n> Auto-generated from [git history]({repo_url})\n"
+
+    lines = [header]
+
+    # Category order
+    order = ["Added", "Fixed", "Changed", "Removed", "Deprecated",
+             "Security", "Performance", "Documentation", "Testing", "CI/CD", "Build"]
+
+    for cat in order:
+        items = categories.pop(cat, [])
+        if items:
+            lines.append(f"\n### {cat}\n")
+            for c in items:
+                scope = ""
+                m = re.match(r"^\w+(\([^)]+\))?!?: (.+)", c["subject"])
+                if m:
+                    desc = m.group(2)
+                else:
+                    desc = c["subject"]
+                link = f"[`{c['hash']}`]({repo_url}/commit/{c['hash']})" if repo_url else f"`{c['hash']}`"
+                lines.append(f"- {desc.capitalize()} ({link})")
+
+    # Any remaining uncategorized
+    for cat, items in categories.items():
+        lines.append(f"\n### {cat}\n")
+        for c in items:
+            link = f"[`{c['hash']}`]({repo_url}/commit/{c['hash']})" if repo_url else f"`{c['hash']}`"
+            lines.append(f"- {c['subject'].capitalize()} ({link})")
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate CHANGELOG.md from git history"
+    )
+    parser.add_argument(
+        "--repo", "-r",
+        default=".",
+        help="Path to the git repository (default: current dir)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default="CHANGELOG.md",
+        help="Output file path (default: CHANGELOG.md)",
+    )
+    parser.add_argument(
+        "--since", "-s",
+        default=None,
+        help="Generate changelog since this ref (default: last tag)",
+    )
+    parser.add_argument(
+        "--version", "-v",
+        default=None,
+        help="Version number for this release",
+    )
+    parser.add_argument(
+        "--repo-url", "-u",
+        default=None,
+        help="Repository URL for commit links",
+    )
+
+    args = parser.parse_args()
+
+    # Determine the starting point
+    since = args.since or get_last_tag(args.repo)
+    if since:
+        print(f"ℹ️  Generating changelog since: {since}")
+    else:
+        print("ℹ️  No tags found — generating changelog from all commits")
+
+    # Fetch commits
+    commits = get_commits_since(since, args.repo)
+    print(f"ℹ️  Found {len(commits)} commits")
+
+    if not commits:
+        print("⚠️  No commits found. Nothing to generate.")
+        sys.exit(0)
+
+    # Auto-detect repo URL if not provided
+    repo_url = args.repo_url
+    if not repo_url:
+        remote = run_git(["remote", "get-url", "origin"], cwd=args.repo)
+        if remote:
+            # Convert SSH/HTTPS to web URL
+            remote = remote.replace("git@", "https://").replace(".git", "")
+            remote = remote.replace("github.com:", "github.com/")
+            if remote.startswith("https://"):
+                repo_url = remote
+
+    # Generate
+    changelog = format_changelog(commits, args.version, repo_url)
+
+    # Write output
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(changelog)
+
+    print(f"✅  CHANGELOG written to {args.output}")
+    print(f"📝  Preview:\n")
+    # Show first 15 lines as preview
+    preview_lines = changelog.split("\n")[:15]
+    for line in preview_lines:
+        print(f"   {line}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a configurable CHANGELOG.md generator that automatically creates structured changelogs from git history.

## What's included

- `generate_changelog.py` — Python script with smart commit categorization
- `changelog.sh` — Simple bash wrapper
- `README.md` — 3-step setup instructions
- `SAMPLE_CHANGELOG.md` — Generated output from a real GitHub repo

## Features

- Auto-categorizes commits into: Added / Fixed / Changed / Removed / Deprecated / Security / Performance / Documentation
- Understands Conventional Commits format (`feat:`, `fix(scope):`, etc.) with keyword fallback
- Auto-detects last git tag for release-to-release changelogs
- Generates Keep a Changelog compliant format with clickable commit links
- Configurable: custom repo path, output file, version number, since ref

## How to use



## Sample output

The PR includes SAMPLE_CHANGELOG.md generated from a real 52-commit history of an active open-source project.

Closes #1