### PR TITLE
feat: Add changelog generator from git history (#1)

### DIFF
--- a/issue-1-changelog/README.md
+++ b/issue-1-changelog/README.md
@@ -1,0 +1,71 @@
+# Generate Changelog — Claude Code Skill
+
+Automatically generate a structured `CHANGELOG.md` from a project's git history.
+
+## Quick Start (3 steps)
+
+```bash
+# 1. Copy the script to your project
+cp changelog.sh /path/to/your/project/changelog.sh
+
+# 2. Make it executable
+chmod +x changelog.sh
+
+# 3. Run it
+./changelog.sh > CHANGELOG.md
+```
+
+## Usage
+
+```bash
+# Generate from last git tag to HEAD (most common)
+./changelog.sh
+
+# Generate for a specific tag range
+./changelog.sh v1.0.0..v2.0.0
+
+# Generate full history
+./changelog.sh --all
+```
+
+## Auto-Categorization
+
+The script categorizes commits by prefix:
+
+| Category | Commit Prefixes |
+|----------|----------------|
+| **Added** | `add`, `feat`, `create`, `introduce`, `implement`, `support`, `new` |
+| **Fixed** | `fix`, `bug`, `patch`, `resolve`, `repair`, `correct`, `hotfix` |
+| **Changed** | `change`, `update`, `modify`, `refactor`, `rename`, `move`, `upgrade`, `migrate`, `bump`, `improve` |
+| **Removed** | `remove`, `delete`, `drop`, `deprecate`, `strip`, `eliminate` |
+
+Commits that don't match any prefix default to **Changed**.
+
+## Sample Output
+
+```markdown
+# Changelog
+
+## 2026-06-19 (v1.0.0..HEAD)
+
+### Added
+- feat: add user authentication endpoint
+- add pagination to list API
+- implement rate limiting middleware
+
+### Fixed
+- fix: resolve null pointer in user lookup
+- hotfix: patch SQL injection vulnerability
+
+### Changed
+- update: upgrade dependencies to latest versions
+- refactor: simplify config loading logic
+
+### Removed
+- remove: deprecated v1 API endpoints
+- drop: legacy MySQL adapter
+```
+
+## Also usable as Claude Code Skill
+
+Copy the `SKILL.md` file to your project and use `/generate-changelog` in Claude Code.

--- a/issue-1-changelog/SKILL.md
+++ b/issue-1-changelog/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: generate-changelog
+description: Generate a structured CHANGELOG.md from git history
+---
+
+# Generate Changelog
+
+Generate a structured `CHANGELOG.md` from the project's git history.
+
+## Instructions
+
+1. Run `bash changelog.sh` or `bash changelog.sh v1.0.0..v2.0.0` for a specific range
+2. The script auto-categorizes commits into: Added / Fixed / Changed / Removed
+3. Review the output and write it to `CHANGELOG.md`
+
+## Commit Prefix Conventions
+
+- `feat:`, `add:` → **Added**
+- `fix:`, `bug:`, `hotfix:` → **Fixed**
+- `update:`, `refactor:`, `change:` → **Changed**
+- `remove:`, `delete:`, `drop:` → **Removed**
+
+If no prefix is detected, the commit goes to **Changed**.

--- a/issue-1-changelog/changelog.sh
+++ b/issue-1-changelog/changelog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# changelog.sh — Generate a structured CHANGELOG.md from git history
+#
+# Usage:
+#   ./changelog.sh                  # Generate from last tag to HEAD
+#   ./changelog.sh v1.0.0..v2.0.0   # Generate for a specific range
+#   ./changelog.sh --all            # Generate full history
+#
+# Categories: Added, Fixed, Changed, Removed
+#
+
+set -euo pipefail
+
+RANGE=""
+if [[ "${1:-}" == "--all" ]]; then
+    RANGE=""
+elif [[ -n "${1:-}" ]]; then
+    RANGE="$1"
+else
+    # Default: from last tag to HEAD
+    LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    if [[ -n "$LAST_TAG" ]]; then
+        RANGE="${LAST_TAG}..HEAD"
+    fi
+fi
+
+# Build commit log
+if [[ -n "$RANGE" ]]; then
+    COMMITS=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null || echo "")
+else
+    COMMITS=$(git log --pretty=format:"%s" 2>/dev/null || echo "")
+fi
+
+if [[ -z "$COMMITS" ]]; then
+    echo "No commits found for the specified range."
+    exit 1
+fi
+
+# Date for the header
+TODAY=$(date +%Y-%m-%d)
+
+# Header
+HEADER="# Changelog"
+if [[ -n "$RANGE" ]]; then
+    HEADER="${HEADER}\n\n## ${TODAY} (${RANGE})"
+else
+    HEADER="${HEADER}\n\n## ${TODAY}"
+fi
+
+# Categorize commits
+ADDED=""
+FIXED=""
+CHANGED=""
+REMOVED=""
+
+while IFS= read -r commit; do
+    [[ -z "$commit" ]] && continue
+
+    # Normalize: lowercase for matching
+    lower=$(echo "$commit" | tr '[:upper:]' '[:lower:]')
+
+    if echo "$lower" | grep -qE '^(add|feat|create|introduce|implement|support|new)'; then
+        ADDED="${ADDED}- ${commit}\n"
+    elif echo "$lower" | grep -qE '^(fix|bug|patch|resolve|repair|correct|hotfix)'; then
+        FIXED="${FIXED}- ${commit}\n"
+    elif echo "$lower" | grep -qE '^(remove|delete|drop|deprecate|strip|eliminate)'; then
+        REMOVED="${REMOVED}- ${commit}\n"
+    elif echo "$lower" | grep -qE '^(change|update|modify|refactor|rename|move|upgrade|migrate|bump|improve)'; then
+        CHANGED="${CHANGED}- ${commit}\n"
+    else
+        # Default to Changed
+        CHANGED="${CHANGED}- ${commit}\n"
+    fi
+done <<< "$COMMITS"
+
+# Build output
+OUTPUT="${HEADER}\n"
+
+if [[ -n "$ADDED" ]]; then
+    OUTPUT="${OUTPUT}\n### Added\n${ADDED}"
+fi
+if [[ -n "$FIXED" ]]; then
+    OUTPUT="${OUTPUT}\n### Fixed\n${FIXED}"
+fi
+if [[ -n "$CHANGED" ]]; then
+    OUTPUT="${OUTPUT}\n### Changed\n${CHANGED}"
+fi
+if [[ -n "$REMOVED" ]]; then
+    OUTPUT="${OUTPUT}\n### Removed\n${REMOVED}"
+fi
+
+echo -e "$OUTPUT"


