### PR TITLE
feat(skill): changelog generator from git history

### DIFF
--- a/PR_BODY_1.md
+++ b/PR_BODY_1.md
@@ -1,0 +1,85 @@
+Resolves #1
+
+## What
+
+A Claude Code skill (`SKILL.md` + `changelog.sh`) that auto-generates a structured `CHANGELOG.md` from git history. Categorizes commits into **Added / Fixed / Changed / Removed** based on conventional commit prefixes.
+
+## How to use
+
+Two ways:
+
+1. Slash command in Claude Code: `/generate-changelog`
+2. From shell: `bash changelog.sh [output_file]`
+
+Output defaults to `CHANGELOG.md` in the current directory.
+
+## What it does
+
+- Fetches commits since the last git tag (or all commits if no tags exist)
+- Auto-categorizes each commit:
+  - `feat:` → **Added**
+  - `fix:` → **Fixed**
+  - `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, `build:`, `ci:` → **Changed**
+  - `BREAKING:`, `revert:`, subject contains "Remove" or "Delete" → **Removed**
+  - Anything else → **Changed** (fallback)
+- Writes a properly formatted Markdown section with subheadings per category
+
+## Files
+
+- `skills/changelog/SKILL.md` — Claude Code skill definition
+- `skills/changelog/changelog.sh` — bash script (no Python / Node dependency, pure shell)
+- `skills/changelog/README.md` — install + sample output
+
+## Sample output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.2.0 - 2026-06-18]
+
+### Added
+
+- User profile page with avatar upload
+- Dark mode toggle in settings
+
+### Fixed
+
+- Login redirect loop on Safari
+- Memory leak in image cache
+
+### Changed
+
+- Upgraded React to 18.3
+- Refactored authentication module
+
+### Removed
+
+- Deprecated v1 API endpoints
+```
+
+## Installation (3 steps)
+
+```bash
+mkdir -p ~/.claude/skills/changelog
+cp changelog.sh ~/.claude/skills/changelog/
+cp SKILL.md ~/.claude/skills/changelog/
+chmod +x ~/.claude/skills/changelog/changelog.sh
+```
+
+The skill auto-loads from `~/.claude/skills/changelog/SKILL.md` in Claude Code.
+
+## Requirements
+
+- `git` on PATH
+- `bash` 4+ (uses `case` glob and `mktemp -d`)
+- **No other dependencies** — pure shell, no Python, no Node, no jq
+
+## Tested on
+
+This PR was developed and verified on `wang282913946/claude-builders-bounty` (this very repo). The script processes the commit history of this PR's branch and produces a valid `CHANGELOG.md` with the expected categories.
+
+## Bounty
+
+$50 via Opire

--- a/examples/sample_CHANGELOG.md
+++ b/examples/sample_CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- changelog generator from git history
+- initial README with bounty board
+
+### Changed
+
+- handle last git log line + create parent dir for output
+- Initial commit
+

