### PR TITLE
feat: Add pre-tool-use hook to block destructive bash commands (#3)

### DIFF
--- a/issue-3-hook/README.md
+++ b/issue-3-hook/README.md
@@ -1,0 +1,71 @@
+# Pre-tool-use Hook: Block Destructive Bash Commands
+
+A Claude Code `pre-tool-use` hook that intercepts dangerous bash commands before they are executed.
+
+## Features
+
+- Blocks destructive commands: `rm -rf`, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without WHERE, `git push --force`, and more
+- Logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, command, and project path
+- Displays a clear message explaining why the command was blocked
+- Does not interfere with normal bash commands
+
+## Installation (2 commands)
+
+```bash
+cd issue-3-hook
+python3 install.py
+```
+
+Or manually:
+
+```bash
+cp block-destructive.py ~/.claude/hooks/block-destructive.py
+chmod +x ~/.claude/hooks/block-destructive.py
+```
+
+Then add to `~/.claude/hooks/settings.json`:
+
+```json
+{
+  "hooks": {
+    "pre-tool-use": [
+      {
+        "matcher": "Bash",
+        "command": "python3 ~/.claude/hooks/block-destructive.py"
+      }
+    ]
+  }
+}
+```
+
+## Testing
+
+```bash
+python3 test_hook.py
+```
+
+## Blocked Patterns
+
+| Pattern | Example |
+|---------|---------|
+| `rm -rf` / `rm --force` | `rm -rf /tmp/test` |
+| `DROP TABLE` / `DROP DATABASE` | `DROP TABLE users;` |
+| `TRUNCATE` | `TRUNCATE TABLE users;` |
+| `DELETE FROM` without `WHERE` | `DELETE FROM users;` |
+| `git push --force` / `-f` | `git push --force origin main` |
+| `chmod 777` | `chmod 777 /etc/passwd` |
+| `mkfs` | `mkfs.ext4 /dev/sda1` |
+| `dd` to device | `dd if=/dev/zero of=/dev/sda` |
+| `sudo rm` | `sudo rm -rf /var/log` |
+
+## Log Format
+
+Blocked commands are logged to `~/.claude/hooks/blocked.log`:
+
+```json
+{"timestamp": "2026-06-19 13:00:00 UTC", "command": "rm -rf /", "reason": "rm -rf or rm --force detected", "project_path": "/home/user/project"}
+```
+
+## How It Works
+
+The hook receives Claude Code's tool-use input via stdin, extracts the bash command, and checks it against blocked patterns using regex. If a match is found, it logs the attempt and exits with code 2 (which tells Claude Code to block the tool use).

--- a/issue-3-hook/block-destructive.py
+++ b/issue-3-hook/block-destructive.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Claude Code Pre-tool-use Hook: Block Destructive Bash Commands
+
+Intercepts dangerous bash commands before execution and blocks them.
+Logs every blocked attempt with timestamp, command, and project path.
+
+Installation:
+  cp block-destructive.py ~/.claude/hooks/block-destructive.py
+  chmod +x ~/.claude/hooks/block-destructive.py
+
+Then add to ~/.claude/hooks/settings.json:
+  {
+    "hooks": {
+      "pre-tool-use": [
+        {
+          "matcher": "Bash",
+          "command": "python3 ~/.claude/hooks/block-destructive.py"
+        }
+      ]
+    }
+  }
+
+Or use the installer:
+  python3 install.py
+"""
+
+import sys
+import json
+import os
+import re
+from datetime import datetime, timezone
+
+BLOCKED_PATTERNS = [
+    # rm -rf variants
+    (r"\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+).*", "rm -rf or rm --force detected"),
+    (r"\brm\s+-[a-zA-Z]*r[a-zA-Z]*\s+.*", "rm -r (recursive delete) detected"),
+    # SQL destructive commands
+    (r"\bDROP\s+TABLE\b", "DROP TABLE detected"),
+    (r"\bDROP\s+DATABASE\b", "DROP DATABASE detected"),
+    (r"\bTRUNCATE\s+", "TRUNCATE detected"),
+    (r"\bDELETE\s+FROM\b(?!.*\bWHERE\b)", "DELETE FROM without WHERE clause detected"),
+    # Git force push
+    (r"\bgit\s+push\s+.*--force", "git push --force detected"),
+    (r"\bgit\s+push\s+.*-f\b", "git push -f detected"),
+    (r"\bgit\s+push\s+--force-with-lease", "git push --force-with-lease detected"),
+    # Additional dangerous patterns
+    (r"\bchmod\s+(-[a-zA-Z]*\s+)?777\b", "chmod 777 detected"),
+    (r"\bmkfs\b", "mkfs (filesystem format) detected"),
+    (r"\bdd\s+.*of=/dev/", "dd to device detected"),
+    (r">\s*/dev/sd", "Write to block device detected"),
+    (r"\bsudo\s+rm\s+", "sudo rm detected"),
+    (r"\bsystemctl\s+(stop|disable|mask)\s+", "systemctl stop/disable/mask detected"),
+]
+
+LOG_FILE = os.path.expanduser("~/.claude/hooks/blocked.log")
+
+
+def log_blocked(command: str, reason: str, project_path: str):
+    """Log a blocked command attempt."""
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    with open(LOG_FILE, "a") as f:
+        f.write(json.dumps({
+            "timestamp": timestamp,
+            "command": command,
+            "reason": reason,
+            "project_path": project_path,
+        }) + "\n")
+
+
+def check_command(command: str) -> tuple:
+    """
+    Check if a command matches any blocked pattern.
+    Returns (is_blocked, reason) tuple.
+    """
+    normalized = command.strip()
+
+    for pattern, reason in BLOCKED_PATTERNS:
+        if re.search(pattern, normalized, re.IGNORECASE):
+            return True, reason
+
+    return False, ""
+
+
+def main():
+    # Read the hook input from stdin
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    project_path = os.getcwd()
+
+    is_blocked, reason = check_command(command)
+
+    if is_blocked:
+        log_blocked(command, reason, project_path)
+        print(f"BLOCKED: {reason}")
+        print(f"Command: {command}")
+        print("This command was blocked for safety. If you truly need to run it,")
+        print("consider a safer alternative or run it directly in your terminal.")
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/issue-3-hook/install.py
+++ b/issue-3-hook/install.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Quick installer for the block-destructive hook. Usage: python3 install.py"""
+
+import os, json, shutil
+
+HOOK_DIR = os.path.expanduser("~/.claude/hooks")
+HOOK_FILE = os.path.join(HOOK_DIR, "block-destructive.py")
+SETTINGS_FILE = os.path.join(HOOK_DIR, "settings.json")
+SOURCE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "block-destructive.py")
+
+
+def main():
+    os.makedirs(HOOK_DIR, exist_ok=True)
+    shutil.copy2(SOURCE_FILE, HOOK_FILE)
+    os.chmod(HOOK_FILE, 0o755)
+    print(f"Installed hook to {HOOK_FILE}")
+
+    hook_entry = {
+        "matcher": "Bash",
+        "command": f"python3 {HOOK_FILE}"
+    }
+
+    settings = {}
+    if os.path.exists(SETTINGS_FILE):
+        with open(SETTINGS_FILE) as f:
+            try:
+                settings = json.load(f)
+            except json.JSONDecodeError:
+                settings = {}
+
+    if "hooks" not in settings:
+        settings["hooks"] = {}
+    if "pre-tool-use" not in settings["hooks"]:
+        settings["hooks"]["pre-tool-use"] = []
+
+    existing = settings["hooks"]["pre-tool-use"]
+    already_installed = any(
+        e.get("command", "").endswith("block-destructive.py") for e in existing
+    )
+
+    if not already_installed:
+        existing.append(hook_entry)
+
+    with open(SETTINGS_FILE, "w") as f:
+        json.dump(settings, f, indent=2)
+    print(f"Updated {SETTINGS_FILE}")
+    print("\nDone! The hook will now block destructive commands.")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue-3-hook/test_hook.py
+++ b/issue-3-hook/test_hook.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for block-destructive.py hook. Run: python3 test_hook.py"""
+
+import json, subprocess, sys, os
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "block-destructive.py")
+
+TESTS = [
+    # Should be BLOCKED
+    ("rm -rf /tmp/test", True, "rm -rf"),
+    ("rm -fr /tmp/test", True, "rm -fr variant"),
+    ("rm --force /tmp/test", True, "rm --force"),
+    ("rm -rf /", True, "rm -rf root"),
+    ("sudo rm -rf /var/log", True, "sudo rm"),
+    ("DROP TABLE users;", True, "DROP TABLE"),
+    ("DROP DATABASE production;", True, "DROP DATABASE"),
+    ("TRUNCATE TABLE users;", True, "TRUNCATE"),
+    ("DELETE FROM users;", True, "DELETE FROM without WHERE"),
+    ("git push origin --force", True, "git push --force"),
+    ("git push -f origin main", True, "git push -f"),
+    ("chmod 777 /etc/passwd", True, "chmod 777"),
+    ("mkfs.ext4 /dev/sda1", True, "mkfs"),
+    ("dd if=/dev/zero of=/dev/sda", True, "dd to device"),
+
+    # Should be ALLOWED
+    ("rm /tmp/single_file.txt", False, "rm single file (no -rf)"),
+    ("git push origin main", False, "normal git push"),
+    ("DROP COLUMN is not SQL", False, "DROP not followed by TABLE"),
+    ("SELECT * FROM users WHERE id = 1", False, "SELECT query"),
+    ("DELETE FROM users WHERE id = 1;", False, "DELETE FROM with WHERE"),
+    ("ls -la /tmp", False, "ls command"),
+    ("pip install requests", False, "pip install"),
+    ("python3 manage.py migrate", False, "Django migrate"),
+    ("echo 'hello world'", False, "echo"),
+    ("git commit -m 'fix bug'", False, "git commit"),
+]
+
+
+def run_hook(command: str) -> tuple:
+    mock_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": command}
+    })
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=mock_input, capture_output=True, text=True, timeout=5
+    )
+    return result.returncode, result.stdout
+
+
+def main():
+    passed = failed = 0
+    for command, should_block, description in TESTS:
+        exit_code, stdout = run_hook(command)
+        was_blocked = (exit_code == 2)
+        ok = was_blocked == should_block
+        passed += ok
+        failed += not ok
+        status = "PASS" if ok else "FAIL"
+        expected = "BLOCKED" if should_block else "ALLOWED"
+        actual = "BLOCKED" if was_blocked else "ALLOWED"
+        print(f"  [{status}] {description}: expected={expected}, actual={actual}")
+        if not ok and stdout:
+            print(f"        Output: {stdout[:100]}")
+
+    print(f"\nResults: {passed} passed, {failed} failed, {passed + failed} total")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements a `pre-tool-use` hook for Claude Code that blocks destructive bash commands before execution.

Closes #3

## Features

- **Blocks dangerous commands**: `rm -rf`, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without WHERE, `git push --force`, `chmod 777`, `mkfs`, `dd` to device, `sudo rm`, `systemctl stop/disable`
- **Logs blocked attempts**: Timestamp, command, and project path saved to `~/.claude/hooks/blocked.log`
- **Clear feedback**: Shows why the command was blocked and suggests alternatives
- **Easy installation**: One-command install via `python3 install.py`
- **Well-tested**: 24 test cases covering all blocked patterns and common safe commands

## Files

- `block-destructive.py` — Main hook script
- `install.py` — Auto-installer
- `test_hook.py` — 24 test cases (all passing)
- `README.md` — Documentation

## Testing

```bash
python3 test_hook.py
# Results: 24 passed, 0 failed, 24 total
```
