### PR TITLE
feat: pre-tool-use hook blocking destructive commands (Closes #3)

### DIFF
--- a/pre-tool-use/README.md
+++ b/pre-tool-use/README.md
@@ -1,0 +1,49 @@
+# Pre-Tool-Use Hook: Block Destructive Commands
+
+Closes [claude-builders-bounty#3](https://github.com/claude-builders-bounty/claude-builders-bounty/issues/3) — **$100 Opire bounty**.
+
+## Install (2 commands)
+
+```bash
+mkdir -p ~/.claude/hooks && cp block_destructive_commands.py ~/.claude/hooks/ && chmod +x ~/.claude/hooks/block_destructive_commands.py
+```
+
+Merge `settings.snippet.json` into `~/.claude/settings.json` (or your project's `.claude/settings.json`).
+
+## What it blocks
+
+| Pattern | Why |
+|---------|-----|
+| `rm -rf` | Irreversible file deletion |
+| `git push --force` / `-f` | Rewrites remote history |
+| `DROP TABLE` | Destroys DB tables |
+| `TRUNCATE` | Wipes table data |
+| `DELETE FROM` without `WHERE` | Deletes all rows |
+
+## Logging
+
+Every blocked attempt is appended to `~/.claude/hooks/blocked.log`:
+
+```
+2026-06-22T10:00:00+00:00	project=/path/to/repo	command='rm -rf /'	reason=...
+```
+
+## Test
+
+```bash
+python -m pytest tests/ -q
+```
+
+Manual smoke test:
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/demo"}}' | python block_destructive_commands.py
+```
+
+Expected stdout:
+
+```json
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", ...}}
+```
+
+Safe commands produce no output and exit 0.

--- a/pre-tool-use/block_destructive_commands.py
+++ b/pre-tool-use/block_destructive_commands.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook: block destructive bash/SQL commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOG_PATH = Path.home() / ".claude" / "hooks" / "blocked.log"
+
+RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"rm\s+(-[^\s]*\s+)*-[^\s]*r[^\s]*f|rm\s+-[^\s]*rf", re.I),
+     "Recursive force-delete (`rm -rf`) can destroy project files irreversibly."),
+    (re.compile(r"\bgit\s+push\b[^\n;|&]*--force\b|\bgit\s+push\b[^\n;|&]*\s-f\b", re.I),
+     "Force-push rewrites remote history and can delete teammates' commits."),
+    (re.compile(r"\bDROP\s+TABLE\b", re.I),
+     "`DROP TABLE` permanently removes database tables."),
+    (re.compile(r"\bTRUNCATE\b", re.I),
+     "`TRUNCATE` wipes table data and is difficult to recover from."),
+    (re.compile(r"\bDELETE\s+FROM\b(?:(?!\bWHERE\b).)*$", re.I | re.S),
+     "`DELETE FROM` without `WHERE` deletes every row in the table."),
+]
+
+
+def project_path() -> str:
+    return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def extract_command(payload: dict) -> str:
+    tool_input = payload.get("tool_input") or payload.get("input") or {}
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command") or tool_input.get("cmd") or ""
+        if command:
+            return str(command)
+    return json.dumps(tool_input)
+
+
+def find_violation(command: str) -> str | None:
+    normalized = command.strip()
+    if not normalized:
+        return None
+    for pattern, reason in RULES:
+        if pattern.search(normalized):
+            return reason
+    return None
+
+
+def append_log(command: str, reason: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    line = (
+        f"{timestamp}\tproject={project_path()}\t"
+        f"command={command!r}\treason={reason}\n"
+    )
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def deny(reason: str, command: str) -> None:
+    append_log(command, reason)
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Blocked by destructive-command hook: {reason} "
+                f"Attempted command: {command}"
+            ),
+        }
+    }
+    json.dump(output, sys.stdout)
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return
+
+    tool_name = str(payload.get("tool_name") or payload.get("tool") or "")
+    if tool_name and tool_name.lower() not in {"bash", "shell"}:
+        return
+
+    command = extract_command(payload)
+    reason = find_violation(command)
+    if reason:
+        deny(reason, command)
+
+
+if __name__ == "__main__":
+    main()

--- a/pre-tool-use/settings.snippet.json
+++ b/pre-tool-use/settings.snippet.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"~/.claude/hooks/block_destructive_commands.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Run hook unit tests without pytest dependency."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+TESTS = Path(__file__).parent / "tests" / "test_block_destructive_commands.py"
+
+
+def main() -> int:
+    try:
+        import pytest  # noqa: F401
+    except ImportError:
+        # Fallback: import and run test functions directly
+        sys.path.insert(0, str(Path(__file__).parent))
+        import tests.test_block_destructive_commands as t
+
+        failures = 0
+        for name in sorted(dir(t)):
+            if not name.startswith("test_"):
+                continue
+            try:
+                getattr(t, name)()
+                print(f"PASS {name}")
+            except Exception as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+        return 1 if failures else 0
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", str(TESTS), "-q"],
+        check=False,
+    )
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block_destructive_commands.py
+++ b/tests/test_block_destructive_commands.py
@@ -1,0 +1,59 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parents[1] / "block_destructive_commands.py"
+
+
+def run_hook(command: str) -> tuple[int, str]:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout.strip()
+
+
+def test_blocks_rm_rf():
+    code, out = run_hook("rm -rf /important")
+    assert code == 0
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_blocks_force_push():
+    code, out = run_hook("git push --force origin main")
+    assert code == 0
+    assert "deny" in out
+
+
+def test_blocks_drop_table():
+    code, out = run_hook("psql -c 'DROP TABLE users'")
+    assert code == 0
+    assert "deny" in out
+
+
+def test_blocks_delete_without_where():
+    code, out = run_hook("DELETE FROM users")
+    assert code == 0
+    assert "deny" in out
+
+
+def test_allows_delete_with_where():
+    code, out = run_hook("DELETE FROM users WHERE id = 1")
+    assert code == 0
+    assert out == ""
+
+
+def test_allows_safe_commands():
+    code, out = run_hook("ls -la && git status")
+    assert code == 0
+    assert out == ""

--- a/tests/test_block_destructive_commands.py
+++ b/tests/test_block_destructive_commands.py
@@ -3,7 +3,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-HOOK = Path(__file__).resolve().parents[1] / "block_destructive_commands.py"
+HOOK = (
+    Path(__file__).resolve().parents[1]
+    / "pre-tool-use"
+    / "block_destructive_commands.py"
+)
 
 
 def run_hook(command: str) -> tuple[int, str]:
@@ -37,6 +41,12 @@ def test_blocks_force_push():
 
 def test_blocks_drop_table():
     code, out = run_hook("psql -c 'DROP TABLE users'")
+    assert code == 0
+    assert "deny" in out
+
+
+def test_blocks_truncate():
+    code, out = run_hook("TRUNCATE TABLE users")
     assert code == 0
     assert "deny" in out
 


### PR DESCRIPTION
## Summary

Implements a Claude Code `PreToolUse` hook that blocks destructive bash/SQL commands before execution.

Closes #3

## What it does

- Blocks: `rm -rf`, `git push --force`, `DROP TABLE`, `TRUNCATE`, `DELETE FROM` without `WHERE`
- Logs blocked attempts to `~/.claude/hooks/blocked.log` (timestamp, command, project path)
- Returns `permissionDecision: deny` with a clear reason for Claude
- Safe commands pass through unchanged

## Files

- `pre-tool-use/block_destructive_commands.py` — hook implementation
- `pre-tool-use/README.md` — 2-command install guide
- `tests/test_block_destructive_commands.py` — unit tests (6 cases)

## Test

```bash
python run_tests.py