--- a/skills/changelog/README.md
+++ b/skills/changelog/README.md
@@ -1,0 +1,96 @@
+# Generate CHANGELOG from Git History
+
+A Claude Code skill that automatically produces a structured `CHANGELOG.md` from a project's git history. Categorizes commits into **Added / Fixed / Changed / Removed** based on conventional commit prefixes.
+
+## What you get
+
+- `CHANGELOG.md` with the most recent release section
+- Auto-categorized subsections (no manual sorting)
+- Works on any git repo with `feat:` / `fix:` / `BREAKING:` style commits
+- Sample output included in this README
+
+## Sample output
+
+Running on a fictional project:
+
+```
+$ bash changelog.sh
+CHANGELOG written to CHANGELOG.md (12 commits processed)
+```
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.2.0 - 2026-06-18]
+
+### Added
+
+- User profile page with avatar upload
+- Dark mode toggle in settings
+
+### Fixed
+
+- Login redirect loop on Safari
+- Memory leak in image cache
+
+### Changed
+
+- Upgraded React to 18.3
+- Refactored authentication module
+
+### Removed
+
+- Deprecated v1 API endpoints
+```
+
+## Installation (3 steps)
+
+### Step 1: Copy the skill
+
+```bash
+mkdir -p ~/.claude/skills/changelog
+cp changelog.sh ~/.claude/skills/changelog/
+cp SKILL.md ~/.claude/skills/changelog/
+chmod +x ~/.claude/skills/changelog/changelog.sh
+```
+
+### Step 2: Register the skill
+
+In Claude Code, the skill auto-loads from `~/.claude/skills/changelog/SKILL.md`. No registration needed if you place it there.
+
+For project-local use, copy the folder into `<your-project>/.claude/skills/changelog/`.
+
+### Step 3: Use it
+
+- In Claude Code: type `/generate-changelog`
+- From the shell: `bash ~/.claude/skills/changelog/changelog.sh`
+
+Output defaults to `CHANGELOG.md`. Pass a path to override:
+
+```bash
+bash changelog.sh docs/CHANGELOG.md
+```
+
+## How it categorizes
+
+| Commit prefix | Category |
+|---|---|
+| `feat:` | Added |
+| `fix:` | Fixed |
+| `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, `build:`, `ci:` | Changed |
+| `BREAKING:`, `revert:`, subject contains "Remove" or "Delete" | Removed |
+| Anything else | Changed (fallback) |
+
+The script uses the **last tag** as the lower bound (`git describe --tags --abbrev=0`). If no tags exist, it includes the full history and labels the section `Unreleased`.
+
+## Requirements
+
+- `git` on PATH
+- `bash` (4+ recommended for `case` glob)
+- No other dependencies
+
+## License
+
+MIT

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: changelog
+description: Generate a structured CHANGELOG.md from a project's git history. Auto-categorizes commits into Added/Fixed/Changed/Removed based on conventional commit prefixes. Use when the user asks to "generate changelog", "make a release", "summarize git history", or "create CHANGELOG.md".
+---
+
+# Changelog Skill
+
+Auto-generate a `CHANGELOG.md` from git history. Works in two ways:
+
+1. **Slash command**: `/generate-changelog` (Claude Code)
+2. **Bash**: `bash changelog.sh [output_file]`
+
+## What it does
+
+- Fetches commits since the last git tag (or all commits if no tags)
+- Categorizes each commit by conventional commit prefix:
+  - `feat:` → **Added**
+  - `fix:` → **Fixed**
+  - `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, `build:`, `ci:` → **Changed**
+  - `BREAKING:`, `revert:`, "Remove" / "Delete" in subject → **Removed**
+- Writes a properly formatted Markdown section with subheadings per category
+
+## Installation (3 steps)
+
+### Step 1: Copy the files
+
+```bash
+mkdir -p ~/.claude/skills/changelog
+cp changelog.sh ~/.claude/skills/changelog/
+chmod +x ~/.claude/skills/changelog/changelog.sh
+```
+
+### Step 2: Register the skill
+
+Add to `~/.claude/skills/registry.json` (or just place this `SKILL.md` in your project's `.claude/skills/` folder):
+
+```json
+{
+  "skills": {
+    "changelog": {
+      "path": "~/.claude/skills/changelog/SKILL.md"
+    }
+  }
+}
+```
+
+### Step 3: Use it
+
+- In Claude Code: type `/generate-changelog`
+- From the shell: `bash ~/.claude/skills/changelog/changelog.sh`
+
+Output defaults to `CHANGELOG.md` in the current directory. Pass a different path as the first argument.
+
+## Example output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.2.0 - 2026-06-18]
+
+### Added
+
+- User profile page with avatar upload
+- Dark mode toggle in settings
+
+### Fixed
+
+- Login redirect loop on Safari
+- Memory leak in image cache
+
+### Changed
+
+- Upgraded React to 18.3
+- Refactored authentication module
+
+### Removed
+
+- Deprecated v1 API endpoints
+```
+
+## Conventional commit prefixes
+
+This skill expects conventional commit messages for best results. Format: `<type>: <subject>` where `type` is one of:
+
+- `feat` — new feature
+- `fix` — bug fix
+- `docs` — documentation only
+- `style` — formatting, no code change
+- `refactor` — code change that neither fixes a bug nor adds a feature
+- `perf` — performance improvement
+- `test` — add/correct tests
+- `chore` — tooling, dependencies, build
+- `build` — build system changes
+- `ci` — CI configuration changes
+- `revert` — revert a previous commit
+- `BREAKING` — breaking change (anywhere in subject)
+
+Commits without a recognizable prefix are categorized as **Changed**.
+
+## Customization
+
+Edit the `case` statement in `changelog.sh` to add custom category rules or rename categories.
+
+## License
+
+MIT

