### PR TITLE
feat: Auto-categorizing Git Changelog Bash Script

### DIFF
--- a/changelog_skill/CHANGELOG.md
+++ b/changelog_skill/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+Generated on 2026-06-18
+
+## Added
+- feat: initial README with bounty board
+
+## Other
+- Initial commit
+

--- a/changelog_skill/README.md
+++ b/changelog_skill/README.md
@@ -1,0 +1,22 @@
+# Git Changelog Generator Skill
+
+A lightweight bash script that automatically analyzes a repository's git commit history and generates a structured, categorized `CHANGELOG.md` file.
+
+## Features
+- Fetches all commits since the last git tag (or all time if no tags exist).
+- Auto-categorizes conventional commits into: `Added`, `Fixed`, `Changed`, and `Removed`.
+- Outputs a perfectly formatted markdown document.
+
+## Setup & Usage (3 Steps)
+
+1. Drop the `changelog.sh` script into the root of your git repository.
+2. Make the script executable: 
+   ```bash
+   chmod +x changelog.sh
+   ```
+3. Run the generator: 
+   ```bash
+   ./changelog.sh
+   ```
+
+A new `CHANGELOG.md` file will be instantly written to your directory containing the neatly categorized git history!

--- a/changelog_skill/changelog.sh
+++ b/changelog_skill/changelog.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Generate a structured CHANGELOG.md from git history
+
+# Find the latest git tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+
+if [ -z "$LAST_TAG" ]; then
+    # If no tags exist, get all commits
+    LOGS=$(git log --pretty=format:"%s")
+else
+    # Get commits since the last tag
+    LOGS=$(git log ${LAST_TAG}..HEAD --pretty=format:"%s")
+fi
+
+if [ -z "$LOGS" ]; then
+    echo "No commits found since the last tag. Exiting."
+    exit 0
+fi
+
+# Categorization buckets
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+# Parse and categorize each commit
+while IFS= read -r msg; do
+    lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+    
+    if [[ "$lower" == add* ]] || [[ "$lower" == feat* ]]; then
+        ADDED="${ADDED}- ${msg}\n"
+    elif [[ "$lower" == fix* ]] || [[ "$lower" == bug* ]]; then
+        FIXED="${FIXED}- ${msg}\n"
+    elif [[ "$lower" == change* ]] || [[ "$lower" == update* ]] || [[ "$lower" == refactor* ]] || [[ "$lower" == chore* ]]; then
+        CHANGED="${CHANGED}- ${msg}\n"
+    elif [[ "$lower" == remove* ]] || [[ "$lower" == delete* ]] || [[ "$lower" == drop* ]]; then
+        REMOVED="${REMOVED}- ${msg}\n"
+    else
+        # Fallback for uncategorized commits
+        OTHER="${OTHER}- ${msg}\n"
+    fi
+done <<< "$LOGS"
+
+DATE=$(date '+%Y-%m-%d')
+OUT_FILE="CHANGELOG.md"
+
+# Generate the Markdown file
+{
+    echo "# Changelog"
+    echo "Generated on $DATE"
+    echo ""
+    
+    if [ -n "$ADDED" ]; then
+        echo "## Added"
+        echo -e "$ADDED"
+    fi
+    
+    if [ -n "$FIXED" ]; then
+        echo "## Fixed"
+        echo -e "$FIXED"
+    fi
+    
+    if [ -n "$CHANGED" ]; then
+        echo "## Changed"
+        echo -e "$CHANGED"
+    fi
+    
+    if [ -n "$REMOVED" ]; then
+        echo "## Removed"
+        echo -e "$REMOVED"
+    fi
+    
+    if [ -n "$OTHER" ]; then
+        echo "## Other"
+        echo -e "$OTHER"
+    fi
+} > "$OUT_FILE"
+
+echo "Success: $OUT_FILE has been generated and auto-categorized!"


### PR DESCRIPTION
Fixes #1.

This PR implements the  Git Changelog generator skill!

### Checklist Completed
- [x] Works via `bash changelog.sh`
- [x] Fetches commits since the last git tag (or all time if no tags exist)
- [x] Auto-categorizes into: `Added` / `Fixed` / `Changed` / `Removed`
- [x] Outputs a properly formatted `CHANGELOG.md`
- [x] Tested on a real GitHub repo (see output below)
- [x] README with setup instructions in 3 steps or fewer

### Sample Output (Tested on this repository)
```markdown
# Changelog
Generated on 2026-06-18

## Added
- feat: initial README with bounty board

## Other
- Initial commit
```

Payment: https://paypal.me/sureshc26
