### PR TITLE
[BOUNTY $100] HOOK: Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/hooks/pre-tool-use/README.md
+++ b/hooks/pre-tool-use/README.md
@@ -1,0 +1,40 @@
+# Claude Code Pre-Tool-Use Hook — Destructive Command Blocker
+
+Blocks dangerous bash commands (`rm -rf`, `DROP TABLE`, `git push --force`, etc.)
+before they execute.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks && ln -sf "$PWD/blocker.py" ~/.claude/hooks/pre-tool-use
+```
+
+That is it. The hook activates on Claude Code's next tool use.
+
+## What It Blocks
+
+| Pattern | Example |
+|---------|---------|
+| Recursive force delete | `rm -rf /` |
+| Database DROP | `DROP TABLE users` |
+| Force push | `git push --force` |
+| TRUNCATE | `TRUNCATE orders` |
+| DELETE without WHERE | `DELETE FROM users` |
+| ALTER TABLE DROP | `ALTER TABLE projects DROP COLUMN budget` |
+| Format filesystem | `mkfs.ext4 /dev/sda1` |
+| Mass permission change | `chmod -R 000 /` |
+
+## What It Allows (Safe Variants)
+- `rm -rf ./node_modules`
+- `DROP TABLE IF EXISTS`
+- `DELETE FROM x WHERE y`
+- `git push --force-with-lease`
+
+## Logs
+
+Blocked commands are logged to `~/.claude/hooks/blocked.log` with timestamp,
+command, reason, and project path.
+
+## Customization
+
+Edit `DESTRUCTIVE_PATTERNS` and `SAFE_OVERRIDES` in `blocker.py`.

--- a/hooks/pre-tool-use/blocker.py
+++ b/hooks/pre-tool-use/blocker.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Claude Code pre-tool-use hook: blocks destructive bash commands."""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
+DESTRUCTIVE_PATTERNS = [
+    (re.compile(r'\brm\s+(-rf?|--recursive\s+--force)\s+'), "rm -rf without relative path"),
+    (re.compile(r'\bDROP\s+(TABLE|DATABASE|SCHEMA)\b', re.IGNORECASE), "SQL DROP statement"),
+    (re.compile(r'\bgit\s+push\s+.*--force\b'), "Git force push"),
+    (re.compile(r'\bTRUNCATE\s+', re.IGNORECASE), "SQL TRUNCATE"),
+    (re.compile(r'\bDELETE\s+FROM\b(?!.*\bWHERE\b)', re.IGNORECASE), "DELETE without WHERE"),
+    (re.compile(r'\bALTER\s+TABLE.*DROP\b', re.IGNORECASE), "ALTER TABLE DROP"),
+    (re.compile(r'\bmkfs\.?\b'), "Format filesystem"),
+    (re.compile(r'\bchmod\s+-R\s+0{3,4}\s+/'), "Chmod root recursively"),
+]
+
+SAFE_OVERRIDES = [
+    re.compile(r'\brm\s+(-rf?|--recursive\s+--force)\s+(\.\/|\.\s)'),
+    re.compile(r'\bDROP\s+TABLE\s+IF\s+EXISTS\b'),
+    re.compile(r'\bDELETE\s+FROM\s+\w+\s+WHERE\b'),
+    re.compile(r'\bgit\s+push\s+--force-with-lease\b'),
+]
+
+
+def log_blocked(command, reason, project_path):
+    entry = {
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "command": command[:500],
+        "reason": reason,
+        "project_path": project_path,
+    }
+    with open(LOG_FILE, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def check_command(command, project_path):
+    for pattern in SAFE_OVERRIDES:
+        if pattern.search(command):
+            return False
+    for pattern, reason in DESTRUCTIVE_PATTERNS:
+        if pattern.search(command):
+            log_blocked(command, reason, project_path)
+            print(
+                f"[BLOCKED] {reason}",
+                file=sys.stderr,
+            )
+            print(
+                f"  Command: {command[:200]}",
+                file=sys.stderr,
+            )
+            print(
+                f"  Logged to: {LOG_FILE}",
+                file=sys.stderr,
+            )
+            print(
+                "  Use --force-with-lease instead of --force, or"
+                " add a SAFE_OVERRIDES pattern.",
+                file=sys.stderr,
+            )
+            return True
+    return False
+
+
+def main():
+    raw = sys.stdin.read()
+    input_data = json.loads(raw)
+    tool_use = input_data.get("toolUse", {})
+    if tool_use.get("name") != "bash":
+        print(json.dumps({"blocked": False}))
+        return
+    inp = tool_use.get("input", {})
+    command = ""
+    if isinstance(inp, dict):
+        command = inp.get("command", "")
+    elif isinstance(inp, list):
+        for item in inp:
+            if isinstance(item, dict) and "command" in item:
+                command = item["command"]
+                break
+    project_path = os.getcwd()
+    blocked = check_command(command, project_path)
+    print(json.dumps({"blocked": blocked}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `hooks/pre-tool-use/blocker.py` — a Claude Code `pre-tool-use` hook that intercepts dangerous bash commands before they execute, plus `hooks/pre-tool-use/README.md` with install instructions.

## Acceptance Criteria

- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE clause
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, reason, and project path
- [x] Displays a clear message to Claude explaining why the command was blocked
- [x] Does not interfere with normal bash commands
- [x] README with installation in 2 commands or fewer

## Hook Architecture

The hook uses two configurable regex lists:

**DESTRUCTIVE_PATTERNS** — triggers a block:
- `rm -rf` without a relative path
- SQL DDL statements (DROP, TRUNCATE, ALTER...DROP, DELETE without WHERE)
- Git force push (not --force-with-lease)
- Filesystem operations (mkfs, chmod -R 000 /)

**SAFE_OVERRIDES** — explicitly allowed:
- `rm -rf ./node_modules` (relative paths)
- `DROP TABLE IF EXISTS` (migration-safe)
- `DELETE FROM ... WHERE ...` (scoped)
- `git push --force-with-lease` (safer force)

## Install

```bash
mkdir -p ~/.claude/hooks && ln -sf \\/home/kish/Documents/projects/claude-builders-bounty/blocker.py\ ~/.claude/hooks/pre-tool-use
```

That is it. No dependencies beyond Python 3.