### PR TITLE
Add destructive Bash command hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/destructive-command-hook/README.md
+++ b/destructive-command-hook/README.md
@@ -1,0 +1,44 @@
+# Destructive Command Hook
+
+This Claude Code `PreToolUse` hook blocks high-risk Bash commands before they run and records every blocked attempt in `~/.claude/hooks/blocked.log`.
+
+## Install
+
+```bash
+mkdir -p ~/.claude/hooks && cp destructive-command-hook/pre_tool_use_blocker.py ~/.claude/hooks/pre_tool_use_blocker.py && chmod +x ~/.claude/hooks/pre_tool_use_blocker.py
+python destructive-command-hook/install_settings.py
+```
+
+The installer adds this hook to `~/.claude/settings.json` under the `PreToolUse` event with matcher `Bash`.
+
+## What It Blocks
+
+- `rm -rf` and equivalent combined `rm` flags containing both recursive and force
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+- `git push --force`, `git push -f`, and `git push --force-with-lease`
+
+Normal Bash commands exit with status `0` and continue through the usual Claude Code permission flow. Blocked commands exit with status `2` and send a clear reason to Claude on stderr.
+
+## Hook Input
+
+Claude Code sends `PreToolUse` JSON on stdin. For Bash, the hook reads:
+
+```json
+{
+  "cwd": "/path/to/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm test"
+  }
+}
+```
+
+## Local Verification
+
+```bash
+python destructive-command-hook/test_hook.py
+```
+

--- a/destructive-command-hook/install_settings.py
+++ b/destructive-command-hook/install_settings.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Install the destructive command hook into ~/.claude/settings.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+HOME = Path.home()
+SETTINGS_PATH = HOME / ".claude" / "settings.json"
+HOOK_COMMAND = str(HOME / ".claude" / "hooks" / "pre_tool_use_blocker.py")
+
+
+def main() -> int:
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if SETTINGS_PATH.exists():
+        settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+    else:
+        settings = {}
+
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    entry = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": HOOK_COMMAND}],
+    }
+
+    if not any(existing == entry for existing in pre_tool_use):
+        pre_tool_use.append(entry)
+
+    SETTINGS_PATH.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"Installed PreToolUse Bash hook in {SETTINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/destructive-command-hook/pre_tool_use_blocker.py
+++ b/destructive-command-hook/pre_tool_use_blocker.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Block destructive Bash commands from Claude Code PreToolUse hooks."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+
+def find_block_reason(command: str) -> str | None:
+    stripped = command.strip()
+    lower = stripped.lower()
+
+    if is_rm_rf(stripped):
+        return "`rm -rf` style recursive force deletion is blocked."
+    if is_forced_git_push(stripped):
+        return "Forced git pushes are blocked to avoid rewriting shared history."
+    if re.search(r"\bdrop\s+table\b", lower):
+        return "`DROP TABLE` is blocked because it can destroy schema and data."
+    if re.search(r"\btruncate\b", lower):
+        return "`TRUNCATE` is blocked because it can erase table contents."
+    if has_delete_without_where(lower):
+        return "`DELETE FROM` without a `WHERE` clause is blocked."
+    return None
+
+
+def is_rm_rf(command: str) -> bool:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    for index, token in enumerate(tokens):
+        if token != "rm":
+            continue
+        flags = ""
+        for following in tokens[index + 1 :]:
+            if not following.startswith("-") or following == "--":
+                break
+            flags += following.lstrip("-")
+        if "r" in flags and "f" in flags:
+            return True
+
+    return bool(re.search(r"\brm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b|\brm\s+-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*\b", command))
+
+
+def is_forced_git_push(command: str) -> bool:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    for index in range(len(tokens) - 2):
+        if tokens[index : index + 2] == ["git", "push"]:
+            push_args = tokens[index + 2 :]
+            return any(
+                arg == "-f"
+                or arg == "--force"
+                or arg == "--force-with-lease"
+                or arg.startswith("--force=")
+                or arg.startswith("--force-with-lease=")
+                for arg in push_args
+            )
+    return False
+
+
+def has_delete_without_where(command_lower: str) -> bool:
+    statements = re.split(r";|\n", command_lower)
+    for statement in statements:
+        match = re.search(r"\bdelete\s+from\b", statement)
+        if match and not re.search(r"\bwhere\b", statement[match.end() :]):
+            return True
+    return False
+
+
+def log_blocked(command: str, cwd: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    safe_cwd = cwd.replace("\n", "\\n")
+    with LOG_PATH.open("a", encoding="utf-8") as log:
+        log.write(f"{timestamp}\t{safe_cwd}\t{safe_command}\t{reason}\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse" or payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    reason = find_block_reason(command)
+    if not reason:
+        return 0
+
+    cwd = payload.get("cwd") or ""
+    log_blocked(command, str(cwd), reason)
+    print(f"Blocked Bash command: {reason}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/destructive-command-hook/test_hook.py
+++ b/destructive-command-hook/test_hook.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Exercise the destructive command hook with representative inputs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+HOOK = Path(__file__).with_name("pre_tool_use_blocker.py")
+
+
+def run_hook(command: str) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "cwd": "/tmp/example-project",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def assert_blocked(command: str) -> None:
+    result = run_hook(command)
+    assert result.returncode == 2, (command, result.returncode, result.stderr)
+    assert "Blocked Bash command:" in result.stderr, result.stderr
+
+
+def assert_allowed(command: str) -> None:
+    result = run_hook(command)
+    assert result.returncode == 0, (command, result.returncode, result.stderr)
+    assert result.stderr == "", result.stderr
+
+
+def main() -> int:
+    for command in [
+        "rm -rf dist",
+        "rm -fr ./tmp",
+        "git push --force origin main",
+        "git push -f",
+        "psql -c 'DROP TABLE users'",
+        "mysql -e 'TRUNCATE sessions'",
+        "psql -c 'DELETE FROM audit_logs'",
+    ]:
+        assert_blocked(command)
+
+    for command in [
+        "rm -r dist",
+        "git push origin main",
+        "psql -c 'DELETE FROM audit_logs WHERE created_at < now()'",
+        "npm test",
+        "python -m pytest",
+    ]:
+        assert_allowed(command)
+
+    print("All hook checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
/claim #3

Closes #3

## Summary
- Add a Claude Code `PreToolUse` Bash hook that blocks destructive commands before execution.
- Blocks `rm -rf`, forced git pushes, `DROP TABLE`, `TRUNCATE`, and `DELETE FROM` statements without `WHERE`.
- Logs blocked attempts to `~/.claude/hooks/blocked.log` with timestamp, project path, attempted command, and reason.
- Includes a two-command installer path, settings installer, and local hook test script.

## Verification
- `python3 -m py_compile destructive-command-hook/pre_tool_use_blocker.py destructive-command-hook/install_settings.py destructive-command-hook/test_hook.py`
- `python3 destructive-command-hook/test_hook.py`
- `git diff --check`