--- a/skills/changelog/changelog.sh
+++ b/skills/changelog/changelog.sh
@@ -12,6 +12,9 @@ OUTPUT="${1:-CHANGELOG.md}"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"
 
+# Ensure parent directory of OUTPUT exists
+mkdir -p "$(dirname "$OUTPUT")" 2>/dev/null || true
+
 # Get last tag (v* or *)
 LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
 if [ -z "$LAST_TAG" ]; then
@@ -31,7 +34,9 @@ for cat in Added Fixed Changed Removed; do
 done
 
 # Parse commits
-git log $RANGE --pretty=format:"%s" 2>/dev/null | while IFS= read -r subject; do
+# Note: `|| [[ -n "$subject" ]]` ensures the last line is processed even if
+# git log doesn't end with a newline.
+git log $RANGE --pretty=format:"%s" 2>/dev/null | while IFS= read -r subject || [[ -n "$subject" ]]; do
     # Strip conventional commit prefix and colon
     msg="${subject#*: }"
     [ "$msg" = "$subject" ] && msg="$subject"  # No prefix

--- a/skills/changelog/changelog.sh
+++ b/skills/changelog/changelog.sh
@@ -41,24 +41,27 @@ git log $RANGE --pretty=format:"%s" 2>/dev/null | while IFS= read -r subject || 
     msg="${subject#*: }"
     [ "$msg" = "$subject" ] && msg="$subject"  # No prefix
 
-    # Categorize based on conventional commit prefix
+    # Categorize using bash case glob (more portable than [[ =~ ]] across bash versions).
+    # Glob matches at start of string, so "feat" only matches "feat" / "Feat" / "feat(scope)" — not "feature".
     case "$subject" in
-        feat*|Feat*|*feat*)
+        feat*|Feat*)
             echo "- $msg" >> "$TMPDIR/Added"
             ;;
-        fix*|Fix*|*fix*)
+        fix*|Fix*)
             echo "- $msg" >> "$TMPDIR/Fixed"
             ;;
         BREAKING*|breaking*|revert*|Revert*)
             echo "- $msg" >> "$TMPDIR/Removed"
             ;;
-        docs*|style*|refactor*|perf*|test*|chore*|build*|ci*|*)
-            # Treat as Changed unless otherwise marked
-            if [[ "$subject" =~ ^[Rr]emove ]] || [[ "$subject" =~ ^[Dd]elete ]]; then
-                echo "- $msg" >> "$TMPDIR/Removed"
-            else
-                echo "- $msg" >> "$TMPDIR/Changed"
-            fi
+        Remove*|remove*|Delete*|delete*)
+            echo "- $msg" >> "$TMPDIR/Removed"
+            ;;
+        docs*|style*|refactor*|perf*|test*|chore*|build*|ci*)
+            echo "- $msg" >> "$TMPDIR/Changed"
+            ;;
+        *)
+            # No recognizable prefix -> Changed (fallback)
+            echo "- $msg" >> "$TMPDIR/Changed"
             ;;
     esac
 done

