### PR TITLE
[BOUNTY #3] HOOK: Pre-tool-use hook that blocks destructive bash commands

### DIFF
--- a/hook/README.md
+++ b/hook/README.md
@@ -1,0 +1,50 @@
+# Destructive Commands Guard
+
+A Claude Code `pre-tool-use` hook that blocks dangerous bash commands before they execute.
+
+## Installation (2 commands)
+
+```bash
+# 1. Install the hook
+cp src/destructive-commands-guard.py ~/.claude/hooks/
+chmod +x ~/.claude/hooks/destructive-commands-guard.py
+
+# 2. Configure Claude Code to use it
+mkdir -p .claude && cp src/settings.json .claude/settings.json
+```
+
+Restart Claude Code. The hook is active immediately.
+
+## What It Blocks
+
+| Pattern | Danger |
+|---|---|
+| `rm -rf`, `rm --recursive --force` | Destructive recursive delete |
+| `DROP TABLE` | Irreversible schema deletion |
+| `git push --force` | Force push (overwrites remote history) |
+| `TRUNCATE` | Bulk table clear |
+| `DELETE FROM` (no `WHERE`) | Unrestricted row deletion |
+
+## What It Allows
+
+Normal commands (`ls`, `cd`, `git push`, `npm install`, `rm file.txt`, `DELETE FROM users WHERE id = ?`) pass through without interference.
+
+## Logging
+
+Every blocked attempt is logged to `~/.claude/hooks/blocked.log` with:
+- Timestamp (ISO 8601)
+- Project path
+- Blocked command
+- Reason
+
+## Verification
+
+```bash
+# Test the hook outside Claude Code
+echo '{"type":"Bash","params":{"command":"rm -rf /important"}}' | python3 ~/.claude/hooks/destructive-commands-guard.py
+# Expected: exits code 2 with BLOCKED message on stderr
+
+# Test a safe command
+echo '{"type":"Bash","params":{"command":"ls -la"}}' | python3 ~/.claude/hooks/destructive-commands-guard.py
+# Expected: exits code 0 silently
+```

--- a/hook/destructive-commands-guard.py
+++ b/hook/destructive-commands-guard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Pre-tool-use hook that blocks destructive bash commands in Claude Code.
+
+Receives JSON on stdin with tool invocation context.
+Exits code 0 to allow, code 2 to block (with reason in stderr).
+Install: place in ~/.claude/hooks/ and add to .claude/settings.json.
+"""
+import json
+import re
+import sys
+import os
+from datetime import datetime, timezone
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+DESTRUCTIVE_PATTERNS = [
+    (re.compile(r'\brm\s+(-rf|--recursive|--force|-r|-f)\b', re.IGNORECASE),
+     "Recursive force delete (rm -rf) — use trash or careful rm instead"),
+    (re.compile(r'\bdrop\s+table\b', re.IGNORECASE),
+     "DROP TABLE — destructive schema change, use migrations instead"),
+    (re.compile(r'\bgit\s+push\s+.*(--force|-f)\b', re.IGNORECASE),
+     "Force push (git push --force) — use --force-with-lease if truly needed"),
+    (re.compile(r'\btruncate\b', re.IGNORECASE),
+     "TRUNCATE — destructive table clear, use DELETE or migrations"),
+    (re.compile(r'\bdelete\s+from\b(?!.*\bwhere\b)', re.IGNORECASE),
+     "DELETE FROM without WHERE clause — will remove ALL rows"),
+]
+
+def log_block(command, reason):
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    project = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    with open(LOG_FILE, "a") as f:
+        f.write(f"[{timestamp}] BLOCKED | project={project} | reason={reason} | cmd={command}\n")
+
+
+def main():
+    try:
+        raw = sys.stdin.read()
+        event = json.loads(raw)
+    except (json.JSONDecodeError, Exception):
+        # Not a valid event, silently allow
+        sys.exit(0)
+
+    tool_type = event.get("type", "")
+    params = event.get("params", {})
+
+    # Only intercept Bash tool calls
+    if tool_type not in ("Bash", "bash"):
+        sys.exit(0)
+
+    command = params.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    for pattern, reason in DESTRUCTIVE_PATTERNS:
+        if pattern.search(command):
+            log_block(command, reason)
+            message = (
+                f"[destructive-commands-guard] BLOCKED: {reason}\n"
+                f"  Command: {command}\n"
+                f"  Logged to: {LOG_FILE}\n"
+                f"  Override: not available — this hook is deterministic."
+            )
+            print(message, file=sys.stderr)
+            sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hook/settings.json
+++ b/hook/settings.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "PreToolUse:Bash": "python3 ~/.claude/hooks/destructive-commands-guard.py"
+  }
+}


### PR DESCRIPTION
## Submission for Issue #3 — $100 Bounty

A Claude Code pre-tool-use hook that blocks destructive bash commands from executing.

### Deliverables
- `hook/destructive-commands-guard.py` — The hook script
- `hook/settings.json` — Claude Code hook configuration
- `hook/README.md` — Installation and usage

### Acceptance Criteria
- [x] Follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without WHERE
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, project
- [x] Displays clear message explaining why command was blocked
- [x] Does not interfere with normal bash commands
- [x] README with installation in 2 commands

Closes #3