### PR TITLE
[bounty #1] Generate changelog from git history

### DIFF
--- a/samples/generate-changelog/sample-output.md
+++ b/samples/generate-changelog/sample-output.md
@@ -1,0 +1,37 @@
+# Sample Output
+
+Command:
+
+```bash
+bash tools/generate-changelog/changelog.sh /tmp/CHANGELOG.sample.md
+```
+
+Repository:
+
+```text
+claude-builders-bounty/claude-builders-bounty
+```
+
+Output excerpt:
+
+```markdown
+# Changelog
+
+## Unreleased - full git history
+
+### Added
+
+- initial README with bounty board
+
+### Fixed
+
+- None.
+
+### Changed
+
+- Initial commit
+
+### Removed
+
+- None.
+```

--- a/tools/generate-changelog/README.md
+++ b/tools/generate-changelog/README.md
@@ -1,0 +1,37 @@
+# Generate Changelog
+
+`changelog.sh` creates a structured `CHANGELOG.md` from the current repository's
+git history. It reads commits since the latest git tag when one exists; otherwise
+it uses the full non-merge history.
+
+## Setup
+
+1. Copy `tools/generate-changelog/changelog.sh` into a git repository.
+2. Run `bash tools/generate-changelog/changelog.sh`.
+3. Review the generated `CHANGELOG.md` before committing it.
+
+## Categories
+
+The script groups commit subjects into:
+
+- `Added`
+- `Fixed`
+- `Changed`
+- `Removed`
+
+It recognizes common prefixes such as `feat:`, `feat(api):`, `fix:`,
+`remove:`, `delete:`, and keyword-based commit subjects.
+
+## Output Path
+
+Pass a custom output file as the first argument:
+
+```bash
+bash tools/generate-changelog/changelog.sh /tmp/CHANGELOG.preview.md
+```
+
+## Verification
+
+```bash
+bash tools/generate-changelog/test-changelog.sh
+```

--- a/tools/generate-changelog/SKILL.md
+++ b/tools/generate-changelog/SKILL.md
@@ -1,0 +1,32 @@
+# Generate Changelog Skill
+
+Use this skill when asked to generate, refresh, or preview a structured
+`CHANGELOG.md` from git history.
+
+## Command
+
+Run from the repository root:
+
+```bash
+bash tools/generate-changelog/changelog.sh
+```
+
+To write to a preview file instead of `CHANGELOG.md`:
+
+```bash
+bash tools/generate-changelog/changelog.sh /tmp/CHANGELOG.preview.md
+```
+
+## Behavior
+
+- Uses commits since the latest git tag when a tag exists.
+- Falls back to the full non-merge git history when no tag exists.
+- Groups commit subjects into `Added`, `Fixed`, `Changed`, and `Removed`.
+- Supports conventional commit scopes such as `feat(api):` and `fix(ui):`.
+- Writes a Markdown changelog suitable for review before committing.
+
+## Verification
+
+```bash
+bash tools/generate-changelog/test-changelog.sh
+```

--- a/tools/generate-changelog/changelog.sh
+++ b/tools/generate-changelog/changelog.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-CHANGELOG.md}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "changelog.sh: run this inside a git repository" >&2
+  exit 1
+fi
+
+last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$last_tag" ]]; then
+  range="${last_tag}..HEAD"
+  heading="Unreleased - changes since ${last_tag}"
+else
+  range="HEAD"
+  heading="Unreleased - full git history"
+fi
+
+commit_lines="$(git log "$range" --pretty=format:'%s' --no-merges)"
+if [[ -z "$commit_lines" ]]; then
+  {
+    echo "# Changelog"
+    echo
+    echo "## ${heading}"
+    echo
+    echo "No new non-merge commits found."
+  } > "$output_file"
+  exit 0
+fi
+
+declare -a added=()
+declare -a fixed=()
+declare -a changed=()
+declare -a removed=()
+
+normalize_subject() {
+  local subject="$1"
+  local prefix_re='^(feat|fix|chore|docs|refactor|remove|removed|delete|deleted|change|changed|add|added)(\([^)]+\))?!?:[[:space:]]*(.*)$'
+  shopt -s nocasematch
+  if [[ "$subject" =~ $prefix_re ]]; then
+    printf '%s' "${BASH_REMATCH[3]}"
+  else
+    printf '%s' "$subject"
+  fi
+  shopt -u nocasematch
+}
+
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  clean="$(normalize_subject "$subject")"
+  conventional_re='(\([^)]+\))?!?:'
+
+  if [[ "$lower" =~ ^(feat|add|added)$conventional_re ]] || [[ "$lower" =~ ^(add|adds|added)[[:space:]] ]] || [[ "$lower" == *" add "* || "$lower" == *" adds "* || "$lower" == *" added "* ]]; then
+    added+=("$clean")
+  elif [[ "$lower" =~ ^(fix|fixed|bugfix)$conventional_re ]] || [[ "$lower" =~ ^(fix|fixes|fixed)[[:space:]] ]] || [[ "$lower" == *" fix "* || "$lower" == *" fixes "* || "$lower" == *" fixed "* ]]; then
+    fixed+=("$clean")
+  elif [[ "$lower" =~ ^(remove|removed|delete|deleted)$conventional_re ]] || [[ "$lower" =~ ^(remove|removes|removed|delete|deletes|deleted)[[:space:]] ]] || [[ "$lower" == *" remove "* || "$lower" == *" removes "* || "$lower" == *" deleted "* ]]; then
+    removed+=("$clean")
+  else
+    changed+=("$clean")
+  fi
+done <<< "$commit_lines"
+
+write_section() {
+  local name="$1"
+  shift
+  local items=("$@")
+
+  echo "### ${name}"
+  echo
+  if (( ${#items[@]} == 0 )); then
+    echo "- None."
+  else
+    for item in "${items[@]}"; do
+      echo "- ${item}"
+    done
+  fi
+  echo
+}
+
+{
+  echo "# Changelog"
+  echo
+  echo "## ${heading}"
+  echo
+  write_section "Added" "${added[@]+"${added[@]}"}"
+  write_section "Fixed" "${fixed[@]+"${fixed[@]}"}"
+  write_section "Changed" "${changed[@]+"${changed[@]}"}"
+  write_section "Removed" "${removed[@]+"${removed[@]}"}"
+} > "$output_file"
+
+echo "Wrote ${output_file}"

--- a/tools/generate-changelog/test-changelog.sh
+++ b/tools/generate-changelog/test-changelog.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+tmp_output="$(mktemp)"
+trap 'rm -f "$tmp_output"' EXIT
+
+bash "$repo_root/tools/generate-changelog/changelog.sh" "$tmp_output" >/dev/null
+
+grep -q '^# Changelog$' "$tmp_output"
+grep -q '^### Added$' "$tmp_output"
+grep -q '^### Fixed$' "$tmp_output"
+grep -q '^### Changed$' "$tmp_output"
+grep -q '^### Removed$' "$tmp_output"
+
+echo "generate-changelog smoke test passed"


### PR DESCRIPTION
## Bounty #1 Implementation

Implements bounty #1: SKILL - Generate a structured CHANGELOG from git history

### Acceptance Criteria Met

- [x] Works via bash changelog.sh
- [x] Fetches commits since the last git tag (falls back to full history)
- [x] Auto-categorizes into: Added / Fixed / Changed / Removed
- [x] Outputs a properly formatted CHANGELOG.md
- [x] Tested - includes sample output
- [x] README with setup instructions in 3 steps or fewer
- [x] Includes SKILL.md for Claude Code integration
- [x] Includes test-changelog.sh for verification

Closes #1