--- a/skills/changelog/changelog.sh
+++ b/skills/changelog/changelog.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# changelog.sh - Generate structured CHANGELOG.md from git history
+# Usage: bash changelog.sh [output_file]
+#
+# Categorizes commits into Added/Fixed/Changed/Removed based on conventional
+# commit prefixes. Fetches commits since the last git tag (or all commits
+# if no tags exist).
+
+set -euo pipefail
+
+OUTPUT="${1:-CHANGELOG.md}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+# Get last tag (v* or *)
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+if [ -z "$LAST_TAG" ]; then
+    RANGE=""
+    SECTION="Unreleased"
+else
+    RANGE="${LAST_TAG}..HEAD"
+    SECTION="${LAST_TAG#v} - $(date +%Y-%m-%d)"
+fi
+
+# Initialize category files
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+for cat in Added Fixed Changed Removed; do
+    : > "$TMPDIR/$cat"
+done
+
+# Parse commits
+git log $RANGE --pretty=format:"%s" 2>/dev/null | while IFS= read -r subject; do
+    # Strip conventional commit prefix and colon
+    msg="${subject#*: }"
+    [ "$msg" = "$subject" ] && msg="$subject"  # No prefix
+
+    # Categorize based on conventional commit prefix
+    case "$subject" in
+        feat*|Feat*|*feat*)
+            echo "- $msg" >> "$TMPDIR/Added"
+            ;;
+        fix*|Fix*|*fix*)
+            echo "- $msg" >> "$TMPDIR/Fixed"
+            ;;
+        BREAKING*|breaking*|revert*|Revert*)
+            echo "- $msg" >> "$TMPDIR/Removed"
+            ;;
+        docs*|style*|refactor*|perf*|test*|chore*|build*|ci*|*)
+            # Treat as Changed unless otherwise marked
+            if [[ "$subject" =~ ^[Rr]emove ]] || [[ "$subject" =~ ^[Dd]elete ]]; then
+                echo "- $msg" >> "$TMPDIR/Removed"
+            else
+                echo "- $msg" >> "$TMPDIR/Changed"
+            fi
+            ;;
+    esac
+done
+
+# Build CHANGELOG
+{
+    echo "# Changelog"
+    echo ""
+    echo "All notable changes to this project will be documented in this file."
+    echo ""
+    echo "## [$SECTION]"
+    echo ""
+
+    for cat in Added Fixed Changed Removed; do
+        if [ -s "$TMPDIR/$cat" ]; then
+            echo "### $cat"
+            echo ""
+            cat "$TMPDIR/$cat"
+            echo ""
+        fi
+    done
+} > "$OUTPUT"
+
+COUNT=$(git log $RANGE --oneline 2>/dev/null | wc -l | tr -d ' ')
+echo "CHANGELOG written to $OUTPUT ($COUNT commits processed)"

