### PR TITLE
Add destructive Bash command safety hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,38 @@ You're in the right place.
 
 ---
 
+## Bounty #3: Destructive Bash Command Hook
+
+This repository includes a Claude Code `PreToolUse` hook that inspects Bash
+commands before execution and blocks destructive patterns:
+
+- `rm -rf`
+- `DROP TABLE`
+- `git push --force`
+- `TRUNCATE`
+- `DELETE FROM` without a `WHERE` clause
+
+Blocked attempts exit with code `2`, print a clear reason to stderr for Claude,
+and append a JSON line to `~/.claude/hooks/blocked.log` with the timestamp,
+attempted command, and project path.
+
+### Install in 2 commands
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/pre_tool_use_safety.py ~/.claude/hooks/pre_tool_use_safety.py && chmod +x ~/.claude/hooks/pre_tool_use_safety.py
+python3 -c 'import json,pathlib;p=pathlib.Path.home()/".claude/settings.json";p.parent.mkdir(parents=True,exist_ok=True);data=json.loads(p.read_text() if p.exists() else "{}");entry={"matcher":"Bash","hooks":[{"type":"command","command":"python3 ~/.claude/hooks/pre_tool_use_safety.py"}]};items=data.setdefault("hooks",{}).setdefault("PreToolUse",[]);items.append(entry) if entry not in items else None;p.write_text(json.dumps(data,indent=2)+"\n")'
+```
+
+### Test
+
+```bash
+python3 -m unittest tests.test_pre_tool_use_safety -v
+```
+
+The hook uses only Python standard-library modules.
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/hooks/pre_tool_use_safety.py
+++ b/hooks/pre_tool_use_safety.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCKERS = [
+    ("rm -rf", re.compile(r"\brm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b")),
+    ("DROP TABLE", re.compile(r"\bdrop\s+table\b", re.IGNORECASE)),
+    ("git push --force", re.compile(r"\bgit\s+push\b.*(?:--force|-f)\b", re.IGNORECASE)),
+    ("TRUNCATE", re.compile(r"\btruncate\b", re.IGNORECASE)),
+]
+
+DELETE_FROM = re.compile(r"\bdelete\s+from\b", re.IGNORECASE)
+WHERE_CLAUSE = re.compile(r"\bwhere\b", re.IGNORECASE)
+
+
+def load_event() -> dict[str, Any]:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def blocked_reason(command: str) -> str | None:
+    for reason, pattern in BLOCKERS:
+        if pattern.search(command):
+            return reason
+
+    if DELETE_FROM.search(command) and not WHERE_CLAUSE.search(command):
+        return "DELETE FROM without WHERE"
+
+    return None
+
+
+def log_blocked_attempt(command: str, cwd: str) -> None:
+    log_path = Path.home() / ".claude" / "hooks" / "blocked.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "command": command,
+        "project_path": cwd,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    event = load_event()
+    if event.get("hook_event_name") != "PreToolUse":
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = event.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    cwd = str(event.get("cwd") or "")
+
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    log_blocked_attempt(command, cwd)
+    print(
+        "Blocked dangerous Bash command before execution: "
+        f"{reason}. Attempted command: {command}",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pre_tool_use_safety.py
+++ b/tests/test_pre_tool_use_safety.py
@@ -1,0 +1,111 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "pre_tool_use_safety.py"
+
+
+def run_hook(payload, home):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+
+def bash_event(command, cwd="/tmp/project"):
+    return {
+        "session_id": "test-session",
+        "cwd": cwd,
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+
+
+class PreToolUseSafetyHookTest(unittest.TestCase):
+    def test_blocks_rm_rf_and_logs_attempt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            result = run_hook(bash_event("rm -rf build"), home)
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("Blocked dangerous Bash command", result.stderr)
+            self.assertIn("rm -rf", result.stderr)
+
+            log_path = home / ".claude" / "hooks" / "blocked.log"
+            self.assertTrue(log_path.exists())
+            log = log_path.read_text(encoding="utf-8")
+            self.assertIn("rm -rf build", log)
+            self.assertIn("/tmp/project", log)
+            self.assertRegex(log, r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+    def test_blocks_required_destructive_patterns(self):
+        cases = [
+            "DROP TABLE users",
+            "git push --force origin main",
+            "TRUNCATE audit_log",
+            "DELETE FROM users",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            for command in cases:
+                with self.subTest(command=command):
+                    result = run_hook(bash_event(command), home)
+
+                    self.assertEqual(result.returncode, 2)
+                    self.assertIn(command, result.stderr)
+
+    def test_allows_delete_from_when_where_clause_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hook(
+                bash_event("DELETE FROM sessions WHERE expires_at < NOW()"),
+                Path(tmp),
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stderr, "")
+
+    def test_allows_normal_bash_commands_without_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            result = run_hook(bash_event("npm test"), home)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stderr, "")
+            self.assertFalse((home / ".claude" / "hooks" / "blocked.log").exists())
+
+    def test_ignores_non_bash_tools(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            result = run_hook(
+                {
+                    "cwd": "/tmp/project",
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "README.md"},
+                },
+                home,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stderr, "")
+            self.assertFalse((home / ".claude" / "hooks" / "blocked.log").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a Claude Code PreToolUse hook that blocks destructive Bash commands before execution
- Log blocked attempts to ~/.claude/hooks/blocked.log with timestamp, attempted command, and project path
- Document two-command installation and add unittest coverage for blocked and allowed cases

## Bounty
Closes #3
/claim #3

## Verification
- python -m unittest tests.test_pre_tool_use_safety -v
- python -m py_compile hooks/pre_tool_use_safety.py tests/test_pre_tool_use_safety.py
