### PR TITLE
feat: CHANGELOG generator script

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,52 @@
+# Changelog Generator
+
+A bash script that generates a structured `CHANGELOG.md` from your git history, automatically categorizing commits since the last tag.
+
+## Install & Use
+
+1. **Copy the script** into your repo (or symlink it):
+
+   ```bash
+   cp changelog/changelog.sh ./changelog.sh
+   chmod +x changelog.sh
+   ```
+
+2. **Run it** from inside any git repository:
+
+   ```bash
+   ./changelog.sh              # writes CHANGELOG.md at repo root
+   ./changelog.sh docs/CHANGELOG.md   # custom output path
+   ```
+
+3. **Done!** Open the generated `CHANGELOG.md` — commits are grouped under **Added**, **Changed**, **Fixed**, **Removed**, and **Other**.
+
+## How It Works
+
+- Finds the most recent git tag (`git describe --tags --abbrev=0`).
+- Collects all commit messages from that tag to `HEAD`.
+- Classifies each commit subject by conventional-commit prefix (`feat`, `fix`, `refactor`, etc.).
+- Writes a Markdown file with sections for each category.
+
+## Example Output
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] — 2026-06-20
+
+*Changes since **v0.1.0** until **HEAD**.*
+
+### Added
+  - feat: add user authentication flow
+  - add dark mode support
+
+### Fixed
+  - fix: resolve crash on empty input
+  - fixed memory leak in worker thread
+
+### Changed
+  - refactor: simplify config parsing
+  - update dependencies to latest versions
+```

--- a/changelog/changelog.sh
+++ b/changelog/changelog.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── changelog.sh ──────────────────────────────────────────────────────
+# Generates a structured CHANGELOG.md from git history since the last tag.
+# Usage: ./changelog.sh [output_file]
+#   output_file defaults to CHANGELOG.md in the repo root.
+# ───────────────────────────────────────────────────────────────────────
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OUTPUT="${1:-$REPO_ROOT/CHANGELOG.md}"
+
+# Find the most recent tag (annotated or lightweight)
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+
+if [ -z "$LAST_TAG" ]; then
+  echo ":: No tags found — using full history."
+  RANGE="HEAD"
+else
+  RANGE="$LAST_TAG..HEAD"
+fi
+
+# Collect commit messages (subject + body) in the range
+COMMITS="$(git log "$RANGE" --pretty=format:"---COMMIT---%n%B" 2>/dev/null)"
+
+if [ -z "$COMMITS" ]; then
+  echo ":: No commits found since ${LAST_TAG:-the beginning}."
+  exit 0
+fi
+
+# ── Classify commits ──────────────────────────────────────────────────
+declare -A SECTIONS
+SECTIONS[Added]=""
+SECTIONS[Changed]=""
+SECTIONS[Fixed]=""
+SECTIONS[Removed]=""
+SECTIONS[Other]=""
+
+while IFS= read -r line; do
+  # Skip separators
+  [ "$line" = "---COMMIT---" ] && continue
+
+  # Trim leading/trailing whitespace
+  entry="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -z "$entry" ] && continue
+
+  # First non-empty line = subject; treat as conventional-commit prefix
+  shopt -s nocasematch
+  if [[ "$entry" =~ ^(feat|add|added|new)\b ]]; then
+    SECTIONS[Added]+="  - $entry"$'\n'
+  elif [[ "$entry" =~ ^fix(ed|ed)?\b ]]; then
+    SECTIONS[Fixed]+="  - $entry"$'\n'
+  elif [[ "$entry" =~ ^(change|update|updated|improve|refactor|chore)\b ]]; then
+    SECTIONS[Changed]+="  - $entry"$'\n'
+  elif [[ "$entry" =~ ^(remove|removed|delete|deleted|deprecate)\b ]]; then
+    SECTIONS[Removed]+="  - $entry"$'\n'
+  else
+    SECTIONS[Other]+="  - $entry"$'\n'
+  fi
+  shopt -u nocasematch
+done <<< "$COMMITS"
+
+# ── Build markdown ────────────────────────────────────────────────────
+DATE="$(date +%Y-%m-%d)"
+
+cat > "$OUTPUT" <<HEADER
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+HEADER
+
+if [ -n "$LAST_TAG" ]; then
+  cat >> "$OUTPUT" <<SECTION
+
+## [Unreleased] — $DATE
+
+*Changes since **$LAST_TAG** until **HEAD**.*
+SECTION
+else
+  cat >> "$OUTPUT" <<SECTION
+
+## [$DATE]
+
+*Full history (no prior tags).*
+SECTION
+fi
+
+for section in Added Changed Fixed Removed Other; do
+  content="${SECTIONS[$section]}"
+  [ -z "$content" ] && continue
+  echo "" >> "$OUTPUT"
+  echo "### $section" >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+  printf "%s" "$content" >> "$OUTPUT"
+done
+
+echo "" >> "$OUTPUT"
+
+echo "✅ CHANGELOG written to $OUTPUT ($(wc -l < "$OUTPUT") lines)"


### PR DESCRIPTION
Closes #1

## Summary

Adds a bash script (changelog/changelog.sh) that generates a structured CHANGELOG.md from git history.

### What it does
- Finds the most recent git tag
- Collects commits from that tag to HEAD
- Auto-classifies into: **Added / Changed / Fixed / Removed / Other**
- Writes a well-formatted CHANGELOG.md

### Files
- changelog/changelog.sh — the generator script
- changelog/README.md — 3-step install & usage docs + example output

### Usage
`ash
cp changelog/changelog.sh ./changelog.sh && chmod +x changelog.sh
./changelog.sh
`