### PR TITLE
Add destructive Bash PreToolUse hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ import json, pathlib
 settings = pathlib.Path.home() / ".claude" / "settings.json"
 data = json.loads(settings.read_text()) if settings.exists() else {}
 data.setdefault("hooks", {}).setdefault("PreToolUse", [])
-entry = {"matcher": "Bash", "hooks": [{"type": "command", "command": str(pathlib.Path.home() / ".claude" / "hooks" / "block-destructive-bash.py")}]} 
+entry = {
+    "matcher": "Bash",
+    "hooks": [
+        {
+            "type": "command",
+            "command": str(pathlib.Path.home() / ".claude" / "hooks" / "block-destructive-bash.py"),
+        }
+    ],
+}
 if entry not in data["hooks"]["PreToolUse"]:
     data["hooks"]["PreToolUse"].append(entry)
 settings.write_text(json.dumps(data, indent=2) + "\n")

--- a/README.md
+++ b/README.md
@@ -34,6 +34,42 @@ You're in the right place.
 
 ---
 
+## Destructive Bash Blocker Hook
+
+This repository includes a Claude Code `PreToolUse` hook for [bounty #3](../../issues/3). It blocks destructive Bash commands before execution and logs every blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, attempted command, project path, and reason.
+
+It blocks:
+
+- `rm` commands that combine recursive and force flags, such as `rm -rf`, `rm -fr`, and `rm -Rf`
+- `DROP TABLE`
+- `TRUNCATE`
+- `DELETE FROM` statements without a `WHERE` clause
+- `git push --force` / `git push -f`
+
+Install in two commands:
+
+```bash
+mkdir -p ~/.claude/hooks && cp hooks/pre_tool_use_block_destructive_bash.py ~/.claude/hooks/block-destructive-bash.py && chmod +x ~/.claude/hooks/block-destructive-bash.py
+python3 - <<'PY'
+import json, pathlib
+settings = pathlib.Path.home() / ".claude" / "settings.json"
+data = json.loads(settings.read_text()) if settings.exists() else {}
+data.setdefault("hooks", {}).setdefault("PreToolUse", [])
+entry = {"matcher": "Bash", "hooks": [{"type": "command", "command": str(pathlib.Path.home() / ".claude" / "hooks" / "block-destructive-bash.py")}]} 
+if entry not in data["hooks"]["PreToolUse"]:
+    data["hooks"]["PreToolUse"].append(entry)
+settings.write_text(json.dumps(data, indent=2) + "\n")
+PY
+```
+
+Run tests:
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+---
+
 ## Rules
 
 - Tasks must be related to Claude Code or AI tooling

--- a/hooks/pre_tool_use_block_destructive_bash.py
+++ b/hooks/pre_tool_use_block_destructive_bash.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook that blocks destructive Bash commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SQL_DELETE_RE = re.compile(r"\bdelete\s+from\b(?P<body>.*?)(?:;|$)", re.IGNORECASE | re.DOTALL)
+SQL_DESTRUCTIVE_RE = re.compile(r"\b(drop\s+table|truncate)\b", re.IGNORECASE)
+
+
+def _shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        # An invalid shell line should not crash the hook. Fall back to a
+        # whitespace split so obvious destructive patterns are still caught.
+        return command.split()
+
+
+def _rm_recursive_force(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    for index, token in enumerate(tokens):
+        if token != "rm":
+            continue
+        has_recursive = False
+        has_force = False
+        for flag in tokens[index + 1 :]:
+            if flag == "--":
+                break
+            if not flag.startswith("-"):
+                continue
+            if flag in {"--recursive", "--dir", "-r", "-R"}:
+                has_recursive = True
+            else:
+                has_recursive = has_recursive or "r" in flag[1:] or "R" in flag[1:]
+            if flag in {"--force", "-f"}:
+                has_force = True
+            else:
+                has_force = has_force or "f" in flag[1:]
+            if has_recursive and has_force:
+                return True
+    return False
+
+
+def _git_push_force(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    for index, token in enumerate(tokens):
+        if token != "git":
+            continue
+        remaining = tokens[index + 1 :]
+        if not remaining or remaining[0] != "push":
+            continue
+        for flag in remaining[1:]:
+            if flag == "--":
+                break
+            if flag in {"--force", "--force-with-lease", "-f"}:
+                return True
+            if flag.startswith("-") and "f" in flag[1:]:
+                return True
+    return False
+
+
+def _delete_without_where(command: str) -> bool:
+    for match in SQL_DELETE_RE.finditer(command):
+        statement_body = match.group("body")
+        if not re.search(r"\bwhere\b", statement_body, re.IGNORECASE):
+            return True
+    return False
+
+
+def destructive_reason(command: str) -> str | None:
+    if _rm_recursive_force(command):
+        return "rm with recursive and force flags is blocked"
+    if _git_push_force(command):
+        return "force-pushing with git is blocked"
+    sql_match = SQL_DESTRUCTIVE_RE.search(command)
+    if sql_match:
+        return f"SQL destructive operation blocked: {sql_match.group(1).upper()}"
+    if _delete_without_where(command):
+        return "DELETE FROM without a WHERE clause is blocked"
+    return None
+
+
+def _log_blocked(command: str, project_path: str, reason: str) -> None:
+    log_dir = Path.home() / ".claude" / "hooks"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    safe_command = command.replace("\n", "\\n")
+    safe_project = project_path.replace("\n", "\\n")
+    safe_reason = reason.replace("\n", "\\n")
+    with (log_dir / "blocked.log").open("a", encoding="utf-8") as handle:
+        handle.write(f"{timestamp}\t{safe_project}\t{safe_reason}\t{safe_command}\n")
+
+
+def _deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    if not command:
+        return 0
+
+    reason = destructive_reason(command)
+    if reason is None:
+        return 0
+
+    project_path = str(payload.get("cwd") or os.getcwd())
+    _log_blocked(command, project_path, reason)
+    _deny(f"Blocked destructive Bash command: {reason}. Command was not executed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pre_tool_use_block_destructive_bash.py
+++ b/tests/test_pre_tool_use_block_destructive_bash.py
@@ -1,0 +1,102 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "pre_tool_use_block_destructive_bash.py"
+
+
+def run_hook(payload, home):
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def bash_payload(command):
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/workspace/project",
+    }
+
+
+class DestructiveBashHookTests(unittest.TestCase):
+    def test_allows_normal_bash_command_without_output_or_log(self):
+        with tempfile.TemporaryDirectory() as home:
+            result = run_hook(bash_payload("git status --short"), home)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((Path(home) / ".claude" / "hooks" / "blocked.log").exists())
+
+    def test_blocks_rm_recursive_force_and_logs_attempt(self):
+        with tempfile.TemporaryDirectory() as home:
+            result = run_hook(bash_payload("sudo rm -r -f /tmp/build"), home)
+            self.assertEqual(result.returncode, 0)
+            decision = json.loads(result.stdout)
+            hook_output = decision["hookSpecificOutput"]
+            self.assertEqual(hook_output["hookEventName"], "PreToolUse")
+            self.assertEqual(hook_output["permissionDecision"], "deny")
+            self.assertIn("rm", hook_output["permissionDecisionReason"])
+
+            log_text = (Path(home) / ".claude" / "hooks" / "blocked.log").read_text()
+            self.assertIn("/workspace/project", log_text)
+            self.assertIn("sudo rm -r -f /tmp/build", log_text)
+
+    def test_blocks_git_force_push(self):
+        with tempfile.TemporaryDirectory() as home:
+            result = run_hook(bash_payload("git push --force origin main"), home)
+            self.assertEqual(result.returncode, 0)
+            hook_output = json.loads(result.stdout)["hookSpecificOutput"]
+            self.assertEqual(hook_output["permissionDecision"], "deny")
+            self.assertIn("force", hook_output["permissionDecisionReason"])
+
+    def test_blocks_sql_destructive_commands(self):
+        with tempfile.TemporaryDirectory() as home:
+            for command in (
+                'psql -c "DROP TABLE users"',
+                'psql -c "TRUNCATE sessions"',
+                'psql -c "DELETE FROM users"',
+            ):
+                with self.subTest(command=command):
+                    result = run_hook(bash_payload(command), home)
+                    self.assertEqual(result.returncode, 0)
+                    self.assertEqual(
+                        json.loads(result.stdout)["hookSpecificOutput"]["permissionDecision"],
+                        "deny",
+                    )
+
+    def test_allows_delete_with_where_clause(self):
+        with tempfile.TemporaryDirectory() as home:
+            result = run_hook(bash_payload('psql -c "DELETE FROM users WHERE id = 1"'), home)
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_ignores_non_bash_tools(self):
+        with tempfile.TemporaryDirectory() as home:
+            result = run_hook(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "rm -rf /"},
+                    "cwd": "/workspace/project",
+                },
+                home,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a Python Claude Code `PreToolUse` hook for Bash calls.
- Blocks destructive commands before execution:
  - `rm` with recursive and force flags (`rm -rf`, `rm -r -f`, etc.)
  - `git push --force`, `git push --force-with-lease`, and `git push -f`
  - `DROP TABLE`
  - `TRUNCATE`
  - `DELETE FROM` without a `WHERE` clause
- Logs each blocked attempt to `~/.claude/hooks/blocked.log` with timestamp, project path, reason, and attempted command.
- Documents a two-command install path in the README.

## Validation

```bash
python3 -m unittest discover -s tests
python3 -m py_compile hooks/pre_tool_use_block_destructive_bash.py tests/test_pre_tool_use_block_destructive_bash.py
git diff --check
```

Also manually tested a `git push --force origin main` hook payload and confirmed it returns a Claude Code `PreToolUse` deny decision.

## Notes

The hook stays silent for non-Bash tools and normal Bash commands so it does not interfere with ordinary shell usage.