### PR DESCRIPTION
## Summary

Implements a CHANGELOG generator that creates structured changelogs from git history.

Closes #1

## Features

- **Auto-categorizes commits** into Added / Fixed / Changed / Removed based on commit prefixes
- **Flexible range**: supports last-tag-to-HEAD, specific tag ranges, or full history
- **Zero dependencies**: Pure bash script, works anywhere
- **Also usable as Claude Code skill**: Includes SKILL.md for `/generate-changelog` command

## Usage

```bash
./changelog.sh                  # From last tag to HEAD
./changelog.sh v1.0.0..v2.0.0   # Specific range
./changelog.sh --all            # Full history
```

## Files

- `changelog.sh` — The generator script
- `README.md` — Documentation with examples
- `SKILL.md` — Claude Code skill definition

## Commit Prefix Conventions

| Category | Prefixes |
|----------|----------|
| Added | `add`, `feat`, `create`, `introduce`, `implement`, `support`, `new` |
| Fixed | `fix`, `bug`, `patch`, `resolve`, `repair`, `correct`, `hotfix` |
| Changed | `change`, `update`, `modify`, `refactor`, `rename`, `move`, `upgrade`, `migrate`, `bump`, `improve` |
| Removed | `remove`, `delete`, `drop`, `deprecate`, `strip`, `eliminate` |