--- a/tests/test_changelog.sh
+++ b/tests/test_changelog.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test_changelog.sh - Manual smoke tests for changelog.sh
+# Run: bash tests/test_changelog.sh
+#
+# Creates a temp git repo with known commit history, runs changelog.sh,
+# and verifies the output. Exits 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CHANGELOG_SH="${REPO_ROOT}/skills/changelog/changelog.sh"
+
+if [ ! -f "$CHANGELOG_SH" ]; then
+    echo "FAIL: changelog.sh not found at $CHANGELOG_SH" >&2
+    exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap "rm -rf $TMPDIR" EXIT
+
+cd "$TMPDIR"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Helper: create empty commit with given message
+commit() { git commit --allow-empty -q -m "$1"; }
+
+# Stage 1: pre-tag commits
+commit "feat: initial user module"
+commit "docs: add README"
+
+git tag v1.0.0
+
+# Stage 2: post-tag commits covering all 4 categories
+commit "feat: dashboard widgets"
+commit "feat(api): add /users endpoint"
+commit "fix: crash on empty input"
+commit "fix(api): handle 404 in /users"
+commit "docs: update README with new endpoints"
+commit "refactor: extract auth helper"
+commit "perf: cache user lookup"
+commit "chore: bump deps"
+commit "BREAKING: remove v1 API"
+commit "revert: undo feature X"
+commit "Remove legacy config"
+
+# Run the script
+OUTPUT="$TMPDIR/CHANGELOG.md"
+bash "$CHANGELOG_SH" "$OUTPUT"
+
+# Validate output
+fail=0
+expect_line() {
+    local pattern="$1"
+    if ! grep -qE "$pattern" "$OUTPUT"; then
+        echo "FAIL: expected line matching: $pattern" >&2
+        fail=1
+    fi
+}
+
+# Header
+expect_line "^# Changelog$"
+expect_line "^## \[1\.0\.0 - [0-9-]+\]$"
+
+# Categories
+expect_line "^### Added$"
+expect_line "^- dashboard widgets$"
+expect_line "^- add /users endpoint$"
+
+expect_line "^### Fixed$"
+expect_line "^- crash on empty input$"
+expect_line "^- handle 404 in /users$"
+
+expect_line "^### Changed$"
+expect_line "^- extract auth helper$"
+expect_line "^- cache user lookup$"
+expect_line "^- bump deps$"
+
+expect_line "^### Removed$"
+expect_line "^- remove v1 API$"
+expect_line "^- undo feature X$"
+expect_line "^- Remove legacy config$"
+
+# Prefixes should NOT appear in output (stripped)
+if grep -qE "^- (feat|fix|docs|refactor|perf|chore|BREAKING|revert): " "$OUTPUT"; then
+    echo "FAIL: commit prefixes leaked into output" >&2
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "OK: all changelog tests passed"
+    cat "$OUTPUT"
+    exit 0
+else
+    echo "FAILED" >&2
+    cat "$OUTPUT" >&2
+    exit 1
+fi


### PR DESCRIPTION
Resolves #1

## What

A Claude Code skill (`SKILL.md` + `changelog.sh`) that auto-generates a structured `CHANGELOG.md` from git history. Categorizes commits into **Added / Fixed / Changed / Removed** based on conventional commit prefixes.

## How to use

Two ways:

1. Slash command in Claude Code: `/generate-changelog`
2. From shell: `bash changelog.sh [output_file]`

Output defaults to `CHANGELOG.md` in the current directory.

## What it does

- Fetches commits since the last git tag (or all commits if no tags exist)
- Auto-categorizes each commit:
  - `feat:` → **Added**
  - `fix:` → **Fixed**
  - `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, `build:`, `ci:` → **Changed**
  - `BREAKING:`, `revert:`, subject contains "Remove" or "Delete" → **Removed**
  - Anything else → **Changed** (fallback)
- Writes a properly formatted Markdown section with subheadings per category

## Files

- `skills/changelog/SKILL.md` — Claude Code skill definition
- `skills/changelog/changelog.sh` — bash script (no Python / Node dependency, pure shell)
- `skills/changelog/README.md` — install + sample output

## Sample output

```markdown
# Changelog

All notable changes to this project will be documented in this file.

## [1.2.0 - 2026-06-18]

### Added

- User profile page with avatar upload
- Dark mode toggle in settings

### Fixed

- Login redirect loop on Safari
- Memory leak in image cache

### Changed

- Upgraded React to 18.3
- Refactored authentication module

### Removed

- Deprecated v1 API endpoints
```

## Installation (3 steps)

```bash
mkdir -p ~/.claude/skills/changelog
cp changelog.sh ~/.claude/skills/changelog/
cp SKILL.md ~/.claude/skills/changelog/
chmod +x ~/.claude/skills/changelog/changelog.sh
```

The skill auto-loads from `~/.claude/skills/changelog/SKILL.md` in Claude Code.

## Requirements

- `git` on PATH
- `bash` 4+ (uses `case` glob and `mktemp -d`)
- **No other dependencies** — pure shell, no Python, no Node, no jq

## Tested on

This PR was developed and verified on `wang282913946/claude-builders-bounty` (this very repo). The script processes the commit history of this PR's branch and produces a valid `CHANGELOG.md` with the expected categories.

## Bounty

$50 via Opire
