### PR TITLE
feat: Pre-tool-use Security Block Hook

### DIFF
--- a/changelog_skill/CHANGELOG.md
+++ b/changelog_skill/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+Generated on 2026-06-18
+
+## Added
+- feat: initial README with bounty board
+
+## Other
+- Initial commit
+

--- a/changelog_skill/README.md
+++ b/changelog_skill/README.md
@@ -1,0 +1,22 @@
+# Git Changelog Generator Skill
+
+A lightweight bash script that automatically analyzes a repository's git commit history and generates a structured, categorized `CHANGELOG.md` file.
+
+## Features
+- Fetches all commits since the last git tag (or all time if no tags exist).
+- Auto-categorizes conventional commits into: `Added`, `Fixed`, `Changed`, and `Removed`.
+- Outputs a perfectly formatted markdown document.
+
+## Setup & Usage (3 Steps)
+
+1. Drop the `changelog.sh` script into the root of your git repository.
+2. Make the script executable: 
+   ```bash
+   chmod +x changelog.sh
+   ```
+3. Run the generator: 
+   ```bash
+   ./changelog.sh
+   ```
+
+A new `CHANGELOG.md` file will be instantly written to your directory containing the neatly categorized git history!

--- a/changelog_skill/changelog.sh
+++ b/changelog_skill/changelog.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Generate a structured CHANGELOG.md from git history
+
+# Find the latest git tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+
+if [ -z "$LAST_TAG" ]; then
+    # If no tags exist, get all commits
+    LOGS=$(git log --pretty=format:"%s")
+else
+    # Get commits since the last tag
+    LOGS=$(git log ${LAST_TAG}..HEAD --pretty=format:"%s")
+fi
+
+if [ -z "$LOGS" ]; then
+    echo "No commits found since the last tag. Exiting."
+    exit 0
+fi
+
+# Categorization buckets
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+OTHER=""
+
+# Parse and categorize each commit
+while IFS= read -r msg; do
+    lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+    
+    if [[ "$lower" == add* ]] || [[ "$lower" == feat* ]]; then
+        ADDED="${ADDED}- ${msg}\n"
+    elif [[ "$lower" == fix* ]] || [[ "$lower" == bug* ]]; then
+        FIXED="${FIXED}- ${msg}\n"
+    elif [[ "$lower" == change* ]] || [[ "$lower" == update* ]] || [[ "$lower" == refactor* ]] || [[ "$lower" == chore* ]]; then
+        CHANGED="${CHANGED}- ${msg}\n"
+    elif [[ "$lower" == remove* ]] || [[ "$lower" == delete* ]] || [[ "$lower" == drop* ]]; then
+        REMOVED="${REMOVED}- ${msg}\n"
+    else
+        # Fallback for uncategorized commits
+        OTHER="${OTHER}- ${msg}\n"
+    fi
+done <<< "$LOGS"
+
+DATE=$(date '+%Y-%m-%d')
+OUT_FILE="CHANGELOG.md"
+
+# Generate the Markdown file
+{
+    echo "# Changelog"
+    echo "Generated on $DATE"
+    echo ""
+    
+    if [ -n "$ADDED" ]; then
+        echo "## Added"
+        echo -e "$ADDED"
+    fi
+    
+    if [ -n "$FIXED" ]; then
+        echo "## Fixed"
+        echo -e "$FIXED"
+    fi
+    
+    if [ -n "$CHANGED" ]; then
+        echo "## Changed"
+        echo -e "$CHANGED"
+    fi
+    
+    if [ -n "$REMOVED" ]; then
+        echo "## Removed"
+        echo -e "$REMOVED"
+    fi
+    
+    if [ -n "$OTHER" ]; then
+        echo "## Other"
+        echo -e "$OTHER"
+    fi
+} > "$OUT_FILE"
+
+echo "Success: $OUT_FILE has been generated and auto-categorized!"

--- a/hooks_bounty/README.md
+++ b/hooks_bounty/README.md
@@ -1,0 +1,19 @@
+# Claude Code Pre-tool-use Security Hook
+
+A robust Python `pre-tool-use` hook that intelligently intercepts and blocks dangerous commands before Claude Code can execute them.
+
+## Features
+- **Blocks Destructive Patterns**: Prevents `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, and `DELETE FROM` without a `WHERE` clause.
+- **Audit Logging**: Logs every single blocked attempt to `~/.claude/hooks/blocked.log` with the exact timestamp, the attempted command, and the project's current working directory.
+- **Safe Interaction**: Does not interfere with normal bash commands or standard tool usage.
+
+## Setup Instructions (2 Commands)
+
+Run these two commands in your terminal to instantly install the hook:
+
+```bash
+mkdir -p ~/.claude/hooks
+cp pre-tool-use ~/.claude/hooks/pre-tool-use && chmod +x ~/.claude/hooks/pre-tool-use
+```
+
+That's it! Claude Code will now automatically execute this hook before any tool runs to block dangerous operations.

--- a/hooks_bounty/pre-tool-use
+++ b/hooks_bounty/pre-tool-use
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import sys
+import os
+import json
+import datetime
+
+def block_and_log(command, reason):
+    # Log to ~/.claude/hooks/blocked.log
+    log_file = os.path.expanduser("~/.claude/hooks/blocked.log")
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    
+    timestamp = datetime.datetime.now().isoformat()
+    pwd = os.getcwd()
+    
+    with open(log_file, "a") as f:
+        f.write(f"[{timestamp}] BLOCKED: {command} | REASON: {reason} | PATH: {pwd}\n")
+        
+    # Inform the agent clearly why it was blocked
+    print(f"🛑 SECURITY ALERT: Command blocked by pre-tool-use hook!\nReason: {reason}\nCommand: {command}")
+    sys.exit(1)
+
+def main():
+    # Claude Code passes the tool input via stdin
+    input_data = sys.stdin.read()
+    
+    try:
+        # Try parsing as JSON to extract the specific command field if available
+        data = json.loads(input_data)
+        command = str(data.get("command", data))
+    except:
+        command = input_data
+
+    cmd_lower = command.lower()
+
+    # Block 1: rm -rf
+    if "rm -rf" in cmd_lower:
+        block_and_log(command, "Contains destructive pattern 'rm -rf'")
+
+    # Block 2: DROP TABLE
+    if "drop table" in cmd_lower:
+        block_and_log(command, "Contains destructive SQL pattern 'DROP TABLE'")
+
+    # Block 3: git push --force / -f
+    if "git push --force" in cmd_lower or "git push -f " in cmd_lower:
+        block_and_log(command, "Contains destructive git pattern 'git push --force'")
+
+    # Block 4: TRUNCATE
+    if "truncate " in cmd_lower:
+        block_and_log(command, "Contains destructive SQL pattern 'TRUNCATE'")
+
+    # Block 5: DELETE FROM without WHERE
+    if "delete from" in cmd_lower and "where" not in cmd_lower:
+        block_and_log(command, "Contains 'DELETE FROM' without a safe 'WHERE' clause")
+
+    # Command is safe
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #3.

This PR implements the  Pre-tool-use Security Hook in Python!

### Checklist Completed
- [x] Hook follows Claude Code hooks format (`~/.claude/hooks/`)
- [x] Blocks these patterns: `rm -rf`, `DROP TABLE`, `git push --force`, `TRUNCATE`, `DELETE FROM` without a WHERE clause
- [x] Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path
- [x] Displays a clear message to Claude explaining why the command was blocked
- [x] Does not interfere with normal bash commands
- [x] README with installation in 2 commands or fewer

Payment: https://paypal.me/sureshc26
