### PR TITLE
feat: add destructive bash command hook

### DIFF
--- a/hooks/destructive-command-blocker/README.md
+++ b/hooks/destructive-command-blocker/README.md
@@ -1,0 +1,54 @@
+# Destructive Command Blocker Hook
+
+Blocks risky Bash commands before Claude Code can run them.
+
+## Install
+
+```bash
+python hooks/destructive-command-blocker/install.py
+```
+
+## What It Blocks
+
+- `rm -rf` and equivalent recursive-force `rm` flag combinations
+- `DROP TABLE`
+- `git push --force`, `git push --force-with-lease`, and `git push -f`
+- `TRUNCATE`
+- `DELETE FROM` statements that do not include a `WHERE` clause
+
+Blocked attempts are appended to `~/.claude/hooks/blocked.log` with a timestamp,
+the attempted command, and the project path from the Claude Code hook payload.
+
+## How It Works
+
+The installer copies `block_destructive_bash.py` into `~/.claude/hooks/` and
+adds this Claude Code hook configuration to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ~/.claude/hooks/block_destructive_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For safe commands, the hook exits silently and does not change Claude Code's
+normal permission flow. For blocked commands, it returns a `PreToolUse` deny
+decision with a clear reason for Claude.
+
+## Verify
+
+```bash
+python hooks/destructive-command-blocker/test_block_destructive_bash.py
+```
+

--- a/hooks/destructive-command-blocker/block_destructive_bash.py
+++ b/hooks/destructive-command-blocker/block_destructive_bash.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+LOG_PATH = Path(os.environ.get("CLAUDE_BLOCKED_LOG_PATH", Path.home() / ".claude" / "hooks" / "blocked.log"))
+
+
+BLOCK_PATTERNS = [
+    (
+        "rm recursive-force",
+        re.compile(r"(?:^|[;&|]\s*|\b(?:sudo|env)\s+)rm\s+(?=[^;&|]*-[^\s;&|]*r)(?=[^;&|]*-[^\s;&|]*f)", re.IGNORECASE),
+        "Recursive force removal is blocked. Use a scoped delete or ask the user to approve it explicitly.",
+    ),
+    (
+        "git push force",
+        re.compile(r"\bgit\s+push\b(?=[^;&|]*(?:--force(?:-with-lease)?\b|-f\b))", re.IGNORECASE),
+        "Force-pushing is blocked. Use a normal push or ask the user to approve rewriting remote history.",
+    ),
+]
+
+DROP_TABLE_RE = re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE)
+TRUNCATE_RE = re.compile(r"\bTRUNCATE\b", re.IGNORECASE)
+DELETE_FROM_RE = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+WHERE_RE = re.compile(r"\bWHERE\b", re.IGNORECASE)
+READ_ONLY_SCAN_RE = re.compile(r"^\s*(?:git\s+grep|grep|rg|ag|ack)\b", re.IGNORECASE)
+
+
+def delete_from_without_where(command: str) -> bool:
+    """Return True when any DELETE FROM statement segment lacks a WHERE clause."""
+
+    for match in DELETE_FROM_RE.finditer(command):
+        segment = command[match.end() :]
+        statement = re.split(r"[;\n\r]", segment, maxsplit=1)[0]
+        if not WHERE_RE.search(statement):
+            return True
+    return False
+
+
+def command_segment_at(command: str, index: int) -> str:
+    start = max(command.rfind(separator, 0, index) for separator in (";", "&", "|", "\n", "\r"))
+    end_candidates = [pos for separator in (";", "&", "|", "\n", "\r") if (pos := command.find(separator, index)) != -1]
+    end = min(end_candidates) if end_candidates else len(command)
+    return command[start + 1 : end]
+
+
+def is_read_only_scan_match(command: str, index: int) -> bool:
+    return bool(READ_ONLY_SCAN_RE.match(command_segment_at(command, index)))
+
+
+def destructive_sql_reason(command: str) -> str | None:
+    for match in DROP_TABLE_RE.finditer(command):
+        if not is_read_only_scan_match(command, match.start()):
+            return "DROP TABLE: DROP TABLE is blocked. Use a migration review flow or ask the user for explicit approval."
+
+    for match in TRUNCATE_RE.finditer(command):
+        if not is_read_only_scan_match(command, match.start()):
+            return "TRUNCATE: TRUNCATE is blocked because it can delete large amounts of data."
+
+    return None
+
+
+def blocked_reason(command: str) -> str | None:
+    """Return a human-readable block reason for a command, or None if safe."""
+
+    for label, pattern, reason in BLOCK_PATTERNS:
+        if pattern.search(command):
+            return f"{label}: {reason}"
+
+    sql_reason = destructive_sql_reason(command)
+    if sql_reason is not None:
+        return sql_reason
+
+    if delete_from_without_where(command):
+        return "DELETE FROM without WHERE: Unqualified DELETE statements are blocked. Add a WHERE clause or ask for explicit approval."
+
+    return None
+
+
+def read_payload() -> dict[str, Any]:
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        print(f"Could not parse Claude Code hook input as JSON: {exc}", file=sys.stderr)
+        return {}
+
+
+def log_blocked_attempt(command: str, cwd: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    safe_command = command.replace("\n", "\\n").replace("\r", "\\r")
+    safe_cwd = cwd.replace("\n", "\\n").replace("\r", "\\r")
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        log_file.write(f"{timestamp}\t{safe_cwd}\t{reason}\t{safe_command}\n")
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Blocked destructive Bash command. {reason}",
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def main() -> int:
+    payload = read_payload()
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    reason = blocked_reason(command)
+    if reason is None:
+        return 0
+
+    cwd = str(payload.get("cwd") or "")
+    log_blocked_attempt(command, cwd, reason)
+    deny(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-blocker/install.py
+++ b/hooks/destructive-command-blocker/install.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Install the destructive Bash command blocker into Claude Code settings."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+HOOK_NAME = "block_destructive_bash.py"
+
+
+def python_command(hook_path: Path) -> str:
+    executable = sys.executable or "python3"
+    if os.name == "nt":
+        return subprocess.list2cmdline([executable, str(hook_path)])
+    return " ".join(shlex.quote(part) for part in (executable, str(hook_path)))
+
+
+def load_settings(settings_path: Path) -> dict:
+    if not settings_path.exists():
+        return {}
+
+    with settings_path.open("r", encoding="utf-8") as settings_file:
+        return json.load(settings_file)
+
+
+def save_settings(settings_path: Path, settings: dict) -> None:
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    with settings_path.open("w", encoding="utf-8") as settings_file:
+        json.dump(settings, settings_file, indent=2)
+        settings_file.write("\n")
+
+
+def add_hook(settings: dict, command: str) -> bool:
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    hook_entry = {"type": "command", "command": command}
+    matcher_entry = {"matcher": "Bash", "hooks": [hook_entry]}
+
+    for entry in pre_tool_use:
+        if entry.get("matcher") != "Bash":
+            continue
+
+        existing_hooks = entry.setdefault("hooks", [])
+        for existing_hook in existing_hooks:
+            if existing_hook.get("type") == "command" and HOOK_NAME in existing_hook.get("command", ""):
+                existing_hook["command"] = command
+                return False
+        existing_hooks.append(hook_entry)
+        return True
+
+    pre_tool_use.append(matcher_entry)
+    return True
+
+
+def main() -> int:
+    source_hook = Path(__file__).with_name(HOOK_NAME)
+    claude_dir = Path.home() / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    installed_hook = hooks_dir / HOOK_NAME
+    settings_path = claude_dir / "settings.json"
+
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_hook, installed_hook)
+
+    settings = load_settings(settings_path)
+    command = python_command(installed_hook)
+    added = add_hook(settings, command)
+    save_settings(settings_path, settings)
+
+    action = "Added" if added else "Updated"
+    print(f"{action} PreToolUse Bash hook: {command}")
+    print(f"Blocked attempts will be logged to: {hooks_dir / 'blocked.log'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/destructive-command-blocker/test_block_destructive_bash.py
+++ b/hooks/destructive-command-blocker/test_block_destructive_bash.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Unit tests for the destructive Bash command blocker."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import block_destructive_bash as hook
+
+
+HOOK_PATH = Path(__file__).with_name("block_destructive_bash.py")
+
+
+class BlockedReasonTests(unittest.TestCase):
+    def assert_blocked(self, command: str) -> None:
+        self.assertIsNotNone(hook.blocked_reason(command), command)
+
+    def assert_allowed(self, command: str) -> None:
+        self.assertIsNone(hook.blocked_reason(command), command)
+
+    def test_blocks_recursive_force_rm(self) -> None:
+        self.assert_blocked("rm -rf build")
+        self.assert_blocked("rm -fr ./tmp")
+        self.assert_blocked("sudo rm -rf /var/tmp/app")
+
+    def test_allows_scoped_rm(self) -> None:
+        self.assert_allowed("rm build/output.txt")
+        self.assert_allowed("rm -r build/cache")
+        self.assert_allowed("rm -f build/output.txt")
+
+    def test_blocks_sql_destruction(self) -> None:
+        self.assert_blocked("psql -c 'DROP TABLE users'")
+        self.assert_blocked("mysql -e 'TRUNCATE sessions'")
+        self.assert_blocked("psql -c 'DELETE FROM users'")
+
+    def test_allows_delete_with_where(self) -> None:
+        self.assert_allowed("psql -c 'DELETE FROM users WHERE id = 1'")
+
+    def test_blocks_force_push(self) -> None:
+        self.assert_blocked("git push --force origin main")
+        self.assert_blocked("git push -f origin main")
+        self.assert_blocked("git push --force-with-lease origin main")
+
+    def test_allows_normal_commands(self) -> None:
+        self.assert_allowed("npm test")
+        self.assert_allowed("git push origin main")
+        self.assert_allowed("grep -R 'DROP TABLE' docs/")
+
+
+class HookIntegrationTests(unittest.TestCase):
+    def run_hook(self, command: str) -> subprocess.CompletedProcess[str]:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": "/tmp/project",
+            "tool_input": {"command": command},
+        }
+        return subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                **os.environ,
+                "CLAUDE_BLOCKED_LOG_PATH": str(Path(tempfile.gettempdir()) / "claude-blocked-test.log"),
+            },
+        )
+
+    def test_safe_command_is_silent(self) -> None:
+        result = self.run_hook("npm test")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_blocked_command_returns_pretool_deny(self) -> None:
+        result = self.run_hook("git push --force origin main")
+        self.assertEqual(result.returncode, 0)
+        data = json.loads(result.stdout)
+        output = data["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "PreToolUse")
+        self.assertEqual(output["permissionDecision"], "deny")
+        self.assertIn("Force-pushing", output["permissionDecisionReason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Summary
- Add a Claude Code PreToolUse Bash hook that blocks destructive commands before execution.
- Log blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, attempted command, and project path.
- Include a one-command installer and README with the required hook configuration.
- Add unit and integration tests covering blocked and allowed command paths.

## Verification
- `python hooks/destructive-command-blocker/test_block_destructive_bash.py`
- `python -m py_compile hooks/destructive-command-blocker/block_destructive_bash.py hooks/destructive-command-blocker/install.py hooks/destructive-command-blocker/test_block_destructive_bash.py`